### PR TITLE
Fix typo: iOs -> iOS

### DIFF
--- a/Scripts/landing.html
+++ b/Scripts/landing.html
@@ -50,6 +50,6 @@
 	        <li><a href="/documentation/eventproducer/">EventProducer</a></li>
 	    </ul>
     </nav>
-    <div class="main-content">The TIDAL SDK for iOs enables fast prototyping and development of new web apps built on TIDAL Developer Platform by providing core functionality in a set of easy-to-use software modules. The TIDAL SDK for iOs serves as a complement to, and extension of, the TIDAL API, meaning that some functionality provided by the TIDAL Developer Platform will only be made available through the TIDAL SDK, whereas some functionality will be available via both the TIDAL API and the TIDAL SDK.</div>
+    <div class="main-content">The TIDAL SDK for iOS enables fast prototyping and development of new web apps built on TIDAL Developer Platform by providing core functionality in a set of easy-to-use software modules. The TIDAL SDK for iOS serves as a complement to, and extension of, the TIDAL API, meaning that some functionality provided by the TIDAL Developer Platform will only be made available through the TIDAL SDK, whereas some functionality will be available via both the TIDAL API and the TIDAL SDK.</div>
 </body>
 </html>


### PR DESCRIPTION
I thought it looked better if we corrected these :-)