### PR TITLE
Use absolute URLs in documentation links

### DIFF
--- a/Scripts/combineDocumentation.sh
+++ b/Scripts/combineDocumentation.sh
@@ -5,13 +5,13 @@ mkdir -p docs/
 for target in "$@"
 do
     echo "Generating docs for $target"
-    swift package --allow-writing-to-directory "$target-docs" generate-documentation --disable-indexing --transform-for-static-hosting --output-path "$target-docs" --target "$target"
+    swift package --allow-writing-to-directory "$target-docs" generate-documentation --disable-indexing --transform-for-static-hosting --hosting-base-path tidal-sdk-ios --output-path "$target-docs" --target "$target"
     cp -r $target-docs/* docs/
     modified_target=$(echo $target | tr '-' '_' | tr '[:upper:]' '[:lower:]')
     cp -r $target-docs/index/index.json "docs/index/$modified_target.json"
 done
 
-echo "<!DOCTYPE html><html><head><meta http-equiv=\"refresh\" content=\"0; url=/documentation/\" /></head><body><ol>" > docs/index.html
+echo "<!DOCTYPE html><html><head><meta http-equiv=\"refresh\" content=\"0; url=/tidal-sdk-ios/documentation/\" /></head><body><ol>" > docs/index.html
 
 for target in "$@"
 do
@@ -19,7 +19,7 @@ do
     cp -R $target-docs/documentation/* docs/documentation/
     rm -r "$target-docs"
     modified_target=$(echo $target | tr '-' '_' | tr '[:upper:]' '[:lower:]')
-    echo "<li><a href=\"/documentation/$modified_target/\">$target</a></li>" >> docs/index.html
+    echo "<li><a href=\"/tidal-sdk-ios/documentation/$modified_target/\">$target</a></li>" >> docs/index.html
 done
 
 echo "</ol></body></html>" >> docs/index.html

--- a/Scripts/landing.html
+++ b/Scripts/landing.html
@@ -45,9 +45,9 @@
     </header>
     <nav>
 	    <ul>
-	        <li><a href="/documentation/player/">Player</a></li>
-	        <li><a href="/documentation/auth/">Auth</a></li>
-	        <li><a href="/documentation/eventproducer/">EventProducer</a></li>
+	        <li><a href="https://tidal-music.github.io/tidal-sdk-ios/documentation/player/">Player</a></li>
+	        <li><a href="https://tidal-music.github.io/tidal-sdk-ios/documentation/auth/">Auth</a></li>
+	        <li><a href="https://tidal-music.github.io/tidal-sdk-ios/documentation/eventproducer/">EventProducer</a></li>
 	    </ul>
     </nav>
     <div class="main-content">The TIDAL SDK for iOS enables fast prototyping and development of new web apps built on TIDAL Developer Platform by providing core functionality in a set of easy-to-use software modules. The TIDAL SDK for iOS serves as a complement to, and extension of, the TIDAL API, meaning that some functionality provided by the TIDAL Developer Platform will only be made available through the TIDAL SDK, whereas some functionality will be available via both the TIDAL API and the TIDAL SDK.</div>


### PR DESCRIPTION
After making the repo public, links in the deployed documentation pages failed due to changes in the relative paths.

This PR fixes it it by making the links absolute.
