### PR TITLE
Remove scopes that aren't needed from documentation

### DIFF
--- a/Sources/Auth/Auth.docc/Documentation.md
+++ b/Sources/Auth/Auth.docc/Documentation.md
@@ -45,8 +45,7 @@ let authConfig = AuthConfig(
     clientId: clientId,
     clientUniqueKey: clientUniqueKey,
     clientSecret: clientSecret,
-    credentialsKey: credentialsKey,
-    scopes: ["r_usr", "w_usr", "w_sub"]
+    credentialsKey: credentialsKey
 )
 
 TidalAuth.shared.config(config: authConfig)

--- a/Sources/Auth/README.md
+++ b/Sources/Auth/README.md
@@ -45,8 +45,7 @@ This authentication method uses `clientId` and `clientSecret`, e.g. when utilizi
         clientId: clientId,
         clientUniqueKey: clientUniqueKey,
         clientSecret: clientSecret,
-        credentialsKey: credentialsKey,
-        scopes: ["r_usr", "w_usr", "w_sub"]
+        credentialsKey: credentialsKey
     )
 
     TidalAuth.shared.config(config: authConfig)

--- a/TestApps/Auth/AuthTestApp/AuthViewModel.swift
+++ b/TestApps/Auth/AuthTestApp/AuthViewModel.swift
@@ -26,7 +26,6 @@ class AuthViewModel: ObservableObject {
 			clientId: isDeviceLoginEnabled ? CLIENT_ID_DEVICE_LOGIN : CLIENT_ID,
 			clientUniqueKey: CLIENT_UNIQUE_KEY,
 			credentialsKey: "storage",
-			scopes: ["r_usr", "w_usr", "w_sub"]
 		)
 	}
 

--- a/Tests/AuthTests/ScopesTests.swift
+++ b/Tests/AuthTests/ScopesTests.swift
@@ -6,7 +6,7 @@ import XCTest
 final class ScopesTests: XCTestCase {
 	func testToString() throws {
 		// given
-		let scopeSet = Set(["r_usr", "w_usr", "w_sub", "r_k"])
+		let scopeSet = Set(["abc", "def", "ghi", "jkl"])
 		let scopes = Scopes(scopes: scopeSet)
 
 		// when
@@ -16,12 +16,12 @@ final class ScopesTests: XCTestCase {
 			.joined(separator: " ")
 
 		// then
-		XCTAssertEqual(convertedString, "r_k r_usr w_sub w_usr")
+		XCTAssertEqual(convertedString, "abc def ghi jkl")
 	}
 
 	func testScopesFromString() throws {
 		// given
-		let scopesString = "r_usr w_usr w_sub"
+		let scopesString = "abc def ghi"
 
 		// when
 		let scopes = try Scopes.fromString(scopesString)


### PR DESCRIPTION
For client credentials authentication, the user doesn't need scopes, so it's misleading to reference them in the documentation. Therefore this removes them.