### PR TITLE
Moved PlayLog tests to a separate GH Action

### DIFF
--- a/.github/workflows/playlog-tests.yml
+++ b/.github/workflows/playlog-tests.yml
@@ -2,6 +2,8 @@ name: Run PlayLog Unit Tests
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "5 3 * * *"
 
 jobs:
   run-xcodebuild-tests:

--- a/.github/workflows/playlog-tests.yml
+++ b/.github/workflows/playlog-tests.yml
@@ -1,0 +1,18 @@
+name: Run PlayLog Unit Tests
+
+on:
+  workflow_dispatch:
+
+jobs:
+  run-xcodebuild-tests:
+    name: Run xcodebuild PlayLog Unit Tests
+    runs-on: macos-14
+    steps:
+    - uses: actions/checkout@v4
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: '15.2.0'
+
+    - name: Run Player PlayLog tests (xcodebuild)
+      run: |-
+        set -o pipefail && xcodebuild -scheme 'Player' -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 15' test -only-testing:PlayerTests/PlayLogTests -skipPackagePluginValidation | xcbeautify --renderer github-actions

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -30,7 +30,7 @@ jobs:
 
     - name: Run Player tests (xcodebuild)
       run: |-
-        set -o pipefail && xcodebuild -scheme 'Player' -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 15' test -skipPackagePluginValidation | xcbeautify --renderer github-actions
+        set -o pipefail && xcodebuild -scheme 'Player' -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 15' test -skip-testing:PlayerTests/PlayLogTests -skipPackagePluginValidation | xcbeautify --renderer github-actions
 
   build-test-apps:
     name: Build Test Apps


### PR DESCRIPTION
While we continue development of the PlayLog unit tests, we have moved them to a separate action that we can trigger manually.

Once they are completed and stable, we will decide the frequency on which to run them, given that they are inherently slow.