### PR TITLE
Fix test flakiness in StreamingPrivilegesHandlerTests

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -2,7 +2,7 @@ name: Run Unit Tests
 
 on:
   workflow_call:
-
+  workflow_dispatch:
   pull_request:
     branches: '*'
 

--- a/Tests/PlayerTests/Helpers/XCTestCase+Player.swift
+++ b/Tests/PlayerTests/Helpers/XCTestCase+Player.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+@testable import Player
 
 extension XCTestCase {
 	func optimizedWait(timeout: Double = 10.0, step: Double = 0.1, until condition: () -> Bool) {
@@ -7,6 +8,21 @@ extension XCTestCase {
 		while timer < timeout {
 			let expectation = expectation(description: "Optimized wait: Waiting for condition to be met")
 			_ = XCTWaiter.wait(for: [expectation], timeout: step)
+
+			if condition() {
+				return
+			}
+
+			timer += step
+		}
+
+		XCTFail("Optimized wait: Condition was not met")
+	}
+	
+	func asyncOptimizedWait(timeout: Double = 10.0, step: Double = 0.1, until condition: @escaping () -> Bool) async {
+		var timer: Double = 0
+		while timer < timeout {
+			try? await Task.sleep(seconds: step)
 
 			if condition() {
 				return

--- a/Tests/PlayerTests/Player/PlaybackEngine/Internal/StreamingPrivileges/StreamingPrivilegesHandlerTests.swift
+++ b/Tests/PlayerTests/Player/PlaybackEngine/Internal/StreamingPrivileges/StreamingPrivilegesHandlerTests.swift
@@ -110,7 +110,9 @@ extension StreamingPrivilegesHandlerTests {
 			await self.streamingPrivilegesHandler.notify()
 		}
 
-		try? await Task.sleep(seconds: Constants.sleepingTime)
+		await asyncOptimizedWait {
+			task.sendMessages.count == 1
+		}
 
 		// THEN
 
@@ -161,12 +163,17 @@ extension StreamingPrivilegesHandlerTests {
 			await self.streamingPrivilegesHandler.notify()
 		}
 
-		try? await Task.sleep(seconds: Constants.sleepingTime)
+		await asyncOptimizedWait {
+			task.sendMessages.count == 1
+		}
 
 		configuration.offlineMode = true
 		streamingPrivilegesHandler.updateConfiguration(configuration)
 
-		try? await Task.sleep(seconds: 5)
+		await asyncOptimizedWait {
+			task.sendMessages.count == 1 &&
+			self.webSocket.responses.count == 1
+		}
 
 		// THEN
 
@@ -222,8 +229,10 @@ extension StreamingPrivilegesHandlerTests {
 			await self.streamingPrivilegesHandler.notify()
 		}
 
-		try? await Task.sleep(seconds: Constants.sleepingTime)
-
+		await asyncOptimizedWait {
+			task.sendMessages.count == 1
+		}
+		
 		// THEN
 
 		// The web socket is opened (one message is sent)
@@ -302,7 +311,9 @@ extension StreamingPrivilegesHandlerTests {
 			await self.streamingPrivilegesHandler.notify()
 		}
 
-		try? await Task.sleep(seconds: Constants.sleepingTimeForErrors)
+		await asyncOptimizedWait {
+			task.sendMessages.count == 1
+		}
 
 		// THEN
 
@@ -384,7 +395,9 @@ extension StreamingPrivilegesHandlerTests {
 			await self.streamingPrivilegesHandler.notify()
 		}
 
-		try? await Task.sleep(seconds: Constants.sleepingTimeForErrors)
+		await asyncOptimizedWait {
+			task.sendMessages.count == 1
+		}
 
 		// THEN
 
@@ -470,7 +483,9 @@ extension StreamingPrivilegesHandlerTests {
 			await self.streamingPrivilegesHandler.notify()
 		}
 
-		try? await Task.sleep(seconds: Constants.sleepingTimeForErrors)
+		await asyncOptimizedWait {
+			task.sendMessages.count == 1
+		}
 
 		// THEN
 


### PR DESCRIPTION
This PR improves speed and stability for StreamingPrivilegesHandlerTests by implementing a more efficient and flexible wait mechanism to allow the async tasks to do their work.

This is not fully controllable, but it has been proven to be quite reliable for us in other tests, and much better than waiting a set amount of time.

### Before:

![Screenshot 2024-05-29 at 16 29 00](https://github.com/tidal-music/tidal-sdk-ios/assets/183470/a58475c2-4ec1-4230-9e55-5e894f8542da)

### After:
![Screenshot 2024-05-29 at 16 29 26](https://github.com/tidal-music/tidal-sdk-ios/assets/183470/95e90cee-fcbf-4af6-a62d-890940797c81)

### 100 runs:
![Screenshot 2024-05-29 at 16 10 08](https://github.com/tidal-music/tidal-sdk-ios/assets/183470/0f142017-959c-4a88-b21f-2e201635f8ff)

