### PR TITLE
Migrate `shouldSendEventsInDeinit` dev flag to production

### DIFF
--- a/Sources/Player/Common/FeatureFlags/FeatureFlagProvider+Standard.swift
+++ b/Sources/Player/Common/FeatureFlags/FeatureFlagProvider+Standard.swift
@@ -4,6 +4,7 @@ public extension FeatureFlagProvider {
 	static let standard = FeatureFlagProvider(
 		isStallWhenTransitionFromEndedToBufferingEnabled: { true },
 		shouldUseEventProducer: { false },
-		isContentCachingEnabled: { true }
+		isContentCachingEnabled: { true },
+		shouldSendEventsInDeinit: { true }
 	)
 }

--- a/Sources/Player/Common/FeatureFlags/FeatureFlagProvider.swift
+++ b/Sources/Player/Common/FeatureFlags/FeatureFlagProvider.swift
@@ -3,15 +3,18 @@ public struct FeatureFlagProvider {
 	public var isStallWhenTransitionFromEndedToBufferingEnabled: () -> Bool
 	public var shouldUseEventProducer: () -> Bool
 	public var isContentCachingEnabled: () -> Bool
-
+	public var shouldSendEventsInDeinit: () -> Bool
+	
 	public init(
 		// swiftlint:disable:next identifier_name
 		isStallWhenTransitionFromEndedToBufferingEnabled: @escaping () -> Bool,
 		shouldUseEventProducer: @escaping () -> Bool,
-		isContentCachingEnabled: @escaping () -> Bool
+		isContentCachingEnabled: @escaping () -> Bool,
+		shouldSendEventsInDeinit: @escaping () -> Bool
 	) {
 		self.isStallWhenTransitionFromEndedToBufferingEnabled = isStallWhenTransitionFromEndedToBufferingEnabled
 		self.shouldUseEventProducer = shouldUseEventProducer
 		self.isContentCachingEnabled = isContentCachingEnabled
+		self.shouldSendEventsInDeinit = shouldSendEventsInDeinit
 	}
 }

--- a/Sources/Player/Common/World/DevelopmentFeatureFlagProvider/DevelopmentFeatureFlagProvider+Live.swift
+++ b/Sources/Player/Common/World/DevelopmentFeatureFlagProvider/DevelopmentFeatureFlagProvider+Live.swift
@@ -1,6 +1,5 @@
 extension DevelopmentFeatureFlagProvider {
 	static let live = DevelopmentFeatureFlagProvider(
-		isOffliningEnabled: false,
-		shouldSendEventsInDeinit: false
+		isOffliningEnabled: false
 	)
 }

--- a/Sources/Player/Common/World/DevelopmentFeatureFlagProvider/DevelopmentFeatureFlagProvider.swift
+++ b/Sources/Player/Common/World/DevelopmentFeatureFlagProvider/DevelopmentFeatureFlagProvider.swift
@@ -3,6 +3,4 @@ import Foundation
 /// Provider of feature flags used during development of new features.
 struct DevelopmentFeatureFlagProvider {
 	var isOffliningEnabled: Bool
-	/// Flag whether we should emit events on the `deinit`` of ``Player item``.
-	var shouldSendEventsInDeinit: Bool
 }

--- a/Sources/Player/Mocks/Common/FeatureFlags/FeatureFlagProvider+Mock.swift
+++ b/Sources/Player/Mocks/Common/FeatureFlags/FeatureFlagProvider+Mock.swift
@@ -4,6 +4,7 @@ public extension FeatureFlagProvider {
 	static let mock = FeatureFlagProvider(
 		isStallWhenTransitionFromEndedToBufferingEnabled: { true },
 		shouldUseEventProducer: { true },
-		isContentCachingEnabled: { true }
+		isContentCachingEnabled: { true },
+		shouldSendEventsInDeinit: { true }
 	)
 }

--- a/Sources/Player/PlaybackEngine/Internal/PlayerItem.swift
+++ b/Sources/Player/PlaybackEngine/Internal/PlayerItem.swift
@@ -25,6 +25,7 @@ final class PlayerItem {
 
 	private weak var playerItemMonitor: PlayerItemMonitor?
 	private let playerEventSender: PlayerEventSender
+	private let featureFlagProvider: FeatureFlagProvider
 	private var playbackStartReason: StartReason
 
 	@Atomic private var metrics: Metrics?
@@ -51,6 +52,7 @@ final class PlayerItem {
 		self.mediaProduct = mediaProduct
 		self.playerItemMonitor = playerItemMonitor
 		self.playerEventSender = playerEventSender
+		self.featureFlagProvider = featureFlagProvider
 
 		isDownloaded = false
 		shouldPlayWhenLoaded = false
@@ -78,7 +80,7 @@ final class PlayerItem {
 	}
 
 	deinit {
-		if PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit {
+		if featureFlagProvider.shouldSendEventsInDeinit() {
 			emitEvents()
 		}
 	}

--- a/Sources/Player/PlaybackEngine/PlayerEngine.swift
+++ b/Sources/Player/PlaybackEngine/PlayerEngine.swift
@@ -90,7 +90,7 @@ final class PlayerEngine {
 
 	/// Flag whether we should emit events on the deinit of the current and next items.
 	private var shouldSendEventsInDeinit: Bool {
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit
+		featureFlagProvider.shouldSendEventsInDeinit()
 	}
 
 	#if !os(macOS)

--- a/Tests/PlayerTests/EventsTests.swift
+++ b/Tests/PlayerTests/EventsTests.swift
@@ -29,7 +29,8 @@ private enum Constants {
 final class EventsTests: XCTestCase {
 	private var timestamp: UInt64 = 1
 	private var uuid = "uuid"
-
+	private var shouldSendEventsInDeinit: Bool = true
+	
 	private var configuration: Configuration!
 	private var errorManager: ErrorManagerMock!
 	private var urlSession: URLSession!
@@ -88,6 +89,9 @@ final class EventsTests: XCTestCase {
 		featureFlagProvider.isContentCachingEnabled = {
 			self.isContentCachingEnabled
 		}
+		featureFlagProvider.shouldSendEventsInDeinit = {
+			self.shouldSendEventsInDeinit
+		}
 
 		// Set up EventSender
 		configuration = Configuration.mock()
@@ -141,7 +145,11 @@ final class EventsTests: XCTestCase {
 			and: playerEventSender,
 			featureFlagProvider: featureFlagProvider
 		)
-		playerLoader = PlayerLoaderMock(with: configuration, and: fairplayLicenseFetcher)
+		playerLoader = PlayerLoaderMock(
+			with: configuration,
+			and: fairplayLicenseFetcher,
+			featureFlagProvider: featureFlagProvider
+		)
 
 		playerEngine = PlayerEngine.mock(
 			queue: OperationQueueMock(),
@@ -168,7 +176,7 @@ final class EventsTests: XCTestCase {
 
 	func testCsssCpbiAndCsseSentAfterSuccessfulLoadAndReset() async {
 		shouldUseEventProducer = true
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = false
+		shouldSendEventsInDeinit = false
 
 		JsonEncodedResponseURLProtocol.succeed(with: Constants.trackPlaybackInfo)
 
@@ -210,7 +218,7 @@ final class EventsTests: XCTestCase {
 
 	func testCsssCpbiAndCsseSentAfterSuccessfulLoadAndReset_legacy() {
 		shouldUseEventProducer = true
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = true
+		shouldSendEventsInDeinit = true
 
 		JsonEncodedResponseURLProtocol.succeed(with: Constants.trackPlaybackInfo)
 
@@ -268,7 +276,7 @@ final class EventsTests: XCTestCase {
 
 	func assertCsssCpbiAndCsseSentAfterSuccessfulLoadAndReset_legacy(shouldSendEventsInDeinit: Bool) async {
 		shouldUseEventProducer = false
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = shouldSendEventsInDeinit
+		self.shouldSendEventsInDeinit = shouldSendEventsInDeinit
 
 		JsonEncodedResponseURLProtocol.succeed(with: Constants.trackPlaybackInfo)
 
@@ -328,7 +336,7 @@ final class EventsTests: XCTestCase {
 
 	func testCsssCpbiAndCsseSentAfterFailedLoad() async {
 		shouldUseEventProducer = true
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = false
+		shouldSendEventsInDeinit = false
 
 		JsonEncodedResponseURLProtocol.fail()
 
@@ -368,7 +376,7 @@ final class EventsTests: XCTestCase {
 
 	func testCsssCpbiAndCsseSentAfterFailedLoad_legacy() {
 		shouldUseEventProducer = true
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = true
+		shouldSendEventsInDeinit = true
 
 		JsonEncodedResponseURLProtocol.fail()
 
@@ -424,7 +432,7 @@ final class EventsTests: XCTestCase {
 
 	func assertCsssCpbiAndCsseSentAfterFailedLoad_legacy(shouldSendEventsInDeinit: Bool) async {
 		shouldUseEventProducer = false
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = shouldSendEventsInDeinit
+		self.shouldSendEventsInDeinit = shouldSendEventsInDeinit
 
 		JsonEncodedResponseURLProtocol.fail()
 
@@ -480,7 +488,7 @@ final class EventsTests: XCTestCase {
 
 	func testCsssAndCpbiSentAfterSkipToNext() async {
 		shouldUseEventProducer = true
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = false
+		shouldSendEventsInDeinit = false
 
 		let playbackInfo = Constants.trackPlaybackInfo
 		JsonEncodedResponseURLProtocol.succeed(with: playbackInfo)
@@ -581,7 +589,7 @@ final class EventsTests: XCTestCase {
 
 	func testCsssAndCpbiSentAfterSkipToNext_legacy() {
 		shouldUseEventProducer = true
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = true
+		shouldSendEventsInDeinit = true
 
 		let playbackInfo = Constants.trackPlaybackInfo
 		JsonEncodedResponseURLProtocol.succeed(with: playbackInfo)
@@ -698,7 +706,7 @@ final class EventsTests: XCTestCase {
 
 	func assertCsssAndCpbiSentAfterSkipToNext_legacy(shouldSendEventsInDeinit: Bool) async {
 		shouldUseEventProducer = false
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = shouldSendEventsInDeinit
+		self.shouldSendEventsInDeinit = shouldSendEventsInDeinit
 
 		let playbackInfo = Constants.trackPlaybackInfo
 		JsonEncodedResponseURLProtocol.succeed(with: playbackInfo)
@@ -819,7 +827,7 @@ final class EventsTests: XCTestCase {
 
 	func testCsssAndCpbiSentAfterSuccessfulLoadOfNext() async {
 		shouldUseEventProducer = true
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = false
+		shouldSendEventsInDeinit = false
 
 		JsonEncodedResponseURLProtocol.succeed(with: Constants.trackPlaybackInfo)
 
@@ -857,7 +865,7 @@ final class EventsTests: XCTestCase {
 
 	func testCsssAndCpbiSentAfterSuccessfulLoadOfNext_legacy() {
 		shouldUseEventProducer = true
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = true
+		shouldSendEventsInDeinit = true
 
 		JsonEncodedResponseURLProtocol.succeed(with: Constants.trackPlaybackInfo)
 
@@ -907,7 +915,7 @@ final class EventsTests: XCTestCase {
 
 	func assertCsssAndCpbiSentAfterSuccessfulLoadOfNext_legacy(shouldSendEventsInDeinit: Bool) async {
 		shouldUseEventProducer = false
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = shouldSendEventsInDeinit
+		self.shouldSendEventsInDeinit = shouldSendEventsInDeinit
 
 		JsonEncodedResponseURLProtocol.succeed(with: Constants.trackPlaybackInfo)
 
@@ -953,7 +961,7 @@ final class EventsTests: XCTestCase {
 
 	func testCsssAndCpbiSentAfterNextIsReplaced() async {
 		shouldUseEventProducer = true
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = false
+		shouldSendEventsInDeinit = false
 
 		JsonEncodedResponseURLProtocol.succeed(with: Constants.trackPlaybackInfo)
 
@@ -1007,7 +1015,7 @@ final class EventsTests: XCTestCase {
 
 	func testCsssAndCpbiSentAfterNextIsReplaced_legacy() {
 		shouldUseEventProducer = false
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = true
+		shouldSendEventsInDeinit = true
 
 		JsonEncodedResponseURLProtocol.succeed(with: Constants.trackPlaybackInfo)
 
@@ -1060,7 +1068,7 @@ final class EventsTests: XCTestCase {
 
 	func assertCsssAndCpbiSentAfterNextIsReplaced_legacy(shouldSendEventsInDeinit: Bool) async {
 		shouldUseEventProducer = false
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = shouldSendEventsInDeinit
+		self.shouldSendEventsInDeinit = shouldSendEventsInDeinit
 
 		JsonEncodedResponseURLProtocol.succeed(with: Constants.trackPlaybackInfo)
 
@@ -1122,7 +1130,7 @@ final class EventsTests: XCTestCase {
 
 	func testCsssAndCpbiSentAfterFailedLoadOfNext() async {
 		shouldUseEventProducer = true
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = false
+		shouldSendEventsInDeinit = false
 
 		JsonEncodedResponseURLProtocol.succeed(with: Constants.trackPlaybackInfo)
 
@@ -1161,7 +1169,7 @@ final class EventsTests: XCTestCase {
 
 	func testCsssAndCpbiSentAfterFailedLoadOfNext_legacy() {
 		shouldUseEventProducer = true
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = true
+		shouldSendEventsInDeinit = true
 
 		JsonEncodedResponseURLProtocol.succeed(with: Constants.trackPlaybackInfo)
 
@@ -1212,7 +1220,7 @@ final class EventsTests: XCTestCase {
 
 	func assertCsssAndCpbiSentAfterFailedLoadOfNext_legacy(shouldSendEventsInDeinit: Bool) async {
 		shouldUseEventProducer = false
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = shouldSendEventsInDeinit
+		self.shouldSendEventsInDeinit = shouldSendEventsInDeinit
 
 		JsonEncodedResponseURLProtocol.succeed(with: Constants.trackPlaybackInfo)
 
@@ -1259,7 +1267,7 @@ final class EventsTests: XCTestCase {
 
 	func testPlayCurrentSucceeds() async {
 		shouldUseEventProducer = true
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = false
+		shouldSendEventsInDeinit = false
 
 		let playbackInfo = Constants.trackPlaybackInfo
 		JsonEncodedResponseURLProtocol.succeed(with: playbackInfo)
@@ -1342,7 +1350,7 @@ final class EventsTests: XCTestCase {
 
 	func testPlayCurrentSucceeds_legacy() {
 		shouldUseEventProducer = true
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = true
+		shouldSendEventsInDeinit = true
 
 		let playbackInfo = Constants.trackPlaybackInfo
 		JsonEncodedResponseURLProtocol.succeed(with: playbackInfo)
@@ -1437,7 +1445,7 @@ final class EventsTests: XCTestCase {
 
 	func assertPlayCurrentSucceeds_legacy(shouldSendEventsInDeinit: Bool) async {
 		shouldUseEventProducer = false
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = shouldSendEventsInDeinit
+		self.shouldSendEventsInDeinit = shouldSendEventsInDeinit
 
 		let playbackInfo = Constants.trackPlaybackInfo
 		JsonEncodedResponseURLProtocol.succeed(with: playbackInfo)
@@ -1529,7 +1537,7 @@ final class EventsTests: XCTestCase {
 	func testPlayCurrentSucceeds_withCachingDisabled() async {
 		shouldUseEventProducer = true
 		isContentCachingEnabled = false
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = false
+		shouldSendEventsInDeinit = false
 
 		let playbackInfo = Constants.trackPlaybackInfo
 		JsonEncodedResponseURLProtocol.succeed(with: playbackInfo)
@@ -1613,7 +1621,7 @@ final class EventsTests: XCTestCase {
 
 	func testPlayCurrentSucceeds_withPreload() async {
 		shouldUseEventProducer = true
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = false
+		shouldSendEventsInDeinit = false
 
 		let playbackInfo = Constants.trackPlaybackInfo
 		JsonEncodedResponseURLProtocol.succeed(with: playbackInfo)
@@ -1697,7 +1705,7 @@ final class EventsTests: XCTestCase {
 
 	func testPlayCurrentSucceeds_withPreload_legacy() {
 		shouldUseEventProducer = false
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = true
+		shouldSendEventsInDeinit = true
 
 		let playbackInfo = Constants.trackPlaybackInfo
 		JsonEncodedResponseURLProtocol.succeed(with: playbackInfo)
@@ -1793,7 +1801,7 @@ final class EventsTests: XCTestCase {
 
 	func assertPlayCurrentSucceeds_withPreload_legacy(shouldSendEventsInDeinit: Bool) async {
 		shouldUseEventProducer = false
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = shouldSendEventsInDeinit
+		self.shouldSendEventsInDeinit = shouldSendEventsInDeinit
 
 		let playbackInfo = Constants.trackPlaybackInfo
 		JsonEncodedResponseURLProtocol.succeed(with: playbackInfo)
@@ -1885,7 +1893,7 @@ final class EventsTests: XCTestCase {
 
 	func testPlayCurrentFails() async {
 		shouldUseEventProducer = true
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = false
+		shouldSendEventsInDeinit = false
 
 		let playbackInfo = Constants.trackPlaybackInfo
 		JsonEncodedResponseURLProtocol.succeed(with: playbackInfo)
@@ -1969,7 +1977,7 @@ final class EventsTests: XCTestCase {
 
 	func testPlayCurrentFails_legacy() {
 		shouldUseEventProducer = false
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = true
+		shouldSendEventsInDeinit = true
 
 		let playbackInfo = Constants.trackPlaybackInfo
 		JsonEncodedResponseURLProtocol.succeed(with: playbackInfo)
@@ -2065,7 +2073,7 @@ final class EventsTests: XCTestCase {
 
 	func assertPlayCurrentFails_legacy(shouldSendEventsInDeinit: Bool) async {
 		shouldUseEventProducer = false
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = shouldSendEventsInDeinit
+		self.shouldSendEventsInDeinit = shouldSendEventsInDeinit
 
 		let playbackInfo = Constants.trackPlaybackInfo
 		JsonEncodedResponseURLProtocol.succeed(with: playbackInfo)
@@ -2157,7 +2165,7 @@ final class EventsTests: XCTestCase {
 
 	func testPlayCurrentReset() async {
 		shouldUseEventProducer = true
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = false
+		shouldSendEventsInDeinit = false
 
 		let playbackInfo = Constants.trackPlaybackInfo
 		JsonEncodedResponseURLProtocol.succeed(with: playbackInfo)
@@ -2244,7 +2252,7 @@ final class EventsTests: XCTestCase {
 
 	func testPlayCurrentReset_legacy() {
 		shouldUseEventProducer = true
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = true
+		shouldSendEventsInDeinit = true
 
 		let playbackInfo = Constants.trackPlaybackInfo
 		JsonEncodedResponseURLProtocol.succeed(with: playbackInfo)
@@ -2343,7 +2351,7 @@ final class EventsTests: XCTestCase {
 
 	func assertPlayCurrentReset_legacy(shouldSendEventsInDeinit: Bool) async {
 		shouldUseEventProducer = false
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = shouldSendEventsInDeinit
+		self.shouldSendEventsInDeinit = shouldSendEventsInDeinit
 
 		let playbackInfo = Constants.trackPlaybackInfo
 		JsonEncodedResponseURLProtocol.succeed(with: playbackInfo)
@@ -2438,7 +2446,7 @@ final class EventsTests: XCTestCase {
 
 	func testPlayCurrentAndNextSuccess() async {
 		shouldUseEventProducer = true
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = false
+		shouldSendEventsInDeinit = false
 
 		let playbackInfo = Constants.trackPlaybackInfo
 		JsonEncodedResponseURLProtocol.succeed(with: playbackInfo)
@@ -2577,7 +2585,7 @@ final class EventsTests: XCTestCase {
 
 	func testPlayCurrentAndNextSuccess_legacy() {
 		shouldUseEventProducer = false
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = true
+		shouldSendEventsInDeinit = true
 
 		let playbackInfo = Constants.trackPlaybackInfo
 		JsonEncodedResponseURLProtocol.succeed(with: playbackInfo)
@@ -2732,7 +2740,7 @@ final class EventsTests: XCTestCase {
 
 	func assertPlayCurrentAndNextSuccess_legacy(shouldSendEventsInDeinit: Bool) async {
 		shouldUseEventProducer = false
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = shouldSendEventsInDeinit
+		self.shouldSendEventsInDeinit = shouldSendEventsInDeinit
 
 		let playbackInfo = Constants.trackPlaybackInfo
 		JsonEncodedResponseURLProtocol.succeed(with: playbackInfo)
@@ -2887,7 +2895,7 @@ final class EventsTests: XCTestCase {
 
 	func testLoadFailsInPlayer() async {
 		shouldUseEventProducer = true
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = false
+		shouldSendEventsInDeinit = false
 
 		let playbackInfo = Constants.trackPlaybackInfo
 		JsonEncodedResponseURLProtocol.succeed(with: playbackInfo)
@@ -2940,7 +2948,7 @@ final class EventsTests: XCTestCase {
 
 	func testLoadFailsInPlayer_legacy() {
 		shouldUseEventProducer = false
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = true
+		shouldSendEventsInDeinit = true
 
 		let playbackInfo = Constants.trackPlaybackInfo
 		JsonEncodedResponseURLProtocol.succeed(with: playbackInfo)
@@ -3005,7 +3013,7 @@ final class EventsTests: XCTestCase {
 
 	func assertLoadFailsInPlayer_legacy(shouldSendEventsInDeinit: Bool) async {
 		shouldUseEventProducer = false
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = shouldSendEventsInDeinit
+		self.shouldSendEventsInDeinit = shouldSendEventsInDeinit
 
 		let playbackInfo = Constants.trackPlaybackInfo
 		JsonEncodedResponseURLProtocol.succeed(with: playbackInfo)
@@ -3066,7 +3074,7 @@ final class EventsTests: XCTestCase {
 
 	func testPlayCurrentNextFailsBetweenPlaybackInfoAndCurrentComplete() async {
 		shouldUseEventProducer = true
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = false
+		shouldSendEventsInDeinit = false
 
 		let playbackInfo = Constants.trackPlaybackInfo
 		JsonEncodedResponseURLProtocol.succeed(with: playbackInfo)
@@ -3171,7 +3179,7 @@ final class EventsTests: XCTestCase {
 
 	func testPlayCurrentNextFailsBetweenPlaybackInfoAndCurrentComplete_legacy() {
 		shouldUseEventProducer = false
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = true
+		shouldSendEventsInDeinit = true
 
 		let playbackInfo = Constants.trackPlaybackInfo
 		JsonEncodedResponseURLProtocol.succeed(with: playbackInfo)
@@ -3275,7 +3283,7 @@ final class EventsTests: XCTestCase {
 
 	func assertPlayCurrentNextFailsBetweenPlaybackInfoAndCurrentComplete_legacy(shouldSendEventsInDeinit: Bool) async {
 		shouldUseEventProducer = false
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = shouldSendEventsInDeinit
+		self.shouldSendEventsInDeinit = shouldSendEventsInDeinit
 
 		let playbackInfo = Constants.trackPlaybackInfo
 		JsonEncodedResponseURLProtocol.succeed(with: playbackInfo)
@@ -3388,7 +3396,7 @@ final class EventsTests: XCTestCase {
 
 	func testPlayingAndPausing() async {
 		shouldUseEventProducer = true
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = false
+		shouldSendEventsInDeinit = false
 
 		let playbackInfo = Constants.trackPlaybackInfo
 		JsonEncodedResponseURLProtocol.succeed(with: playbackInfo)
@@ -3474,7 +3482,7 @@ final class EventsTests: XCTestCase {
 
 	func testPlayingAndPausing_legacy() {
 		shouldUseEventProducer = false
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = true
+		shouldSendEventsInDeinit = true
 
 		let playbackInfo = Constants.trackPlaybackInfo
 		JsonEncodedResponseURLProtocol.succeed(with: playbackInfo)
@@ -3572,7 +3580,7 @@ final class EventsTests: XCTestCase {
 
 	func assertPlayingAndPausing_legacy(shouldSendEventsInDeinit: Bool) async {
 		shouldUseEventProducer = false
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = shouldSendEventsInDeinit
+		self.shouldSendEventsInDeinit = shouldSendEventsInDeinit
 
 		let playbackInfo = Constants.trackPlaybackInfo
 		JsonEncodedResponseURLProtocol.succeed(with: playbackInfo)
@@ -3666,7 +3674,7 @@ final class EventsTests: XCTestCase {
 
 	func testPlayingAndStalling() async {
 		shouldUseEventProducer = true
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = false
+		shouldSendEventsInDeinit = false
 
 		let playbackInfo = Constants.trackPlaybackInfo
 		JsonEncodedResponseURLProtocol.succeed(with: playbackInfo)
@@ -3769,7 +3777,7 @@ final class EventsTests: XCTestCase {
 
 	func testPlayingAndStalling_legacy() {
 		shouldUseEventProducer = false
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = true
+		shouldSendEventsInDeinit = true
 
 		let playbackInfo = Constants.trackPlaybackInfo
 		JsonEncodedResponseURLProtocol.succeed(with: playbackInfo)
@@ -3879,7 +3887,7 @@ final class EventsTests: XCTestCase {
 
 	func testPlayingAndStalling_legacy(shouldSendEventsInDeinit: Bool) {
 		shouldUseEventProducer = false
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = true
+		self.shouldSendEventsInDeinit = true
 
 		let playbackInfo = Constants.trackPlaybackInfo
 		JsonEncodedResponseURLProtocol.succeed(with: playbackInfo)
@@ -3981,7 +3989,7 @@ final class EventsTests: XCTestCase {
 
 	func testPlayingAndSeeking() async {
 		shouldUseEventProducer = true
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = false
+		shouldSendEventsInDeinit = false
 
 		let playbackInfo = Constants.trackPlaybackInfo
 		JsonEncodedResponseURLProtocol.succeed(with: playbackInfo)
@@ -4073,7 +4081,7 @@ final class EventsTests: XCTestCase {
 
 	func testPlayingAndSeeking_legacy() {
 		shouldUseEventProducer = false
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = true
+		shouldSendEventsInDeinit = true
 
 		let playbackInfo = Constants.trackPlaybackInfo
 		JsonEncodedResponseURLProtocol.succeed(with: playbackInfo)
@@ -4177,7 +4185,7 @@ final class EventsTests: XCTestCase {
 
 	func testPlayingAndSeeking_legacy(shouldSendEventsInDeinit: Bool) {
 		shouldUseEventProducer = false
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = true
+		self.shouldSendEventsInDeinit = true
 
 		let playbackInfo = Constants.trackPlaybackInfo
 		JsonEncodedResponseURLProtocol.succeed(with: playbackInfo)
@@ -4273,7 +4281,7 @@ final class EventsTests: XCTestCase {
 
 	func testStallsDueToSeek() async {
 		shouldUseEventProducer = true
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = false
+		shouldSendEventsInDeinit = false
 
 		let playbackInfo = Constants.trackPlaybackInfo
 		JsonEncodedResponseURLProtocol.succeed(with: playbackInfo)
@@ -4374,7 +4382,7 @@ final class EventsTests: XCTestCase {
 
 	func testStallsDueToSeek_legacy() {
 		shouldUseEventProducer = false
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = true
+		shouldSendEventsInDeinit = true
 
 		let playbackInfo = Constants.trackPlaybackInfo
 		JsonEncodedResponseURLProtocol.succeed(with: playbackInfo)
@@ -4487,7 +4495,7 @@ final class EventsTests: XCTestCase {
 
 	func assertStallsDueToSeek_legacy(shouldSendEventsInDeinit: Bool) async  {
 		shouldUseEventProducer = false
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = shouldSendEventsInDeinit
+		self.shouldSendEventsInDeinit = shouldSendEventsInDeinit
 
 		let playbackInfo = Constants.trackPlaybackInfo
 		JsonEncodedResponseURLProtocol.succeed(with: playbackInfo)
@@ -4596,7 +4604,7 @@ final class EventsTests: XCTestCase {
 
 	func testStallAndAbortedSeeks() async {
 		shouldUseEventProducer = true
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = false
+		shouldSendEventsInDeinit = false
 
 		let playbackInfo = Constants.trackPlaybackInfo
 		JsonEncodedResponseURLProtocol.succeed(with: playbackInfo)
@@ -4708,7 +4716,7 @@ final class EventsTests: XCTestCase {
 
 	func testStallAndAbortedSeeks_legacy() {
 		shouldUseEventProducer = false
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = true
+		shouldSendEventsInDeinit = true
 
 		let playbackInfo = Constants.trackPlaybackInfo
 		JsonEncodedResponseURLProtocol.succeed(with: playbackInfo)
@@ -4827,7 +4835,7 @@ final class EventsTests: XCTestCase {
 
 	func assertStallAndAbortedSeeks_legacy(shouldSendEventsInDeinit: Bool) async {
 		shouldUseEventProducer = false
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = shouldSendEventsInDeinit
+		self.shouldSendEventsInDeinit = shouldSendEventsInDeinit
 
 		let playbackInfo = Constants.trackPlaybackInfo
 		JsonEncodedResponseURLProtocol.succeed(with: playbackInfo)

--- a/Tests/PlayerTests/Mocks/Common/World/DevelopmentFeatureFlagProvider+Mock.swift
+++ b/Tests/PlayerTests/Mocks/Common/World/DevelopmentFeatureFlagProvider+Mock.swift
@@ -1,5 +1,7 @@
 @testable import Player
 
 extension DevelopmentFeatureFlagProvider {
-	static let mock: Self = DevelopmentFeatureFlagProvider(isOffliningEnabled: false, shouldSendEventsInDeinit: false)
+	static let mock: Self = DevelopmentFeatureFlagProvider(
+		isOffliningEnabled: false
+	)
 }

--- a/Tests/PlayerTests/Player/PlaybackEngine/Internal/Events/PlayerEventSenderTests.swift
+++ b/Tests/PlayerTests/Player/PlaybackEngine/Internal/Events/PlayerEventSenderTests.swift
@@ -410,7 +410,6 @@ extension PlayerEventSenderTests {
 
 	func test_updateUserConfiguration_legacy() async {
 		shouldUseEventProducer = false
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = false
 
 		var streamingSessionStart = StreamingSessionStart.mock()
 		var expectedDecodedEvent = LegacyEvent<StreamingSessionStart>(

--- a/Tests/PlayerTests/Player/PlaybackEngine/Internal/PlayerItemTests.swift
+++ b/Tests/PlayerTests/Player/PlaybackEngine/Internal/PlayerItemTests.swift
@@ -17,6 +17,7 @@ final class PlayerItemTests: XCTestCase {
 	private var monitor: PlayerItemMonitorMock!
 	private var dataWriter: DataWriterMock!
 	private var playerEventSender: PlayerEventSenderMock!
+	private var featureFlagProvider: FeatureFlagProvider!
 	private var player: PlayerMock!
 
 	private let configuration: Configuration = .mock()
@@ -30,7 +31,8 @@ final class PlayerItemTests: XCTestCase {
 	}
 
 	private var timestamp: UInt64 = 1
-
+	private var shouldSendEventsInDeinit: Bool = true
+	
 	override func setUp() {
 		// Set up time and uuid provider
 		let timeProvider = TimeProvider.mock(
@@ -48,6 +50,12 @@ final class PlayerItemTests: XCTestCase {
 		monitor = PlayerItemMonitorMock()
 		dataWriter = DataWriterMock()
 		playerEventSender = PlayerEventSenderMock(dataWriter: dataWriter)
+		
+		featureFlagProvider = FeatureFlagProvider.mock
+		featureFlagProvider.shouldSendEventsInDeinit = {
+			self.shouldSendEventsInDeinit
+		}
+
 		player = PlayerMock()
 
 		let userConfiguration = UserConfiguration.mock()
@@ -62,7 +70,7 @@ final class PlayerItemTests: XCTestCase {
 
 	func test_init_sendsOnlyStreamingSessionStart_legacy() {
 		// GIVEN
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = true
+		shouldSendEventsInDeinit = true
 
 		let mediaProduct = MediaProduct.mock()
 		let playerItem = PlayerItem.mock(
@@ -74,6 +82,7 @@ final class PlayerItemTests: XCTestCase {
 			playerItemMonitor: monitor,
 			playerEventSender: playerEventSender,
 			timestamp: timestamp,
+			featureFlagProvider: featureFlagProvider,
 			isPreload: false
 		)
 
@@ -99,7 +108,7 @@ final class PlayerItemTests: XCTestCase {
 
 	func test_init_sendsOnlyStreamingSessionStart() {
 		// GIVEN
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = false
+		shouldSendEventsInDeinit = false
 
 		let mediaProduct = MediaProduct.mock()
 		_ = PlayerItem.mock(
@@ -111,6 +120,7 @@ final class PlayerItemTests: XCTestCase {
 			playerItemMonitor: monitor,
 			playerEventSender: playerEventSender,
 			timestamp: timestamp,
+			featureFlagProvider: featureFlagProvider,
 			isPreload: false
 		)
 
@@ -133,7 +143,7 @@ final class PlayerItemTests: XCTestCase {
 
 	func test_init_preload() {
 		// GIVEN
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = false
+		shouldSendEventsInDeinit = false
 
 		let mediaProduct = MediaProduct.mock()
 		_ = PlayerItem.mock(
@@ -145,6 +155,7 @@ final class PlayerItemTests: XCTestCase {
 			playerItemMonitor: monitor,
 			playerEventSender: playerEventSender,
 			timestamp: timestamp,
+			featureFlagProvider: featureFlagProvider,
 			isPreload: true
 		)
 
@@ -167,7 +178,7 @@ final class PlayerItemTests: XCTestCase {
 
 	func test_init_cachingDisabled() {
 		// GIVEN
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = false
+		shouldSendEventsInDeinit = false
 
 		var featureFlagProvider = FeatureFlagProvider.mock
 		featureFlagProvider.isContentCachingEnabled = { false }
@@ -205,7 +216,7 @@ final class PlayerItemTests: XCTestCase {
 
 	func test_init_and_deinit_withoutMetrics_sendsOnlyStreamingSessionStart_and_StreamingSessionEnd_legacy() {
 		// GIVEN
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = true
+		shouldSendEventsInDeinit = true
 
 		let mediaProduct = MediaProduct.mock()
 		var playerItem: PlayerItem? = PlayerItem.mock(
@@ -217,6 +228,7 @@ final class PlayerItemTests: XCTestCase {
 			playerItemMonitor: monitor,
 			playerEventSender: playerEventSender,
 			timestamp: timestamp,
+			featureFlagProvider: featureFlagProvider,
 			isPreload: false
 		)
 
@@ -255,7 +267,7 @@ final class PlayerItemTests: XCTestCase {
 
 	func test_init_and_deinit_withoutMetrics_sendsOnlyStreamingSessionStart_and_StreamingSessionEnd() {
 		// GIVEN
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = false
+		shouldSendEventsInDeinit = false
 
 		let mediaProduct = MediaProduct.mock()
 		var playerItem: PlayerItem? = PlayerItem.mock(
@@ -267,6 +279,7 @@ final class PlayerItemTests: XCTestCase {
 			playerItemMonitor: monitor,
 			playerEventSender: playerEventSender,
 			timestamp: timestamp,
+			featureFlagProvider: featureFlagProvider,
 			isPreload: false
 		)
 
@@ -299,7 +312,7 @@ final class PlayerItemTests: XCTestCase {
 	func test_usualStreamingPlayFlow_legacy() {
 		// GIVEN
 		let initialTimestamp = timestamp
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = true
+		shouldSendEventsInDeinit = true
 
 		let mediaProduct = MediaProduct.mock()
 		let startReason: StartReason = .EXPLICIT
@@ -312,6 +325,7 @@ final class PlayerItemTests: XCTestCase {
 			playerItemMonitor: monitor,
 			playerEventSender: playerEventSender,
 			timestamp: timestamp,
+			featureFlagProvider: featureFlagProvider,
 			isPreload: false
 		)
 
@@ -409,7 +423,7 @@ final class PlayerItemTests: XCTestCase {
 	func test_usualStreamingPlayFlow() {
 		// GIVEN
 		let initialTimestamp = timestamp
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = false
+		shouldSendEventsInDeinit = false
 
 		let mediaProduct = MediaProduct.mock()
 		let startReason: StartReason = .EXPLICIT
@@ -422,6 +436,7 @@ final class PlayerItemTests: XCTestCase {
 			playerItemMonitor: monitor,
 			playerEventSender: playerEventSender,
 			timestamp: timestamp,
+			featureFlagProvider: featureFlagProvider,
 			isPreload: false
 		)
 
@@ -520,7 +535,7 @@ final class PlayerItemTests: XCTestCase {
 
 	func test_unload_legacy() async throws {
 		// GIVEN
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = true
+		shouldSendEventsInDeinit = true
 
 		let playerItem = PlayerItem.mock(
 			startReason: .EXPLICIT,
@@ -531,6 +546,7 @@ final class PlayerItemTests: XCTestCase {
 			playerItemMonitor: monitor,
 			playerEventSender: playerEventSender,
 			timestamp: timestamp,
+			featureFlagProvider: featureFlagProvider,
 			isPreload: false
 		)
 
@@ -553,7 +569,7 @@ final class PlayerItemTests: XCTestCase {
 
 	func test_unload() async throws {
 		// GIVEN
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = false
+		shouldSendEventsInDeinit = false
 
 		let playerItem = PlayerItem.mock(
 			startReason: .EXPLICIT,
@@ -564,6 +580,7 @@ final class PlayerItemTests: XCTestCase {
 			playerItemMonitor: monitor,
 			playerEventSender: playerEventSender,
 			timestamp: timestamp,
+			featureFlagProvider: featureFlagProvider,
 			isPreload: false
 		)
 
@@ -588,7 +605,7 @@ final class PlayerItemTests: XCTestCase {
 
 	func test_unloadFromPlayer_legacy() async throws {
 		// GIVEN
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = true
+		shouldSendEventsInDeinit = true
 
 		let playerItem = PlayerItem.mock(
 			startReason: .EXPLICIT,
@@ -599,6 +616,7 @@ final class PlayerItemTests: XCTestCase {
 			playerItemMonitor: monitor,
 			playerEventSender: playerEventSender,
 			timestamp: timestamp,
+			featureFlagProvider: featureFlagProvider,
 			isPreload: false
 		)
 
@@ -623,7 +641,7 @@ final class PlayerItemTests: XCTestCase {
 
 	func test_unloadFromPlayer() async throws {
 		// GIVEN
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = false
+		shouldSendEventsInDeinit = false
 
 		let playerItem = PlayerItem.mock(
 			startReason: .EXPLICIT,
@@ -634,6 +652,7 @@ final class PlayerItemTests: XCTestCase {
 			playerItemMonitor: monitor,
 			playerEventSender: playerEventSender,
 			timestamp: timestamp,
+			featureFlagProvider: featureFlagProvider,
 			isPreload: false
 		)
 
@@ -660,7 +679,7 @@ final class PlayerItemTests: XCTestCase {
 
 	func test_play_legacy() {
 		// GIVEN
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = true
+		shouldSendEventsInDeinit = true
 
 		let playerItem = PlayerItem.mock(
 			startReason: .EXPLICIT,
@@ -671,6 +690,7 @@ final class PlayerItemTests: XCTestCase {
 			playerItemMonitor: monitor,
 			playerEventSender: playerEventSender,
 			timestamp: timestamp,
+			featureFlagProvider: featureFlagProvider,
 			isPreload: false
 		)
 
@@ -691,7 +711,7 @@ final class PlayerItemTests: XCTestCase {
 
 	func test_play() {
 		// GIVEN
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = false
+		shouldSendEventsInDeinit = false
 
 		let playerItem = PlayerItem.mock(
 			startReason: .EXPLICIT,
@@ -702,6 +722,7 @@ final class PlayerItemTests: XCTestCase {
 			playerItemMonitor: monitor,
 			playerEventSender: playerEventSender,
 			timestamp: timestamp,
+			featureFlagProvider: featureFlagProvider,
 			isPreload: false
 		)
 
@@ -724,7 +745,7 @@ final class PlayerItemTests: XCTestCase {
 
 	func test_pause_legacy() {
 		// GIVEN
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = true
+		shouldSendEventsInDeinit = true
 
 		let playerItem = PlayerItem.mock(
 			startReason: .EXPLICIT,
@@ -735,6 +756,7 @@ final class PlayerItemTests: XCTestCase {
 			playerItemMonitor: monitor,
 			playerEventSender: playerEventSender,
 			timestamp: timestamp,
+			featureFlagProvider: featureFlagProvider,
 			isPreload: false
 		)
 
@@ -755,7 +777,7 @@ final class PlayerItemTests: XCTestCase {
 
 	func test_pause() {
 		// GIVEN
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = false
+		shouldSendEventsInDeinit = false
 
 		let playerItem = PlayerItem.mock(
 			startReason: .EXPLICIT,
@@ -766,6 +788,7 @@ final class PlayerItemTests: XCTestCase {
 			playerItemMonitor: monitor,
 			playerEventSender: playerEventSender,
 			timestamp: timestamp,
+			featureFlagProvider: featureFlagProvider,
 			isPreload: false
 		)
 
@@ -788,7 +811,7 @@ final class PlayerItemTests: XCTestCase {
 
 	func test_seek_legacy() {
 		// GIVEN
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = true
+		shouldSendEventsInDeinit = true
 
 		let playerItem = PlayerItem.mock(
 			startReason: .EXPLICIT,
@@ -799,6 +822,7 @@ final class PlayerItemTests: XCTestCase {
 			playerItemMonitor: monitor,
 			playerEventSender: playerEventSender,
 			timestamp: timestamp,
+			featureFlagProvider: featureFlagProvider,
 			isPreload: false
 		)
 
@@ -819,7 +843,7 @@ final class PlayerItemTests: XCTestCase {
 
 	func test_seek() {
 		// GIVEN
-		PlayerWorld.developmentFeatureFlagProvider.shouldSendEventsInDeinit = false
+		shouldSendEventsInDeinit = false
 
 		let playerItem = PlayerItem.mock(
 			startReason: .EXPLICIT,
@@ -830,6 +854,7 @@ final class PlayerItemTests: XCTestCase {
 			playerItemMonitor: monitor,
 			playerEventSender: playerEventSender,
 			timestamp: timestamp,
+			featureFlagProvider: featureFlagProvider,
 			isPreload: false
 		)
 

--- a/Tests/PlayerTests/Player/PlaybackEngine/PlayerEngineTests.swift
+++ b/Tests/PlayerTests/Player/PlaybackEngine/PlayerEngineTests.swift
@@ -890,7 +890,8 @@ extension PlayerEngineTests {
 			mediaProduct: mediaProduct,
 			playerItemMonitor: playerEngine,
 			playerEventSender: playerEventSender,
-			timestamp: 2
+			timestamp: 2,
+			featureFlagProvider: featureFlagProvider
 		)
 
 		if shouldSetMetadataAndAsset {


### PR DESCRIPTION
We have been testing for a while a change in our Player codebase to send events in a more predictable and controllable manner, which will help a lot with tests stability.

Previously, we were sending events in `PlayerItem.deinit` which puts us at the mercy of the autorelease pool cadence in tests. 

We changed this a more than a month ago, and have been testing both code paths in our tests since then without apparent functionality changes.

This PR migrates our internal development flag to the FeatureFlagProvider so we can test this change in production in a safe manner before committing to it.
