### PR TITLE
Append `client_unique_key` only if present (iOS-Auth)

### DIFF
--- a/Sources/Auth/Network/DefaultLoginService.swift
+++ b/Sources/Auth/Network/DefaultLoginService.swift
@@ -19,15 +19,17 @@ struct DefaultLoginService: LoginService, HTTPService {
 		codeVerifier: String,
 		clientUniqueKey: String?
 	) async throws -> LoginResponse {
-		let queryItems = [
+		var queryItems = [
 			URLQueryItem(name: "code", value: code),
 			URLQueryItem(name: "client_id", value: clientId),
 			URLQueryItem(name: "grant_type", value: grantType),
 			URLQueryItem(name: "redirect_uri", value: redirectUri),
 			URLQueryItem(name: "scope", value: scopes),
-			URLQueryItem(name: "code_verifier", value: codeVerifier),
-			URLQueryItem(name: "client_unique_key", value: clientUniqueKey),
+			URLQueryItem(name: "code_verifier", value: codeVerifier)
 		]
+		if let clientUniqueKey, !clientUniqueKey.isEmpty {
+			queryItems.append(URLQueryItem(name: "client_unique_key", value: clientUniqueKey))
+		}
 		guard let request = request(url: authBaseUrl, path: TOKEN_AUTH_PATH, queryItems: queryItems) else {
 			throw NSError(domain: "Invalid URL", code: 0, userInfo: nil)
 		}


### PR DESCRIPTION
`client_unique_key` can be `nil` or an `empty string` and as such should not be included as a part of URLQuery items.