### PR TITLE
Add merge_group trigger to fossa scan

### DIFF
--- a/.github/workflows/fossa-scan.yml
+++ b/.github/workflows/fossa-scan.yml
@@ -3,7 +3,9 @@ name: FOSSA Scans
 on:
   pull_request:
     branches: main
-
+  merge_group:
+    types: [checks_requested]
+    
 jobs:
     fossa-scan:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Otherwise this workflow blocks PRs from being merged.