### PR TITLE
Add support for immersiveaudio param in playbackinfo

### DIFF
--- a/Sources/Player/Common/PlaybackInfo/PlaybackInfoFetcher.swift
+++ b/Sources/Player/Common/PlaybackInfo/PlaybackInfoFetcher.swift
@@ -114,9 +114,10 @@ private extension PlaybackInfoFetcher {
 
 	func getTrackPlaybackInfoUrl(trackId: String, playbackMode: PlaybackMode) throws -> URL {
 		let audioQuality = getAudioQuality(given: playbackMode)
+		let immersiveAudio = configuration.isImmersiveAudio
 
 		let path = "https://api.tidal.com/v1/tracks/\(trackId)/playbackinfo"
-		let parameters = "audioquality=\(audioQuality)&assetpresentation=FULL&playbackmode=\(playbackMode)"
+		let parameters = "audioquality=\(audioQuality)&assetpresentation=FULL&playbackmode=\(playbackMode)&immersiveaudio=\(immersiveAudio)"
 
 		return try PlaybackInfoFetcher.createUrl(from: "\(path)?\(parameters)")
 	}

--- a/Sources/Player/Configuration.swift
+++ b/Sources/Player/Configuration.swift
@@ -53,6 +53,8 @@ public struct Configuration {
 	public var offlineVideoQuality: VideoQuality = .MEDIUM
 
 	public var allowOfflineOverCellular: Bool = false
+	
+	public var isImmersiveAudio: Bool = true
 
 	init(clientVersion: String = Bundle.main.appVersion) {
 		self.clientVersion = clientVersion

--- a/Tests/PlayerTests/PlaybackInfoFetcherTests.swift
+++ b/Tests/PlayerTests/PlaybackInfoFetcherTests.swift
@@ -94,7 +94,8 @@ final class PlaybackInfoFetcherTests: XCTestCase {
 				playbackInfoURL(
 					trackId: mediaProduct.productId,
 					audioQuality: configuration.streamingCellularAudioQuality,
-					playbackMode: playbackMode
+					playbackMode: playbackMode,
+					immersiveAudio: configuration.isImmersiveAudio
 				)
 			)
 		} catch {
@@ -141,7 +142,8 @@ final class PlaybackInfoFetcherTests: XCTestCase {
 				playbackInfoURL(
 					trackId: mediaProduct.productId,
 					audioQuality: configuration.offlineAudioQuality,
-					playbackMode: playbackMode
+					playbackMode: playbackMode,
+					immersiveAudio: configuration.isImmersiveAudio
 				)
 			)
 		} catch {
@@ -640,9 +642,9 @@ final class PlaybackInfoFetcherTests: XCTestCase {
 }
 
 extension PlaybackInfoFetcherTests {
-	func playbackInfoURL(trackId: String, audioQuality: AudioQuality, playbackMode: PlaybackMode) -> String {
+	func playbackInfoURL(trackId: String, audioQuality: AudioQuality, playbackMode: PlaybackMode, immersiveAudio: Bool) -> String {
 		let path = "https://api.tidal.com/v1/tracks/\(trackId)/playbackinfo"
-		let parameters = "audioquality=\(audioQuality.rawValue)&assetpresentation=FULL&playbackmode=\(playbackMode.rawValue)"
+		let parameters = "audioquality=\(audioQuality.rawValue)&assetpresentation=FULL&playbackmode=\(playbackMode.rawValue)&immersiveaudio=\(immersiveAudio)"
 		let url = "\(path)?\(parameters)"
 		return url
 	}


### PR DESCRIPTION
This PR adds a new param `immersiveaudio` to `playbackinfo` endpoint. When set to false and requesting an immersive audio track, a stereo replacement will be served instead.