### PR TITLE
Part 1: Feature flag setup for new caching implementation

### DIFF
--- a/Sources/Player/Common/Extensions/AVPlayer.swift
+++ b/Sources/Player/Common/Extensions/AVPlayer.swift
@@ -1,0 +1,16 @@
+import Foundation
+import MediaPlayer
+
+extension AVPlayer {
+	func seek(to position: Double) async -> Bool {
+		await withCheckedContinuation { continuation in
+			guard let currentItem else {
+				return
+			}
+
+			seek(to: CMTime(seconds: min(position, currentItem.duration.seconds), preferredTimescale: 1000)) { finished in
+				continuation.resume(returning: finished)
+			}
+		}
+	}
+}

--- a/Sources/Player/Common/Extensions/AVURLAsset.swift
+++ b/Sources/Player/Common/Extensions/AVURLAsset.swift
@@ -1,0 +1,8 @@
+import Foundation
+import MediaPlayer
+
+extension AVURLAsset {
+	var isPlayableOffline: Bool {
+		assetCache?.isPlayableOffline ?? false
+	}
+}

--- a/Sources/Player/Common/Extensions/Player+Extensions.swift
+++ b/Sources/Player/Common/Extensions/Player+Extensions.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension Player {
+	static func mainPlayerType(_ featureFlagProvider: FeatureFlagProvider) -> GenericMediaPlayer.Type {
+		if featureFlagProvider.shouldUseImprovedCaching() {
+			AVQueuePlayerWrapperLegacy.self
+		} else {
+			AVQueuePlayerWrapperLegacy.self
+		}
+	}
+}

--- a/Sources/Player/Common/FeatureFlags/FeatureFlagProvider+Standard.swift
+++ b/Sources/Player/Common/FeatureFlags/FeatureFlagProvider+Standard.swift
@@ -5,6 +5,7 @@ public extension FeatureFlagProvider {
 		isStallWhenTransitionFromEndedToBufferingEnabled: { true },
 		shouldUseEventProducer: { false },
 		isContentCachingEnabled: { true },
-		shouldSendEventsInDeinit: { true }
+		shouldSendEventsInDeinit: { true },
+		shouldUseImprovedCaching: { false }
 	)
 }

--- a/Sources/Player/Common/FeatureFlags/FeatureFlagProvider.swift
+++ b/Sources/Player/Common/FeatureFlags/FeatureFlagProvider.swift
@@ -4,17 +4,20 @@ public struct FeatureFlagProvider {
 	public var shouldUseEventProducer: () -> Bool
 	public var isContentCachingEnabled: () -> Bool
 	public var shouldSendEventsInDeinit: () -> Bool
-	
+	public var shouldUseImprovedCaching: () -> Bool
+
 	public init(
 		// swiftlint:disable:next identifier_name
 		isStallWhenTransitionFromEndedToBufferingEnabled: @escaping () -> Bool,
 		shouldUseEventProducer: @escaping () -> Bool,
 		isContentCachingEnabled: @escaping () -> Bool,
-		shouldSendEventsInDeinit: @escaping () -> Bool
+		shouldSendEventsInDeinit: @escaping () -> Bool,
+		shouldUseImprovedCaching: @escaping () -> Bool
 	) {
 		self.isStallWhenTransitionFromEndedToBufferingEnabled = isStallWhenTransitionFromEndedToBufferingEnabled
 		self.shouldUseEventProducer = shouldUseEventProducer
 		self.isContentCachingEnabled = isContentCachingEnabled
 		self.shouldSendEventsInDeinit = shouldSendEventsInDeinit
+		self.shouldUseImprovedCaching = shouldUseImprovedCaching
 	}
 }

--- a/Sources/Player/Mocks/Common/FeatureFlags/FeatureFlagProvider+Mock.swift
+++ b/Sources/Player/Mocks/Common/FeatureFlags/FeatureFlagProvider+Mock.swift
@@ -5,6 +5,7 @@ public extension FeatureFlagProvider {
 		isStallWhenTransitionFromEndedToBufferingEnabled: { true },
 		shouldUseEventProducer: { true },
 		isContentCachingEnabled: { true },
-		shouldSendEventsInDeinit: { true }
+		shouldSendEventsInDeinit: { true },
+		shouldUseImprovedCaching: { false }
 	)
 }

--- a/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/Legacy/AVPlayerAssetLegacy.swift
+++ b/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/Legacy/AVPlayerAssetLegacy.swift
@@ -1,14 +1,14 @@
 import AVFoundation
 import Foundation
 
-// MARK: - AVPlayerAsset
+// MARK: - AVPlayerAssetLegacy
 
-class AVPlayerAsset: Asset {
+class AVPlayerAssetLegacy: Asset {
 	private let contentKeySession: AVContentKeySession?
 	private let contentKeySessionDelegate: AVContentKeySessionDelegate?
 
 	required init(
-		with player: AVQueuePlayerWrapper,
+		with player: AVQueuePlayerWrapperLegacy,
 		loudnessNormalizationConfiguration: LoudnessNormalizationConfiguration,
 		_ contentKeySession: AVContentKeySession?,
 		and contentKeySessionDelegate: AVContentKeySessionDelegate?
@@ -23,11 +23,11 @@ class AVPlayerAsset: Asset {
 	}
 }
 
-// MARK: - LiveAVPlayerAsset
+// MARK: - LiveAVPlayerAssetLegacy
 
-final class LiveAVPlayerAsset: AVPlayerAsset {
+final class LiveAVPlayerAssetLegacy: AVPlayerAssetLegacy {
 	required init(
-		with player: AVQueuePlayerWrapper,
+		with player: AVQueuePlayerWrapperLegacy,
 		loudnessNormalizationConfiguration: LoudnessNormalizationConfiguration,
 		_ contentKeySession: AVContentKeySession?,
 		and contentKeySessionDelegate: AVContentKeySessionDelegate?

--- a/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/Legacy/AVURLAssetFactoryLegacy.swift
+++ b/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/Legacy/AVURLAssetFactoryLegacy.swift
@@ -1,15 +1,15 @@
 import AVFoundation
 import Foundation
 
-// MARK: - AVURLAssetFactory
+// MARK: - AVURLAssetFactoryLegacy
 
-final class AVURLAssetFactory: NSObject {
+final class AVURLAssetFactoryLegacy: NSObject {
 	private static let TTL: Int = 24 * 60 * 60
 
 	private var downloads: [Download] = [Download]()
 
 	private let queue: OperationQueue
-	private let assetCache: AssetCache
+	private let assetCache: AssetCacheLegacy
 
 	private lazy var session: AVAssetDownloadURLSession = AVAssetDownloadURLSession(
 		configuration: URLSessionConfiguration.background(withIdentifier: "com.tidal.player.hls.cache"),
@@ -19,7 +19,7 @@ final class AVURLAssetFactory: NSObject {
 
 	init(
 		with queue: OperationQueue,
-		assetCache: AssetCache = AssetCache()
+		assetCache: AssetCacheLegacy = AssetCacheLegacy()
 	) {
 		self.queue = queue
 		self.assetCache = assetCache
@@ -43,7 +43,7 @@ final class AVURLAssetFactory: NSObject {
 	}
 }
 
-private extension AVURLAssetFactory {
+private extension AVURLAssetFactoryLegacy {
 	func getAssetFromLocalStorage(with cacheKey: String) -> AVURLAsset? {
 		guard let url = assetCache.get(cacheKey) else {
 			return nil
@@ -86,14 +86,14 @@ private extension AVURLAssetFactory {
 
 		let newPolicy = AVMutableAssetDownloadStorageManagementPolicy()
 		newPolicy.priority = .default
-		newPolicy.expirationDate = Date(timeIntervalSinceNow: Double(AVURLAssetFactory.TTL))
+		newPolicy.expirationDate = Date(timeIntervalSinceNow: Double(AVURLAssetFactoryLegacy.TTL))
 		AVAssetDownloadStorageManager.shared().setStorageManagementPolicy(newPolicy, for: url)
 	}
 }
 
 // MARK: AVAssetDownloadDelegate
 
-extension AVURLAssetFactory: AVAssetDownloadDelegate {
+extension AVURLAssetFactoryLegacy: AVAssetDownloadDelegate {
 	func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
 		guard let download = downloads.first(where: { $0.task == task }) else {
 			return
@@ -134,11 +134,5 @@ private final class Download {
 
 	func isComplete() -> Bool {
 		(task as? AVAggregateAssetDownloadTask).map { $0.urlAsset.isPlayableOffline } ?? false
-	}
-}
-
-extension AVURLAsset {
-	var isPlayableOffline: Bool {
-		assetCache?.isPlayableOffline ?? false
 	}
 }

--- a/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/Legacy/AssetCacheLegacy.swift
+++ b/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/Legacy/AssetCacheLegacy.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-// MARK: - AssetCache
+// MARK: - AssetCacheLegacy
 
-final class AssetCache {
+final class AssetCacheLegacy {
 	private var userDefaults: UserDefaultsClient
 
 	init(userDefaults: UserDefaultsClient = UserDefaultsClient.live()) {
@@ -32,7 +32,7 @@ final class AssetCache {
 	}
 }
 
-private extension AssetCache {
+private extension AssetCacheLegacy {
 	func delete(_ url: URL?, and key: String) {
 		guard let url else {
 			return

--- a/Sources/Player/PlaybackEngine/Internal/Events/StreamingMetrics/StreamingSessionStart/StreamingSessionStart.swift
+++ b/Sources/Player/PlaybackEngine/Internal/Events/StreamingMetrics/StreamingSessionStart/StreamingSessionStart.swift
@@ -4,6 +4,7 @@ struct StreamingSessionStart: StreamingMetricsEvent {
 	enum SessionTag: String, Codable {
 		case PRELOADED
 		case CACHING_DISABLED
+		case CACHING_V2
 	}
 
 	// MARK: - StreamingMetricsEvent

--- a/Sources/Player/PlaybackEngine/Internal/InternalPlayerLoader.swift
+++ b/Sources/Player/PlaybackEngine/Internal/InternalPlayerLoader.swift
@@ -153,10 +153,20 @@ final class InternalPlayerLoader: PlayerLoader {
 	}
 
 	func renderVideo(in view: AVPlayerLayer) {
-		guard let videoPlayer = mainPlayer as? AVQueuePlayerWrapper else {
-			return
+		// TODO: Split video capabilities to a different protocol to clean this
+		if featureFlagProvider.shouldUseImprovedCaching() {
+			guard let videoPlayer = mainPlayer as? AVQueuePlayerWrapperLegacy else {
+				return
+			}
+
+			videoPlayer.renderVideo(in: view)
+		} else {
+			guard let videoPlayer = mainPlayer as? AVQueuePlayerWrapperLegacy else {
+				return
+			}
+
+			videoPlayer.renderVideo(in: view)
 		}
-		videoPlayer.renderVideo(in: view)
 	}
 }
 

--- a/Sources/Player/PlaybackEngine/Internal/PlayerItem.swift
+++ b/Sources/Player/PlaybackEngine/Internal/PlayerItem.swift
@@ -65,6 +65,9 @@ final class PlayerItem {
 		if !featureFlagProvider.isContentCachingEnabled() {
 			sessionTags.append(StreamingSessionStart.SessionTag.CACHING_DISABLED)
 		}
+		if featureFlagProvider.shouldUseImprovedCaching() {
+			sessionTags.append(StreamingSessionStart.SessionTag.CACHING_V2)
+		}
 
 		playerEventSender.send(StreamingSessionStart(
 			streamingSessionId: id,

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -256,28 +256,18 @@ public extension Player {
 	func preload(_ mediaProduct: MediaProduct) -> PlayerLoaderHandle {
 		let time = PlayerWorld.timeProvider.timestamp()
 
-		let internalPlayerLoader = InternalPlayerLoader(
-			with: configuration,
-			and: fairplayLicenseFetcher,
-			featureFlagProvider: featureFlagProvider,
-			credentialsProvider: credentialsProvider,
-			mainPlayer: AVQueuePlayerWrapper.self,
-			externalPlayers: registeredPlayers
-		)
-
-		let player = PlayerEngine(
-			with: OperationQueue.new(),
-			HttpClient(using: playerURLSession),
-			credentialsProvider,
-			fairplayLicenseFetcher,
-			djProducer,
+		let player = Player.newPlayerEngine(
+			playerURLSession,
 			configuration,
-			playerEventSender,
-			networkMonitor,
 			storage,
-			internalPlayerLoader,
+			djProducer,
+			fairplayLicenseFetcher,
+			networkMonitor,
+			playerEventSender,
+			nil, // We don't want to notify the client about this player yet
 			featureFlagProvider,
-			nil // We don't want to notify the client about this player yet
+			registeredPlayers,
+			credentialsProvider
 		)
 
 		player.load(mediaProduct, timestamp: time, isPreload: true)
@@ -407,7 +397,7 @@ private extension Player {
 			and: fairplayLicenseFetcher,
 			featureFlagProvider: featureFlagProvider,
 			credentialsProvider: credentialsProvider,
-			mainPlayer: AVQueuePlayerWrapper.self,
+			mainPlayer: Player.mainPlayerType(featureFlagProvider),
 			externalPlayers: externalPlayers
 		)
 

--- a/Tests/PlayerTests/Playlog/PlayLogTests.swift
+++ b/Tests/PlayerTests/Playlog/PlayLogTests.swift
@@ -37,7 +37,7 @@ final class PlayLogTests: XCTestCase {
 	private var timestamp: UInt64 = 1
 	private var uuid = "uuid"
 	private var shouldSendEventsInDeinit: Bool = true
-	
+
 	lazy var shortAudioFile: AudioFile = {
 		let url = PlayLogTestsHelper.url(from: Constants.AudioFileName.short)
 		return AudioFile(
@@ -130,7 +130,7 @@ final class PlayLogTests: XCTestCase {
 			and: fairplayLicenseFetcher,
 			featureFlagProvider: featureFlagProvider,
 			credentialsProvider: credentialsProvider,
-			mainPlayer: AVQueuePlayerWrapper.self,
+			mainPlayer: Player.mainPlayerType(featureFlagProvider),
 			externalPlayers: []
 		)
 


### PR DESCRIPTION
This PR adds a new FeatureFlag to control access to the new player caching implementations that will follow in the next PR.

Renames the 3-4 classes for the current AVQueuePlayerWrapper implementation as `ClassNameLegacy` as we have done in previous similar situations. This duplicates code but will allow us to quickly delete the legacy implementation once we have validated the new one in production.

It also adds metrics tracking via a new `SessionTag`. 

All these will allows us to control the deployment of the new code and measure its impact vs the previous implementation.