### PR TITLE
Fix long buffering w/ new caching implementation

### DIFF
--- a/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/AVQueuePlayerWrapper.swift
+++ b/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/AVQueuePlayerWrapper.swift
@@ -219,6 +219,12 @@ final class AVQueuePlayerWrapper: GenericMediaPlayer {
 
 	func play() {
 		queue.dispatch {
+			if self.player.items().isEmpty {
+				guard let (playerItem, _) = self.playerItemAssets.first else {
+					return
+				}
+				self.player.insert(playerItem, after: nil)
+			}
 			self.player.play()
 		}
 	}


### PR DESCRIPTION
## Context

While testing the new caching implementation currently under a FeatureFlag, it was noticed that in some scenarios, there was a 3-4 second buffering that should not be happening.

## Description

When the first track in a PlayerEngine instance is loaded, and the track is not offlined or cached, it could lead to the track not starting playback until the full track is downloaded/cached.

The solution is to load into the player queue on the play() command whatever track has been loaded but was being cached.