### PR TITLE
Fix playback not stopping immediately on reset

### DIFF
--- a/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/AVQueuePlayerWrapper.swift
+++ b/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/AVQueuePlayerWrapper.swift
@@ -431,6 +431,7 @@ private extension AVQueuePlayerWrapper {
 
 		assetFactory.reset()
 
+		player.pause()
 		player.removeAllItems()
 
 		player = AVQueuePlayerWrapper.createPlayer()


### PR DESCRIPTION
## Context

While testing the new caching implementation currently under a FeatureFlag, it was noticed that when killing the app, playback would continue for 3-4 extra seconds instead of stopping automatically.

## Description

A change was made to call `player.removeAllItems()` instead of `player.pause()` when unloading/resetting the player.
This is what the documentation for removeAllItems() says
```
/**
  @method     removeAllItems
  @abstract   Removes all items from the queue.
  @discussion Stops playback by the target.
*/
open func removeAllItems()
```

The solution is to call `player.pause()` too as `player.removeAllItems()` is not enough to stop playback, even if the documentation says it should be.