### PR TITLE
Splitted GenericMediaPlayer responsibilities

### DIFF
--- a/Sources/Player/Common/Extensions/Player+Extensions.swift
+++ b/Sources/Player/Common/Extensions/Player+Extensions.swift
@@ -1,7 +1,9 @@
 import Foundation
 
 extension Player {
-	static func mainPlayerType(_ featureFlagProvider: FeatureFlagProvider) -> GenericMediaPlayer.Type {
+	static func mainPlayerType(
+		_ featureFlagProvider: FeatureFlagProvider
+	) -> (GenericMediaPlayer & LiveMediaPlayer & UCMediaPlayer & VideoPlayer).Type {
 		if featureFlagProvider.shouldUseImprovedCaching() {
 			AVQueuePlayerWrapper.self
 		} else {

--- a/Sources/Player/Common/Extensions/Player+Extensions.swift
+++ b/Sources/Player/Common/Extensions/Player+Extensions.swift
@@ -3,7 +3,7 @@ import Foundation
 extension Player {
 	static func mainPlayerType(
 		_ featureFlagProvider: FeatureFlagProvider
-	) -> (GenericMediaPlayer & LiveMediaPlayer & UCMediaPlayer & VideoPlayer).Type {
+	) -> MainPlayerType.Type {
 		if featureFlagProvider.shouldUseImprovedCaching() {
 			AVQueuePlayerWrapper.self
 		} else {

--- a/Sources/Player/Mocks/PlaybackEngine/PlayerMock.swift
+++ b/Sources/Player/Mocks/PlaybackEngine/PlayerMock.swift
@@ -77,35 +77,6 @@ public final class PlayerMock: GenericMediaPlayer {
 		return asset
 	}
 
-	public func loadLive(_ url: URL, with licenseLoader: LicenseLoader?) async -> Asset {
-		loadLiveCallCount += 1
-		licenseLoaders.append(licenseLoader)
-		let loudnessNormalizationConfiguration = LoudnessNormalizationConfiguration(
-			loudnessNormalizationMode: loudnessNormalizationMode,
-			loudnessNormalizer: loudnessNormalizer
-		)
-		let asset = AssetMock(with: self, loudnessNormalizationConfiguration: loudnessNormalizationConfiguration)
-
-		assets.append(asset)
-		return asset
-	}
-
-	public func loadUC(
-		_ url: URL,
-		loudnessNormalizationConfiguration: LoudnessNormalizationConfiguration,
-		headers: [String: String]
-	) async -> Asset {
-		loadUploadedCallCount += 1
-		let loudnessNormalizationConfiguration = LoudnessNormalizationConfiguration(
-			loudnessNormalizationMode: loudnessNormalizationMode,
-			loudnessNormalizer: loudnessNormalizer
-		)
-		let asset = AssetMock(with: self, loudnessNormalizationConfiguration: loudnessNormalizationConfiguration)
-
-		assets.append(asset)
-		return asset
-	}
-
 	public func unload(asset: Asset) {
 		unloadCallCount += 1
 		unloadedAssets.append(asset)
@@ -125,8 +96,6 @@ public final class PlayerMock: GenericMediaPlayer {
 		seekCallCount += 1
 	}
 
-	func renderVideo(in view: AVPlayerLayer) {}
-
 	public func updateVolume(loudnessNormalizer: LoudnessNormalizer?) {
 		loudnessNormalizers.append(loudnessNormalizer)
 		updateVolumeCallCount += 1
@@ -145,6 +114,49 @@ public final class PlayerMock: GenericMediaPlayer {
 		assetPosition = 0
 		assets.removeAll()
 	}
+}
+
+// MARK: LiveMediaPlayer
+
+extension PlayerMock: LiveMediaPlayer {
+	public func loadLive(_ url: URL, with licenseLoader: LicenseLoader?) async -> Asset {
+		loadLiveCallCount += 1
+		licenseLoaders.append(licenseLoader)
+		let loudnessNormalizationConfiguration = LoudnessNormalizationConfiguration(
+			loudnessNormalizationMode: loudnessNormalizationMode,
+			loudnessNormalizer: loudnessNormalizer
+		)
+		let asset = AssetMock(with: self, loudnessNormalizationConfiguration: loudnessNormalizationConfiguration)
+
+		assets.append(asset)
+		return asset
+	}
+}
+
+// MARK: UCMediaPlayer
+
+extension PlayerMock: UCMediaPlayer {
+	public func loadUC(
+		_ url: URL,
+		loudnessNormalizationConfiguration: LoudnessNormalizationConfiguration,
+		headers: [String: String]
+	) async -> Asset {
+		loadUploadedCallCount += 1
+		let loudnessNormalizationConfiguration = LoudnessNormalizationConfiguration(
+			loudnessNormalizationMode: loudnessNormalizationMode,
+			loudnessNormalizer: loudnessNormalizer
+		)
+		let asset = AssetMock(with: self, loudnessNormalizationConfiguration: loudnessNormalizationConfiguration)
+
+		assets.append(asset)
+		return asset
+	}
+}
+
+// MARK: VideoPlayer
+
+extension PlayerMock: VideoPlayer {
+	func renderVideo(in view: AVPlayerLayer) {}
 }
 
 extension PlayerMock {

--- a/Sources/Player/PlaybackEngine/Internal/InternalPlayerLoader.swift
+++ b/Sources/Player/PlaybackEngine/Internal/InternalPlayerLoader.swift
@@ -12,7 +12,7 @@ final class InternalPlayerLoader: PlayerLoader {
 
 	private let featureFlagProvider: FeatureFlagProvider
 
-	let mainPlayer: GenericMediaPlayer
+	let mainPlayer: GenericMediaPlayer & LiveMediaPlayer & UCMediaPlayer & VideoPlayer
 	var players: [GenericMediaPlayer] = []
 
 	// MARK: - Convenience properties
@@ -28,7 +28,7 @@ final class InternalPlayerLoader: PlayerLoader {
 		and fairplayLicenseFetcher: FairPlayLicenseFetcher,
 		featureFlagProvider: FeatureFlagProvider,
 		credentialsProvider: CredentialsProvider,
-		mainPlayer: GenericMediaPlayer.Type,
+		mainPlayer: (GenericMediaPlayer & LiveMediaPlayer & UCMediaPlayer & VideoPlayer).Type,
 		externalPlayers: [GenericMediaPlayer.Type]
 	) {
 		self.configuration = configuration
@@ -115,14 +115,6 @@ final class InternalPlayerLoader: PlayerLoader {
 			preAmp: configuration.currentPreAmpValue
 		)
 
-		let player = try getPlayer(
-			for: playbackInfo.audioMode,
-			and: playbackInfo.audioQuality,
-			with: playbackInfo.mediaType,
-			audioCodec: playbackInfo.audioCodec,
-			type: playbackInfo.productType
-		)
-
 		var licenseLoader: StreamingLicenseLoader?
 		if playbackInfo.licenseSecurityToken != nil {
 			licenseLoader = StreamingLicenseLoader(
@@ -133,17 +125,24 @@ final class InternalPlayerLoader: PlayerLoader {
 
 		switch playbackInfo.productType {
 		case .TRACK:
+			let player = try getPlayer(
+				for: playbackInfo.audioMode,
+				and: playbackInfo.audioQuality,
+				with: playbackInfo.mediaType,
+				audioCodec: playbackInfo.audioCodec,
+				type: playbackInfo.productType
+			)
 			return await loadTrack(using: playbackInfo, with: loudnessNormalizer, and: licenseLoader, player: player)
 		case .VIDEO:
-			return await loadVideo(using: playbackInfo, with: loudnessNormalizer, and: licenseLoader, player: player)
+			return await loadVideo(using: playbackInfo, with: loudnessNormalizer, and: licenseLoader, player: mainPlayer)
 		case .BROADCAST:
-			return await loadBroadcast(using: playbackInfo, and: licenseLoader, player: player)
+			return await loadBroadcast(using: playbackInfo, and: licenseLoader, player: mainPlayer)
 		case .UC:
 			return try await loadUC(
 				using: playbackInfo,
 				with: streamingSessionId,
 				and: loudnessNormalizer,
-				player: player
+				player: mainPlayer
 			)
 		}
 	}
@@ -157,20 +156,7 @@ final class InternalPlayerLoader: PlayerLoader {
 	}
 
 	func renderVideo(in view: AVPlayerLayer) {
-		// TODO: Split video capabilities to a different protocol to clean this
-		if featureFlagProvider.shouldUseImprovedCaching() {
-			guard let videoPlayer = mainPlayer as? AVQueuePlayerWrapper else {
-				return
-			}
-
-			videoPlayer.renderVideo(in: view)
-		} else {
-			guard let videoPlayer = mainPlayer as? AVQueuePlayerWrapperLegacy else {
-				return
-			}
-
-			videoPlayer.renderVideo(in: view)
-		}
+		mainPlayer.renderVideo(in: view)
 	}
 }
 
@@ -208,7 +194,7 @@ private extension InternalPlayerLoader {
 	func loadBroadcast(
 		using playbackInfo: PlaybackInfo,
 		and licenseLoader: LicenseLoader?,
-		player: GenericMediaPlayer
+		player: LiveMediaPlayer
 	) async -> Asset {
 		await player.loadLive(playbackInfo.url, with: licenseLoader)
 	}
@@ -235,7 +221,7 @@ private extension InternalPlayerLoader {
 		using playbackInfo: PlaybackInfo,
 		with streamingSessionId: String,
 		and loudnessNormalizer: LoudnessNormalizer?,
-		player: GenericMediaPlayer
+		player: UCMediaPlayer
 	) async throws -> Asset {
 		do {
 			let loudnessNormalizationConfiguration = LoudnessNormalizationConfiguration(

--- a/Sources/Player/PlaybackEngine/Internal/InternalPlayerLoader.swift
+++ b/Sources/Player/PlaybackEngine/Internal/InternalPlayerLoader.swift
@@ -4,6 +4,10 @@ import Foundation
 
 // MARK: - InternalPlayerLoader
 
+typealias MainPlayerType = GenericMediaPlayer & LiveMediaPlayer & UCMediaPlayer & VideoPlayer
+
+// MARK: - InternalPlayerLoader
+
 final class InternalPlayerLoader: PlayerLoader {
 	private let configuration: Configuration
 	private let fairPlayLicenseFetcher: FairPlayLicenseFetcher
@@ -12,7 +16,7 @@ final class InternalPlayerLoader: PlayerLoader {
 
 	private let featureFlagProvider: FeatureFlagProvider
 
-	let mainPlayer: GenericMediaPlayer & LiveMediaPlayer & UCMediaPlayer & VideoPlayer
+	let mainPlayer: MainPlayerType
 	var players: [GenericMediaPlayer] = []
 
 	// MARK: - Convenience properties
@@ -28,7 +32,7 @@ final class InternalPlayerLoader: PlayerLoader {
 		and fairplayLicenseFetcher: FairPlayLicenseFetcher,
 		featureFlagProvider: FeatureFlagProvider,
 		credentialsProvider: CredentialsProvider,
-		mainPlayer: (GenericMediaPlayer & LiveMediaPlayer & UCMediaPlayer & VideoPlayer).Type,
+		mainPlayer: MainPlayerType.Type,
 		externalPlayers: [GenericMediaPlayer.Type]
 	) {
 		self.configuration = configuration

--- a/Sources/Player/PlaybackEngine/Internal/MediaPlayers/GenericMediaPlayer.swift
+++ b/Sources/Player/PlaybackEngine/Internal/MediaPlayers/GenericMediaPlayer.swift
@@ -22,17 +22,6 @@ public protocol GenericMediaPlayer: AnyObject {
 		and licenseLoader: LicenseLoader?
 	) async -> Asset
 
-	func loadLive(
-		_ url: URL,
-		with licenseLoader: LicenseLoader?
-	) async -> Asset
-
-	func loadUC(
-		_ url: URL,
-		loudnessNormalizationConfiguration: LoudnessNormalizationConfiguration,
-		headers: [String: String]
-	) async -> Asset
-
 	func play()
 	func pause()
 	func seek(to time: Double)

--- a/Sources/Player/PlaybackEngine/Internal/MediaPlayers/LiveMediaPlayer.swift
+++ b/Sources/Player/PlaybackEngine/Internal/MediaPlayers/LiveMediaPlayer.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+protocol LiveMediaPlayer: AnyObject {
+	func loadLive(
+		_ url: URL,
+		with licenseLoader: LicenseLoader?
+	) async -> Asset
+}

--- a/Sources/Player/PlaybackEngine/Internal/MediaPlayers/UCMediaPlayer.swift
+++ b/Sources/Player/PlaybackEngine/Internal/MediaPlayers/UCMediaPlayer.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+protocol UCMediaPlayer: AnyObject {
+	func loadUC(
+		_ url: URL,
+		loudnessNormalizationConfiguration: LoudnessNormalizationConfiguration,
+		headers: [String: String]
+	) async -> Asset
+}

--- a/Sources/Player/PlaybackEngine/Internal/MediaPlayers/VideoPlayer.swift
+++ b/Sources/Player/PlaybackEngine/Internal/MediaPlayers/VideoPlayer.swift
@@ -1,0 +1,6 @@
+import AVFoundation
+import Foundation
+
+protocol VideoPlayer {
+	func renderVideo(in view: AVPlayerLayer)
+}

--- a/Sources/Player/PlaybackEngine/Internal/PlayerLoader.swift
+++ b/Sources/Player/PlaybackEngine/Internal/PlayerLoader.swift
@@ -24,7 +24,7 @@ protocol PlayerLoader: AnyObject {
 		and fairplayLicenseFetcher: FairPlayLicenseFetcher,
 		featureFlagProvider: FeatureFlagProvider,
 		credentialsProvider: CredentialsProvider,
-		mainPlayer: GenericMediaPlayer.Type,
+		mainPlayer: (GenericMediaPlayer & LiveMediaPlayer & UCMediaPlayer & VideoPlayer).Type,
 		externalPlayers: [GenericMediaPlayer.Type]
 	)
 

--- a/Sources/Player/PlaybackEngine/Internal/PlayerLoader.swift
+++ b/Sources/Player/PlaybackEngine/Internal/PlayerLoader.swift
@@ -24,7 +24,7 @@ protocol PlayerLoader: AnyObject {
 		and fairplayLicenseFetcher: FairPlayLicenseFetcher,
 		featureFlagProvider: FeatureFlagProvider,
 		credentialsProvider: CredentialsProvider,
-		mainPlayer: (GenericMediaPlayer & LiveMediaPlayer & UCMediaPlayer & VideoPlayer).Type,
+		mainPlayer: MainPlayerType.Type,
 		externalPlayers: [GenericMediaPlayer.Type]
 	)
 

--- a/Tests/PlayerTests/Mocks/PlaybackEngine/Internal/PlayerLoaderMock.swift
+++ b/Tests/PlayerTests/Mocks/PlaybackEngine/Internal/PlayerLoaderMock.swift
@@ -17,7 +17,7 @@ final class PlayerLoaderMock: PlayerLoader {
 		and fairplayLicenseFetcher: FairPlayLicenseFetcher,
 		featureFlagProvider: FeatureFlagProvider = .mock,
 		credentialsProvider: CredentialsProvider = CredentialsProviderMock(),
-		mainPlayer: (GenericMediaPlayer & LiveMediaPlayer & UCMediaPlayer & VideoPlayer).Type = PlayerMock.self,
+		mainPlayer: MainPlayerType.Type = PlayerMock.self,
 		externalPlayers: [GenericMediaPlayer.Type] = []
 	) {}
 

--- a/Tests/PlayerTests/Mocks/PlaybackEngine/Internal/PlayerLoaderMock.swift
+++ b/Tests/PlayerTests/Mocks/PlaybackEngine/Internal/PlayerLoaderMock.swift
@@ -17,7 +17,7 @@ final class PlayerLoaderMock: PlayerLoader {
 		and fairplayLicenseFetcher: FairPlayLicenseFetcher,
 		featureFlagProvider: FeatureFlagProvider = .mock,
 		credentialsProvider: CredentialsProvider = CredentialsProviderMock(),
-		mainPlayer: GenericMediaPlayer.Type = PlayerMock.self,
+		mainPlayer: (GenericMediaPlayer & LiveMediaPlayer & UCMediaPlayer & VideoPlayer).Type = PlayerMock.self,
 		externalPlayers: [GenericMediaPlayer.Type] = []
 	) {}
 


### PR DESCRIPTION
 
 ## Context
 
Our current `GenericMediaPlayer` interface was being used for both the main internal player and for external players, but some of the functionality in the interface can't be supported from external players.

This was forcing external players to implement the extra method signatures as no-ops.

 ## Description

This PR splits all the related functionality only available to the main player out of the `GenericMediaPlayer` protocol and into their own interfaces, to avoid imposing them on external players that won't need them.
