### PR TITLE
Disabled playback metadata assertions

### DIFF
--- a/Sources/Player/Common/World/DevelopmentFeatureFlagProvider/DevelopmentFeatureFlagProvider+Live.swift
+++ b/Sources/Player/Common/World/DevelopmentFeatureFlagProvider/DevelopmentFeatureFlagProvider+Live.swift
@@ -1,5 +1,6 @@
 extension DevelopmentFeatureFlagProvider {
 	static let live = DevelopmentFeatureFlagProvider(
-		isOffliningEnabled: false
+		isOffliningEnabled: false,
+		shouldReadAndVerifyPlaybackMetadata: false
 	)
 }

--- a/Sources/Player/Common/World/DevelopmentFeatureFlagProvider/DevelopmentFeatureFlagProvider.swift
+++ b/Sources/Player/Common/World/DevelopmentFeatureFlagProvider/DevelopmentFeatureFlagProvider.swift
@@ -3,4 +3,5 @@ import Foundation
 /// Provider of feature flags used during development of new features.
 struct DevelopmentFeatureFlagProvider {
 	var isOffliningEnabled: Bool
+	var shouldReadAndVerifyPlaybackMetadata: Bool
 }

--- a/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/AVQueuePlayerWrapper.swift
+++ b/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/AVQueuePlayerWrapper.swift
@@ -397,6 +397,25 @@ private extension AVQueuePlayerWrapper {
 		playerItemAssets[playerItem] = asset
 	}
 
+	func readPlaybackMetadata(playerItem: AVPlayerItem) {
+		guard PlayerWorld.developmentFeatureFlagProvider.shouldReadAndVerifyPlaybackMetadata else {
+			return
+		}
+
+		// In a separate context to not block player operation
+		SafeTask {
+			if let metadata = await self.readPlaybackMetadata(playerItem) {
+				queue.dispatch {
+					guard let asset = self.playerItemAssets[playerItem] else {
+						return
+					}
+					asset.playbackMetadata = metadata
+					self.delegates.playbackMetadataLoaded(asset: asset)
+				}
+			}
+		}
+	}
+
 	func readPlaybackMetadata(_ playerItem: AVPlayerItem) async -> AssetPlaybackMetadata? {
 		do {
 			var formatDescriptions = [CMFormatDescription]()
@@ -447,20 +466,9 @@ private extension AVQueuePlayerWrapper {
 				return
 			}
 
-			self.delegates.loaded(asset: asset, with: CMTimeGetSeconds(playerItem.duration))
-		}
+			self.readPlaybackMetadata(playerItem: playerItem)
 
-		// In a separate context to not block player operation
-		SafeTask {
-			if let metadata = await self.readPlaybackMetadata(playerItem) {
-				queue.dispatch {
-					guard let asset = self.playerItemAssets[playerItem] else {
-						return
-					}
-					asset.playbackMetadata = metadata
-					self.delegates.playbackMetadataLoaded(asset: asset)
-				}
-			}
+			self.delegates.loaded(asset: asset, with: CMTimeGetSeconds(playerItem.duration))
 		}
 	}
 

--- a/Tests/PlayerTests/Mocks/Common/World/DevelopmentFeatureFlagProvider+Mock.swift
+++ b/Tests/PlayerTests/Mocks/Common/World/DevelopmentFeatureFlagProvider+Mock.swift
@@ -2,6 +2,7 @@
 
 extension DevelopmentFeatureFlagProvider {
 	static let mock: Self = DevelopmentFeatureFlagProvider(
-		isOffliningEnabled: false
+		isOffliningEnabled: false,
+		shouldReadAndVerifyPlaybackMetadata: false
 	)
 }


### PR DESCRIPTION
## Context

A long time ago, we added reading playback metadata from the actual content as a PoC, and later, when we started getting that data from the backend, we decided to use it as an extra verification to make sure both datapoints match.

It also allowed us to give the client the metadata in cases where things had been offlined before this metadata was being used.

## Description

Now we are in a position where the backend will always provide the data, and there is no need to backfill old offlined items with it, so this is probably something we should get rid of.

This PR moves all the related functionality behind a Development Feature Flag, which allows us to disable it without removing the code yet and will make it easier later to either add it again or remove it completely.
