### PR TITLE
Ensure queue is accessed on background

### DIFF
--- a/Sources/EventProducer/Events/Logic/EventQueue.swift
+++ b/Sources/EventProducer/Events/Logic/EventQueue.swift
@@ -4,7 +4,6 @@ import SWXMLHash
 
 final class EventQueue {
 	static let databaseName = "EventQueueDatabase.sqlite"
-
 	static let shared = EventQueue()
 	var dbQueue: DatabaseQueue!
 
@@ -16,9 +15,12 @@ final class EventQueue {
 		guard let databaseURL = FileManagerHelper.shared.eventQueueDatabaseURL else {
 			throw EventProducerError.eventQueueDatabaseURLFailure
 		}
+		
+		var configuration = Configuration()
+		configuration.qos = .background
 
 		do {
-			dbQueue = try DatabaseQueue(path: databaseURL.path)
+			dbQueue = try DatabaseQueue(path: databaseURL.path, configuration: configuration)
 			try dbQueue.write { db in
 				try db.create(table: EventPersistentObject.databaseTableName, ifNotExists: true) { table in
 					table.column(EventPersistentObject.columnID, .text).notNull()

--- a/Sources/EventProducer/Monitoring/MonitoringQueue.swift
+++ b/Sources/EventProducer/Monitoring/MonitoringQueue.swift
@@ -14,9 +14,12 @@ public final class MonitoringQueue {
 		guard let databaseURL = FileManagerHelper.shared.eventQueueDatabaseURL else {
 			throw EventProducerError.monitoringQueueDatabaseURLFailure
 		}
+		
+		var configuration = Configuration()
+		configuration.qos = .background
 
 		do {
-			databaseQueue = try DatabaseQueue(path: databaseURL.path)
+			databaseQueue = try DatabaseQueue(path: databaseURL.path, configuration: configuration)
 			try databaseQueue.write { database in
 				try database.create(table: MonitoringInfoPersistentObject.databaseTableName, ifNotExists: true) { table in
 					table.column(MonitoringInfoPersistentObject.columnId, .text).notNull()


### PR DESCRIPTION
If user has selected to block non-essential cookies, there were instances where writing to the DB caused collisions, which resulted in events being dropped.

This PR introduces a `Configuration` with `.qos` set to `background` which mitigates this issue.

Major props to @micai23 for helping it debugging this and finding the actual solution 🙌 🎉