### PR TITLE
Fixed EventProducer SQLITE_LOCKED errors

### DIFF
--- a/Sources/EventProducer/Monitoring/MonitoringQueue.swift
+++ b/Sources/EventProducer/Monitoring/MonitoringQueue.swift
@@ -11,7 +11,7 @@ public final class MonitoringQueue {
 	}
 
 	private func setup() throws {
-		guard let databaseURL = FileManagerHelper.shared.eventQueueDatabaseURL else {
+		guard let databaseURL = FileManagerHelper.shared.monitoringQueueDatabaseURL else {
 			throw EventProducerError.monitoringQueueDatabaseURLFailure
 		}
 


### PR DESCRIPTION
I believe a typo was causing the `EventProducer` module to open multiple connections to the same DB, causing `SQLITE_LOCKED` errors.