### PR TITLE
Check Queue Size (iOS)

### DIFF
--- a/Sources/EventProducer/Events/Models/EventConfig.swift
+++ b/Sources/EventProducer/Events/Models/EventConfig.swift
@@ -2,7 +2,8 @@ import Foundation
 import protocol Auth.CredentialsProvider
 
 public struct EventConfig: EventProducer {
-	static let defaultMaxDiskUsageBytes = 204800
+	static let defaultQueueMaxDiskUsageBytes = 204800
+	static let singleEventMaxDiskUsageBytes = 20480
 	
 	/// An access token provider, used by the EventProducer to get access token.
 	public var credentialsProvider: CredentialsProvider

--- a/Sources/EventProducer/Events/Models/EventConfig.swift
+++ b/Sources/EventProducer/Events/Models/EventConfig.swift
@@ -2,7 +2,7 @@ import Foundation
 import protocol Auth.CredentialsProvider
 
 public struct EventConfig: EventProducer {
-	static let defaultMaxDiskUsageBytes = 20480
+	static let defaultMaxDiskUsageBytes = 204800
 	
 	/// An access token provider, used by the EventProducer to get access token.
 	public var credentialsProvider: CredentialsProvider

--- a/Sources/EventProducer/Outage/OutageState.swift
+++ b/Sources/EventProducer/Outage/OutageState.swift
@@ -2,6 +2,6 @@ import Common
 import Foundation
 
 public enum OutageState {
-	case outage(error: OutageStartError)
-	case noOutage(message: OutageEndMessage)
+	case outageStart(error: OutageStartError)
+	case outageEnd(message: OutageEndMessage)
 }

--- a/Sources/EventProducer/TidalEventSender.swift
+++ b/Sources/EventProducer/TidalEventSender.swift
@@ -14,11 +14,21 @@ public final class TidalEventSender: EventSender {
 	public var config: EventConfig?
 	
 	// MARK: - Private properties
-
-	private let outageSubject = PassthroughSubject<OutageState, Never>()
+	
+	var isOutage: Bool {
+		guard let outageState = monitoring.outageSubject?.value else {
+			return false
+		}
+		switch outageState {
+			case .outageStart:
+					return true
+			case .outageEnd:
+					return false
+			}
+	}
 	private var scheduler: EventScheduler
 	private let eventSubmitter: EventSubmitter
-	private let monitoring: Monitoring
+	private var monitoring: Monitoring
 	private var monitoringScheduler: MonitoringScheduler
 	private let fileManager: FileManagerHelper
 	
@@ -104,11 +114,11 @@ public final class TidalEventSender: EventSender {
 		monitoringScheduler.runScheduling(with: headerHelper)
 	}
 
-	private func startOutage(eventName: String) {
-		outageSubject.send(.outage(error: .init(code: "100", message: "Start outage error for \(eventName)")))
+	private func startOutage(eventName event: String) {
+		monitoring.startOutage(eventName: event)
 	}
 
-	private func endOutage(eventName: String) {
-		outageSubject.send(.noOutage(message: .init(message: "No outage for \(eventName)")))
+	private func endOutage(eventName event: String) {
+		monitoring.endOutage(eventName: event)
 	}
 }

--- a/Sources/EventProducer/TidalEventSender.swift
+++ b/Sources/EventProducer/TidalEventSender.swift
@@ -70,7 +70,7 @@ public final class TidalEventSender: EventSender {
 		}
 
 		guard !fileManager.exceedsMaximumSize(object: eventData,
-																					maximumSize: config?.maxDiskUsageBytes ?? EventConfig.defaultMaxDiskUsageBytes) else {
+																					maximumSize: EventConfig.singleEventMaxDiskUsageBytes) else {
 			try await monitoring.updateMonitoringEvent(monitoringEventType: .failedStorage, eventName: event.name)
 			startOutage(eventName: event.name)
 			return

--- a/Sources/EventProducer/TidalEventSender.swift
+++ b/Sources/EventProducer/TidalEventSender.swift
@@ -50,7 +50,7 @@ public final class TidalEventSender: EventSender {
 	
 	public func updateConfiguration(_ config: EventConfig) {
 		self.config = config
-		self.scheduler = EventScheduler(consumerUri: config.consumerUri)
+		self.scheduler = EventScheduler(consumerUri: config.consumerUri, maxDiskUsageBytes: config.maxDiskUsageBytes)
 		self.monitoringScheduler = MonitoringScheduler(consumerUri: config.consumerUri)
 	}
 

--- a/Tests/EventProducerTests/EventsTests/EventsTests.swift
+++ b/Tests/EventProducerTests/EventsTests/EventsTests.swift
@@ -24,7 +24,7 @@ final class EventsTests: XCTestCase {
 	private let testAccessToken = "testAccessToken"
 	private let queue = EventQueue.shared
 	private var headerHelper: HeaderHelper!
-	private let maxDiskUsageBytes = 20480
+	private let maxDiskUsageBytes = 204800
 
 	override func setUp() async throws {
 		try await super.setUp()

--- a/Tests/EventProducerTests/HelperTests/FileManagerHelperTests.swift
+++ b/Tests/EventProducerTests/HelperTests/FileManagerHelperTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class FileManagerHelperTests: XCTestCase {
 	private let sut: FileManagerHelper = .shared
-	private let maxDiskUsageBytes = 20480
+	private let maxDiskUsageBytes = 204800
 
 	func testExceedsMaximumSize() {
 		let data = Data(count: 10480)

--- a/Tests/EventProducerTests/MonitoringTests/MonitoringTests.swift
+++ b/Tests/EventProducerTests/MonitoringTests/MonitoringTests.swift
@@ -19,7 +19,7 @@ final class MonitoringTests: XCTestCase {
 		var isUserLoggedIn: Bool
 	}
 
-	private let sut: Monitoring = .shared
+	private var sut: Monitoring = .shared
 	private let monitoringQueue: MonitoringQueue = .shared
 	private var headerHelper: HeaderHelper!
 	private let maxDiskUsageBytes = 204800
@@ -190,5 +190,27 @@ final class MonitoringTests: XCTestCase {
 
 		let monitoringInfoAfterDeletion = await sut.getMonitoringInfo()
 		XCTAssertEqual(sut.emptyMonitoringInfo, monitoringInfoAfterDeletion)
+	}
+	
+	func testisOutageGetsTriggeredOnMonitoringUpdate() async throws {
+		
+		sut.startOutage(eventName: "test")
+		
+		guard let outageState = sut.outageSubject?.value else {
+			XCTFail("outageSubject not accessible")
+			return
+		}
+		/// start outage
+		var isOutage: Bool = if case .outageStart? = sut.outageSubject?.value { true } else { false }
+		
+		/// Verify that the outage is active
+		XCTAssertTrue(isOutage)
+		
+		/// end outage
+		sut.endOutage(eventName: "test")
+		isOutage = if case .outageStart? = sut.outageSubject?.value { true } else { false }
+		
+		/// Verify that the outage is not active
+		XCTAssertFalse(isOutage)
 	}
 }

--- a/Tests/EventProducerTests/MonitoringTests/MonitoringTests.swift
+++ b/Tests/EventProducerTests/MonitoringTests/MonitoringTests.swift
@@ -22,7 +22,7 @@ final class MonitoringTests: XCTestCase {
 	private let sut: Monitoring = .shared
 	private let monitoringQueue: MonitoringQueue = .shared
 	private var headerHelper: HeaderHelper!
-	private let maxDiskUsageBytes = 20480
+	private let maxDiskUsageBytes = 204800
 	
 	private var mockCredentialsProvider: CredentialsProvider {
 		MockCredentialsProvider(isUserLoggedIn: true)

--- a/Tests/EventProducerTests/MonitoringTests/MonitoringTests.swift
+++ b/Tests/EventProducerTests/MonitoringTests/MonitoringTests.swift
@@ -196,7 +196,7 @@ final class MonitoringTests: XCTestCase {
 		
 		sut.startOutage(eventName: "test")
 		
-		guard let outageState = sut.outageSubject?.value else {
+		guard sut.outageSubject != nil else {
 			XCTFail("outageSubject not accessible")
 			return
 		}

--- a/Tests/EventProducerTests/NetworkingTests/NetworkingTests.swift
+++ b/Tests/EventProducerTests/NetworkingTests/NetworkingTests.swift
@@ -12,7 +12,7 @@ final class NetworkingTests: XCTestCase {
 		}
 	}
 	
-	private let maxDiskUsageBytes = 20480
+	private let maxDiskUsageBytes = 204800
 	
 	private var mockAuthProvider: AuthProvider {
 		MockAuthProvider(token: "testAccessToken", clientID: "testURL")


### PR DESCRIPTION
Currently we only check if a single event is under a certain `maxDiskUsageBytes`, whereas we need to make sure the entire queue is under the pre-defined size, as noted in [🧾 documentation.](https://github.com/tidal-music/tidal-sdk/blob/main/EventProducer.md#queue)

This PR addresses that issue and introduces the default check for a singular event.