### PR TITLE
Fix EventQueue.addEvent crash

### DIFF
--- a/Sources/EventProducer/Events/Logic/EventQueue.swift
+++ b/Sources/EventProducer/Events/Logic/EventQueue.swift
@@ -2,7 +2,7 @@ import Foundation
 import GRDB
 import SWXMLHash
 
-final class EventQueue {
+actor EventQueue {
 	static let databaseName = "EventQueueDatabase.sqlite"
 	
 	private var _dbQueue: DatabaseQueue?

--- a/Sources/EventProducer/Monitoring/MonitoringQueue.swift
+++ b/Sources/EventProducer/Monitoring/MonitoringQueue.swift
@@ -1,7 +1,7 @@
 import Foundation
 import GRDB
 
-public final class MonitoringQueue {
+actor MonitoringQueue {
 	static let databaseName = "MonitoringDatabase.sqlite"
 	private var _databaseQueue: DatabaseQueue?
 	


### PR DESCRIPTION
We open database in `EventQueue` (i.e we create an instance of `DatabaseQueue`) if it was not done before. If it is already there, we just return it.

However, if multiple threads try to do it simultaneously, the `if let _dbQueue` is `false` for all of them and thus, we create multiple instances of the database. Since we override `_dbQueue` every time, we assume that at some point we try to call already deallocated instance - and there is a crash
![Screenshot 2024-07-22 at 17 02 20](https://github.com/user-attachments/assets/571fcd91-0539-4c9a-905a-bcd7302a3d0f)

Changing class to actor should solve this data race by providing thread-safe access to `dbQueue` computed property - so we will really have only one instance, and further calls will just return already existing `_dbQueue`

| Before    | After |
| -------- | ------- |
|![Screenshot 2024-07-22 at 17 14 16](https://github.com/user-attachments/assets/0ea7ab1e-458c-451d-b496-37daa70fd47b)| ![Screenshot 2024-07-22 at 17 13 38](https://github.com/user-attachments/assets/4c369cd5-c627-4057-956a-e9c72b140658)|