### PR TITLE
Playlog tests: Align skipToNext behavior with Android: don't do anything when there's no nextItem set up

### DIFF
--- a/Sources/Player/PlaybackEngine/PlayerEngine.swift
+++ b/Sources/Player/PlaybackEngine/PlayerEngine.swift
@@ -181,13 +181,10 @@ final class PlayerEngine {
 
 	func skipToNext(timestamp: UInt64) {
 		queue.dispatch {
-			let playerItem = self.nextItem
-			self.currentItem?.unloadFromPlayer()
-
-			guard let playerItem else {
-				self.reset(to: .IDLE)
+			guard let playerItem = self.nextItem else {
 				return
 			}
+			self.currentItem?.unloadFromPlayer()
 
 			// The order is important due to logic for emitting events in didSet of the items.
 			self.currentItem = playerItem

--- a/Tests/PlayerTests/Player/PlaybackEngine/PlayerEngineTests.swift
+++ b/Tests/PlayerTests/Player/PlaybackEngine/PlayerEngineTests.swift
@@ -496,7 +496,7 @@ extension PlayerEngineTests {
 
 		// THEN
 		// Make sure it's idle, and items remain nil
-		XCTAssertEqual(playerEngine.getState(), .IDLE)
+		XCTAssertEqual(playerEngine.getState(), .NOT_PLAYING)
 		XCTAssertEqual(playerEngine.currentItem, nil)
 		XCTAssertEqual(playerEngine.nextItem, nil)
 
@@ -618,17 +618,17 @@ extension PlayerEngineTests {
 		assertGenericPlayer(assets: [asset], playCount: 2, pauseCount: 0)
 
 		// WHEN
-		// skipToNext() should unload the current one, set the previously next as current, and nextItem should become nil.
+		// skipToNext() should not do anything when next item is not set up.
+		// If still playing, it will continue till it ends.
 		playerEngine.skipToNext(timestamp: timestamp)
 
-		// Since setNext was not called, meaning there's no nextItem set up, then both currentItem and nextItem are nil, reset is
-		// called, and set to IDLE state.
-		assertItem(item: playerEngine.currentItem, expectedItem: nil, shouldBeLoaded: nil)
+		// Since setNext was not called and skipToNext didn't do anything, everything remains.
+		assertItem(item: playerEngine.currentItem, expectedItem: expectedPlayerItem1, shouldBeLoaded: true)
 		assertItem(item: playerEngine.nextItem, expectedItem: nil, shouldBeLoaded: nil)
-		XCTAssertEqual(playerEngine.getState(), .IDLE)
+		XCTAssertEqual(playerEngine.getState(), .PLAYING)
 
 		// Same as above
-		assertGenericPlayer(assets: [], playCount: 2, pauseCount: 0)
+		assertGenericPlayer(assets: [asset], playCount: 2, pauseCount: 0)
 		assertPlayerLoader(trackPlaybackInfos: [trackPlaybackInfo1])
 	}
 


### PR DESCRIPTION
In order to fix the playlog tests, we need to address one of the different behaviors observed. So in this PR we address this different behavior - used by new playlog tests coming up in next PRs.

⚠️ The functionality itself (skip to next) is still under testing and therefore under control in case of any issues - the reason why I haven't added a FF.

⚠️ We can only run all player tests in all PRs again after this set of PRs are merged and we fix known existing flakiness.

---

This pull request includes changes to the `PlayerEngine` class in the `PlayerEngine.swift` file to streamline the `skipToNext` method and improve code readability.

Code simplification:

* [`Sources/Player/PlaybackEngine/PlayerEngine.swift`](diffhunk://#diff-e72feb354eac41dcce7baa31a6b2455945960a35c569f3ab640daa0e629a2015L184-R187): Simplified the `skipToNext` method by combining the assignment and the `guard` statement for `playerItem`, ensuring the current item is unloaded only when the next item is available.