### PR TITLE
fix GH workflow PR trigger in lint.yml and unit-test.yml

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,8 @@ on:
   workflow_call:
 
   pull_request:
-    branches: '*'
+    branches:
+      - '**'
 
   merge_group:
     types: [checks_requested]

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -4,7 +4,8 @@ on:
   workflow_call:
   workflow_dispatch:
   pull_request:
-    branches: '*'
+    branches:
+      - '**'
 
   merge_group:
     types: [checks_requested]


### PR DESCRIPTION
It seems our `branches` array in the `pull_request` trigger had a wrong format, which was affecting both `lint` and `unit-test` actions. This PR aims to fix it.

---

This pull request includes changes to the GitHub Actions workflows to improve branch matching for pull requests.

Changes to GitHub Actions workflows:

* [`.github/workflows/lint.yml`](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2L7-R8): Updated the `pull_request` trigger to match all branches using the `**` wildcard.
* [`.github/workflows/unit-test.yml`](diffhunk://#diff-d4223b44df678cece85f2542c19b9cd060d43b22f753c25214d5942ef2ca5d18L7-R8): Updated the `pull_request` trigger to match all branches using the `**` wildcard.