### PR TITLE
Fix Credentials related crashes

### DIFF
--- a/Sources/Auth/Storage/DefaultTokensStore.swift
+++ b/Sources/Auth/Storage/DefaultTokensStore.swift
@@ -9,6 +9,8 @@ final class DefaultTokensStore: TokensStore {
 
 	private var latestTokens: Tokens?
 
+	private let credentialsQueue = DispatchQueue(label: "com.tidal.auth.credentialsQueue")
+	
 	init(credentialsKey: String, credentialsAccessGroup: String?) {
 		storageKey = "\(credentialsKey)_\(PREFS_FILE_NAME)"
 		self.credentialsKey = credentialsKey
@@ -20,8 +22,12 @@ final class DefaultTokensStore: TokensStore {
 	}
 
 	func getLatestTokens() throws -> Tokens? {
-		latestTokens = try latestTokens ?? loadTokens()
-		return latestTokens
+		try credentialsQueue.sync {
+			if latestTokens == nil {
+				latestTokens = try loadTokens()
+			}
+			return latestTokens
+		}
 	}
 
 	private func loadTokens() throws -> Tokens? {
@@ -38,7 +44,7 @@ final class DefaultTokensStore: TokensStore {
 				// try to decode legacy tokens, convert them to tokens and save tokens
 				print("Failed to decode tokens. Attempting to decode legacy tokens")
 				if let convertedLegacyTokens = try? decoder.decode(LegacyTokens.self, from: data).toTokens() {
-					try saveTokens(tokens: convertedLegacyTokens)
+					try saveTokensUnsafe(tokens: convertedLegacyTokens)
 					return convertedLegacyTokens
 				} else {
 					throw error
@@ -48,14 +54,22 @@ final class DefaultTokensStore: TokensStore {
 	}
 
 	func saveTokens(tokens: Tokens) throws {
+		try credentialsQueue.sync {
+			try saveTokensUnsafe(tokens: tokens)
+		}
+	}
+
+	func eraseTokens() throws {
+		try credentialsQueue.sync {
+			latestTokens = nil
+			try encryptedStorage.removeAll()
+		}
+	}
+	
+	private func saveTokensUnsafe(tokens: Tokens) throws {
 		let data = try JSONEncoder().encode(tokens)
 		encryptedStorage[credentialsKey] = String(data: data, encoding: .utf8)
 		latestTokens = tokens
 		// TODO: emit credentails update:  `bus.emit(CredentialsUpdatedMessage)`
-	}
-
-	func eraseTokens() throws {
-		latestTokens = nil
-		try encryptedStorage.removeAll()
 	}
 }


### PR DESCRIPTION
We have already fixed EP crash here: https://github.com/tidal-music/tidal-sdk-ios/pull/39

But our `DefaultTokensStore` is also not thread-safe and we get similar crashes (related to deallocation of `Tokens`). Supposedly, the reason is the same...

We can't apply the same approach with `actor`, because it requires to make all methods `async`, and methods calling these methods too, etc 