### PR TITLE
Add available check for mac in AVPlayerItemErrorLogEvent

### DIFF
--- a/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/AVPlayerItemErrorLogEvent.swift
+++ b/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/AVPlayerItemErrorLogEvent.swift
@@ -3,7 +3,7 @@ import Foundation
 
 public extension AVPlayerItemErrorLogEvent {
 	override var description: String {
-		let httpResponseHeaderFields: String = if #available(iOS 17.5, *) {
+		let httpResponseHeaderFields: String = if #available(iOS 17.5, macOS 14.5, *) {
 			self.allHTTPResponseHeaderFields?.description ?? "N/A"
 		} else {
 			"N/A"


### PR DESCRIPTION
In [the previous PR](https://github.com/tidal-music/tidal-sdk-ios/pull/56), I missed adding the available also for mac, so doing it now.