### PR TITLE
Add parameter encoding

### DIFF
--- a/Sources/Common/Extensions/String+Extensions.swift
+++ b/Sources/Common/Extensions/String+Extensions.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+extension String {
+	/// Returns a percent-escaped string following RFC 3986 for a query string key or value.
+	///
+	/// RFC 3986 states that the following characters are "reserved" characters.
+	///
+	/// - General Delimiters: ":", "#", "[", "]", "@", "?", "/"
+	/// - Sub-Delimiters: "!", "$", "&", "'", "(", ")", "*", "+", ",", ";", "="
+	///
+	/// In RFC 3986 - Section 3.4, it states that the "?" and "/" characters should not be escaped to allow
+	/// query strings to include a URL. Therefore, all "reserved" characters with the exception of "?" and "/"
+	/// should be percent-escaped in the query string.
+	///
+	/// - returns: percent-escaped string.
+	public func encoded() -> String {
+		let generalDelimitersToEncode = ":#[]@"
+		let subDelimitersToEncode = "!$&'()*+,;="
+		var allowedCharacterSet = CharacterSet.urlQueryAllowed
+		allowedCharacterSet.remove(charactersIn: "\(generalDelimitersToEncode)\(subDelimitersToEncode)")
+		return self.addingPercentEncoding(withAllowedCharacters: allowedCharacterSet) ?? ""
+	}
+}

--- a/Sources/EventProducer/Events/Logic/EventScheduler.swift
+++ b/Sources/EventProducer/Events/Logic/EventScheduler.swift
@@ -161,12 +161,12 @@ final class EventScheduler: Scheduler {
 				"\(Parameters.sendBatch.rawValue).\(index).\(Parameters.attribute.rawValue).\(attributeIndex)"
 
 			// Format base attributes
-			parameters["\(Parameters.sendBatch.rawValue).\(index).\(Parameters.id.rawValue)"] = event.id
-			parameters["\(Parameters.sendBatch.rawValue).\(index).\(Parameters.body.rawValue)"] = event.payload
+			parameters["\(Parameters.sendBatch.rawValue).\(index).\(Parameters.id.rawValue)"] = event.id.encoded()
+			parameters["\(Parameters.sendBatch.rawValue).\(index).\(Parameters.body.rawValue)"] = event.payload.encoded()
 
-			parameters["\(baseAttributePrefix).\(Parameters.nameKey.rawValue)"] = Parameters.nameKey.rawValue
-			parameters["\(baseAttributePrefix).\(Parameters.value.rawValue)"] = event.name
-			parameters["\(baseAttributePrefix).\(Parameters.valueDatatype.rawValue)"] = Parameters.string.rawValue
+			parameters["\(baseAttributePrefix).\(Parameters.nameKey.rawValue)"] = Parameters.nameKey.rawValue.encoded()
+			parameters["\(baseAttributePrefix).\(Parameters.value.rawValue)"] = event.name.encoded()
+			parameters["\(baseAttributePrefix).\(Parameters.valueDatatype.rawValue)"] = Parameters.string.rawValue.encoded()
 
 			// Format headers
 			guard let eventHeadersString = event.headers.jsonEncoded else {
@@ -177,9 +177,9 @@ final class EventScheduler: Scheduler {
 			let baseHeaderPrefix =
 				"\(Parameters.sendBatch.rawValue).\(index).\(Parameters.attribute.rawValue).\(headerAttributeIndex)"
 
-			parameters["\(baseHeaderPrefix).\(Parameters.nameKey.rawValue)"] = Parameters.headers.rawValue
-			parameters["\(baseHeaderPrefix).\(Parameters.value.rawValue)"] = eventHeadersString
-			parameters["\(baseHeaderPrefix).\(Parameters.valueDatatype.rawValue)"] = Parameters.string.rawValue
+			parameters["\(baseHeaderPrefix).\(Parameters.nameKey.rawValue)"] = Parameters.headers.rawValue.encoded()
+			parameters["\(baseHeaderPrefix).\(Parameters.value.rawValue)"] = eventHeadersString.encoded()
+			parameters["\(baseHeaderPrefix).\(Parameters.valueDatatype.rawValue)"] = Parameters.string.rawValue.encoded()
 		}
 		return parameters
 	}

--- a/Tests/EventProducerTests/EventsTests/EventsTests.swift
+++ b/Tests/EventProducerTests/EventsTests/EventsTests.swift
@@ -134,12 +134,14 @@ final class EventsTests: XCTestCase {
 		
 		let event2 = Event(
 			name: "testEvent#2",
-			payload: "https://tidal.com/test/ +"
+			payload: "https://api.tidal.com/v2/home/initiate?countryCode=NO"
 		)
 		
+		
 		let encodedEvents = eventScheduler.formatEvents([event1, event2])
+		print("🔥\(encodedEvents)")
 		XCTAssertTrue(encodedEvents.contains(where: { $0.value == "firstPayload" }))
-		XCTAssertTrue(encodedEvents.contains(where: { $0.value == "https%3A//tidal.com/test/%20%2B" }))
+		XCTAssertTrue(encodedEvents.contains(where: { $0.value == "https%3A//api.tidal.com/v2/home/initiate?countryCode%3DNO" }))
 	}
 
 	func testSendEventThroughScheduler() async throws {

--- a/Tests/EventProducerTests/EventsTests/EventsTests.swift
+++ b/Tests/EventProducerTests/EventsTests/EventsTests.swift
@@ -119,6 +119,28 @@ final class EventsTests: XCTestCase {
 		XCTAssertTrue(fetchedEvents.contains(where: { $0.name == "testEvent#2" }))
 		XCTAssertFalse(fetchedEvents.contains(where: { $0.name == "fakeEvent" }))
 	}
+	
+	func testEventsEncoded() async throws {
+		guard let consumerUri = eventSender.config?.consumerUri else {
+			XCTFail("Default consumerUri should be set")
+			return
+		}
+		
+		let eventScheduler = EventScheduler(consumerUri: consumerUri, eventQueue: queue, monitoring: monitoring)
+		let event1 = Event(
+			name: "testEvent#1",
+			payload: "firstPayload"
+		)
+		
+		let event2 = Event(
+			name: "testEvent#2",
+			payload: "https://tidal.com/test/ +"
+		)
+		
+		let encodedEvents = eventScheduler.formatEvents([event1, event2])
+		XCTAssertTrue(encodedEvents.contains(where: { $0.value == "firstPayload" }))
+		XCTAssertTrue(encodedEvents.contains(where: { $0.value == "https%3A//tidal.com/test/%20%2B" }))
+	}
 
 	func testSendEventThroughScheduler() async throws {
 		guard let consumerUri = eventSender.config?.consumerUri else {


### PR DESCRIPTION
Currently parameter value do not conform to [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986) allowing certain events to fail.

✅ No changes needed on client-side
✅ Verified ingestion