### PR TITLE
Remove `isStallWhenTransitionFromEndedToBufferingEnabled` from `FeatureFlagProvider`

### DIFF
--- a/Sources/Player/Common/FeatureFlags/FeatureFlagProvider+Standard.swift
+++ b/Sources/Player/Common/FeatureFlags/FeatureFlagProvider+Standard.swift
@@ -2,7 +2,6 @@ import Foundation
 
 public extension FeatureFlagProvider {
 	static let standard = FeatureFlagProvider(
-		isStallWhenTransitionFromEndedToBufferingEnabled: { true },
 		shouldUseEventProducer: { false },
 		isContentCachingEnabled: { true },
 		shouldSendEventsInDeinit: { true },

--- a/Sources/Player/Common/FeatureFlags/FeatureFlagProvider.swift
+++ b/Sources/Player/Common/FeatureFlags/FeatureFlagProvider.swift
@@ -1,20 +1,15 @@
 public struct FeatureFlagProvider {
-	// swiftlint:disable:next identifier_name
-	public var isStallWhenTransitionFromEndedToBufferingEnabled: () -> Bool
 	public var shouldUseEventProducer: () -> Bool
 	public var isContentCachingEnabled: () -> Bool
 	public var shouldSendEventsInDeinit: () -> Bool
 	public var shouldUseImprovedCaching: () -> Bool
 
 	public init(
-		// swiftlint:disable:next identifier_name
-		isStallWhenTransitionFromEndedToBufferingEnabled: @escaping () -> Bool,
 		shouldUseEventProducer: @escaping () -> Bool,
 		isContentCachingEnabled: @escaping () -> Bool,
 		shouldSendEventsInDeinit: @escaping () -> Bool,
 		shouldUseImprovedCaching: @escaping () -> Bool
 	) {
-		self.isStallWhenTransitionFromEndedToBufferingEnabled = isStallWhenTransitionFromEndedToBufferingEnabled
 		self.shouldUseEventProducer = shouldUseEventProducer
 		self.isContentCachingEnabled = isContentCachingEnabled
 		self.shouldSendEventsInDeinit = shouldSendEventsInDeinit

--- a/Sources/Player/Mocks/Common/FeatureFlags/FeatureFlagProvider+Mock.swift
+++ b/Sources/Player/Mocks/Common/FeatureFlags/FeatureFlagProvider+Mock.swift
@@ -2,7 +2,6 @@ import Foundation
 
 public extension FeatureFlagProvider {
 	static let mock = FeatureFlagProvider(
-		isStallWhenTransitionFromEndedToBufferingEnabled: { true },
 		shouldUseEventProducer: { true },
 		isContentCachingEnabled: { true },
 		shouldSendEventsInDeinit: { true },


### PR DESCRIPTION
This pull request includes changes to the `FeatureFlagProvider` struct and its extensions to remove the `isStallWhenTransitionFromEndedToBufferingEnabled` feature flag. The most important changes involve updating the initialization and usage of `FeatureFlagProvider` in both the main and mock implementations.

Changes to `FeatureFlagProvider`:

* [`Sources/Player/Common/FeatureFlags/FeatureFlagProvider.swift`](diffhunk://#diff-4cd187606f8aae83fb59b73a080a87896fe6033ce7fed43af1bc02b0d4b5dfc5L2-L17): Removed the `isStallWhenTransitionFromEndedToBufferingEnabled` property and its initialization from the `FeatureFlagProvider` struct.

Updates to standard feature flags:

* [`Sources/Player/Common/FeatureFlags/FeatureFlagProvider+Standard.swift`](diffhunk://#diff-357b6e003c6e1c07f64bda0a4006d43ba8928ecc38a2c1b7e8c5848e6f6b9fecL5): Removed the `isStallWhenTransitionFromEndedToBufferingEnabled` feature flag from the standard feature flag provider.

Updates to mock feature flags:

* [`Sources/Player/Mocks/Common/FeatureFlags/FeatureFlagProvider+Mock.swift`](diffhunk://#diff-29ec55675dc54daf5487ce14e6350480fed65a1f0163e4d1bda67fe83128c6deL5): Removed the `isStallWhenTransitionFromEndedToBufferingEnabled` feature flag from the mock feature flag provider.