### PR TITLE
Added MediaProduct.referenceId from the Player spec

### DIFF
--- a/Sources/Player/Common/Types/Interruption.swift
+++ b/Sources/Player/Common/Types/Interruption.swift
@@ -5,7 +5,13 @@ import Foundation
 /// and grow. Ideally this class should not exist.
 public final class Interruption: MediaProduct {
 	public init(productType: ProductType, productId: String) {
-		super.init(productType: productType, productId: productId, progressSource: nil, playLogSource: nil)
+		super.init(
+			productType: productType,
+			productId: productId,
+			referenceId: nil,
+			progressSource: nil,
+			playLogSource: nil
+		)
 	}
 
 	required init(from decoder: Decoder) throws {

--- a/Sources/Player/Common/Types/MediaProduct.swift
+++ b/Sources/Player/Common/Types/MediaProduct.swift
@@ -5,17 +5,20 @@ import Foundation
 public class MediaProduct: Codable {
 	public let productType: ProductType
 	public let productId: String
+	public let referenceId: String?
 	public let progressSource: Source?
 	public let playLogSource: Source?
 
 	public init(
 		productType: ProductType,
 		productId: String,
+		referenceId: String?,
 		progressSource: Source?,
 		playLogSource: Source?
 	) {
 		self.productType = productType
 		self.productId = productId
+		self.referenceId = referenceId
 		self.progressSource = progressSource
 		self.playLogSource = playLogSource
 	}
@@ -24,6 +27,7 @@ public class MediaProduct: Codable {
 		self.init(
 			productType: productType,
 			productId: productId,
+			referenceId: nil,
 			progressSource: nil,
 			playLogSource: nil
 		)
@@ -36,6 +40,7 @@ extension MediaProduct: Equatable {
 	public static func == (lhs: MediaProduct, rhs: MediaProduct) -> Bool {
 		lhs.productId == rhs.productId &&
 			lhs.productType == rhs.productType &&
+			lhs.referenceId == rhs.referenceId &&
 			lhs.playLogSource == rhs.playLogSource &&
 			lhs.progressSource == rhs.progressSource
 	}
@@ -45,6 +50,6 @@ extension MediaProduct: Equatable {
 
 extension MediaProduct: CustomStringConvertible {
 	public var description: String {
-		"MediaProduct(productType: \(productType), productId: \"\(productId)\", progressSource: \(String(describing: progressSource)), playLogSource: \(String(describing: playLogSource)))"
+		"MediaProduct(productType: \(productType), productId: \"\(productId)\", referenceId: \"\(String(describing: referenceId))\", progressSource: \(String(describing: progressSource)), playLogSource: \(String(describing: playLogSource)))"
 	}
 }

--- a/Sources/Player/Common/Types/StoredMediaProduct.swift
+++ b/Sources/Player/Common/Types/StoredMediaProduct.swift
@@ -17,6 +17,7 @@ public final class StoredMediaProduct: MediaProduct {
 	public init(
 		productType: ProductType,
 		productId: String,
+		referenceId: String?,
 		progressSource: Source?,
 		playLogSource: Source?,
 		assetPresentation: AssetPresentation,
@@ -48,6 +49,7 @@ public final class StoredMediaProduct: MediaProduct {
 		super.init(
 			productType: productType,
 			productId: productId,
+			referenceId: referenceId,
 			progressSource: progressSource,
 			playLogSource: playLogSource
 		)

--- a/Sources/Player/Mocks/Common/Types/MediaProduct+Mock.swift
+++ b/Sources/Player/Mocks/Common/Types/MediaProduct+Mock.swift
@@ -4,6 +4,7 @@ public extension MediaProduct {
 	static func mock(
 		productType: ProductType = .TRACK,
 		productId: String = "productId",
+		referenceId: String? = nil,
 		progressSource: Source? = nil,
 		playLogSource: Source? = nil,
 		productURL: URL? = nil
@@ -11,6 +12,7 @@ public extension MediaProduct {
 		MediaProduct(
 			productType: productType,
 			productId: productId,
+			referenceId: referenceId,
 			progressSource: progressSource,
 			playLogSource: playLogSource
 		)

--- a/Sources/Player/Mocks/Common/Types/StoredMediaProduct+Mock.swift
+++ b/Sources/Player/Mocks/Common/Types/StoredMediaProduct+Mock.swift
@@ -4,6 +4,7 @@ public extension StoredMediaProduct {
 	static func mock(
 		productType: ProductType = .TRACK,
 		productId: String = "1",
+		referenceId: String? = nil,
 		progressSource: Source? = nil,
 		playLogSource: Source? = nil,
 		assetPresentation: AssetPresentation = .FULL,
@@ -22,6 +23,7 @@ public extension StoredMediaProduct {
 		StoredMediaProduct(
 			productType: productType,
 			productId: productId,
+			referenceId: referenceId,
 			progressSource: progressSource,
 			playLogSource: playLogSource,
 			assetPresentation: assetPresentation,

--- a/TestApps/Player/PlayerTestApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TestApps/Player/PlayerTestApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
   "pins" : [
     {
+      "identity" : "anycodable",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Flight-School/AnyCodable",
+      "state" : {
+        "revision" : "862808b2070cd908cb04f9aafe7de83d35f81b05",
+        "version" : "0.6.7"
+      }
+    },
+    {
       "identity" : "grdb.swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/groue/GRDB.swift.git",
@@ -25,6 +34,15 @@
       "state" : {
         "revision" : "a46542ce639581af2a85ab9ec1616a507a5d4ae2",
         "version" : "4.2.2"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "9cb486020ebf03bfa5b5df985387a14a98744537",
+        "version" : "1.6.1"
       }
     },
     {


### PR DESCRIPTION
We were missing `referenceId` inside `MediaProduct` from the Player spec.