### PR TITLE
Update unit-test.yml to fix broken release trigger

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,6 +1,7 @@
 name: Run Unit Tests
 
 on:
+  workflow_call:
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -2,6 +2,7 @@ name: Run Unit Tests
 
 on:
   workflow_call:
+  workflow_dispatch:
   pull_request:
     branches:
       - '**'


### PR DESCRIPTION
Seems like I deleted one line by mistake in this [PR](https://github.com/tidal-music/tidal-sdk-ios/commit/7752931130586d7c8b51c0ae8a08f232e3f0c526). And from there on the trigger release got broken for 3 weeks. 🙀 

---

This pull request includes a small change to the `.github/workflows/unit-test.yml` file. The change adds a `workflow_call` trigger to the unit test workflow.

* [`.github/workflows/unit-test.yml`](diffhunk://#diff-d4223b44df678cece85f2542c19b9cd060d43b22f753c25214d5942ef2ca5d18R4): Added `workflow_call` trigger to the unit test workflow to enable reusability of the workflow in other workflows.