### PR TITLE
Update ownership removing platform, pace and bits and replacing them with mf

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,16 +2,17 @@
 
 # Teams
 
-## BITS
-Sources/Player/ @tidal-music/bits-ios @tidal-music/pace-ios
-Tests/PlayerTests/ @tidal-music/bits-ios @tidal-music/pace-ios
+## Music Foundations
 
-## Platform
-Sources/Auth/ @tidal-music/platform-ios
-Sources/Common/ @tidal-music/platform-ios
-Sources/EventProducer/ @tidal-music/platform-ios
-Sources/Template/ @tidal-music/platform-ios
-Tests/AuthTests/ @tidal-music/platform-ios
-Tests/CommonTests/ @tidal-music/platform-ios
-Tests/EventProducerTests/ @tidal-music/platform-ios
-Tests/TemplateTests/ @tidal-music/platform-ios
+### Player
+Sources/Player/ @tidal-music/mf-ios
+Tests/PlayerTests/ @tidal-music/mf-ios
+
+Sources/Auth/ @tidal-music/mf-ios
+Tests/AuthTests/ @tidal-music/mf-ios
+Sources/Common/ @tidal-music/mf-ios
+Tests/CommonTests/ @tidal-music/mf-ios
+Sources/EventProducer/ @tidal-music/mf-ios
+Tests/EventProducerTests/ @tidal-music/mf-ios
+Sources/Template/ @tidal-music/mf-ios
+Tests/TemplateTests/ @tidal-music/mf-ios


### PR DESCRIPTION
This pull request includes changes to the `.github/CODEOWNERS` file, reorganizing team ownership assignments for various source and test files. The most important changes involve consolidating multiple teams under a single team and updating the ownership structure to reflect this consolidation.

Ownership reorganization:

* Consolidated the `BITS` and `Platform` teams into the `Music Foundations` team. (`.github/CODEOWNERS`)
* Assigned the `Music Foundations` team to the following directories and their respective test directories:
  - `Sources/Player/`
  - `Sources/Auth/`
  - `Sources/Common/`
  - `Sources/EventProducer/`
  - `Sources/Template/` (`.github/CODEOWNERS`)