### PR TITLE
Do not set up logging system in auth

### DIFF
--- a/Sources/Auth/Model/AuthConfig.swift
+++ b/Sources/Auth/Model/AuthConfig.swift
@@ -1,7 +1,4 @@
 import Foundation
-import protocol Logging.LogHandler
-
-public typealias LogHandlerFactory = (String) -> LogHandler
 
 public struct AuthConfig {
 	public let clientId: String
@@ -13,7 +10,7 @@ public struct AuthConfig {
 	public let tidalLoginServiceBaseUri: String
 	public let tidalAuthServiceBaseUri: String
 	public let enableCertificatePinning: Bool
-	public let logHandlerFactory: LogHandlerFactory?
+	public let enableLogging: Bool
 	
 	public init(
 		clientId: String,
@@ -25,7 +22,7 @@ public struct AuthConfig {
 		tidalLoginServiceBaseUri: String = "https://login.tidal.com",
 		tidalAuthServiceBaseUri: String = "https://auth.tidal.com",
 		enableCertificatePinning: Bool = true,
-		logHandlerFactory: LogHandlerFactory? = nil
+		enableLogging: Bool = false
 	) {
 		self.clientId = clientId
 		self.clientUniqueKey = clientUniqueKey
@@ -36,6 +33,6 @@ public struct AuthConfig {
 		self.tidalLoginServiceBaseUri = tidalLoginServiceBaseUri
 		self.tidalAuthServiceBaseUri = tidalAuthServiceBaseUri
 		self.enableCertificatePinning = enableCertificatePinning
-		self.logHandlerFactory = logHandlerFactory
+		self.enableLogging = enableLogging
 	}
 }

--- a/Sources/Auth/Model/AuthLoggable.swift
+++ b/Sources/Auth/Model/AuthLoggable.swift
@@ -20,6 +20,7 @@ enum AuthLoggable {
 
 // MARK: - Logging
 extension AuthLoggable {
+	static var enableLogging: Bool = false
 	private static let metadataErrorKey = "error"
 	private static let metadataReasonKey = "reason"
 	private static let metadataPreviousSubstatusKey = "previous_substatus"
@@ -90,6 +91,9 @@ extension AuthLoggable {
 	}
 	
 	func log() {
+		guard Self.enableLogging else {
+			return
+		}
 		var logger = Logger(label: "auth_logger")
 		// IIUC, this is a minimum level for the logger
 		logger.logLevel = .trace

--- a/Sources/Auth/TidalAuth.swift
+++ b/Sources/Auth/TidalAuth.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Logging
 import Common
 
 // MARK: - TidalAuth
@@ -19,9 +18,6 @@ public class TidalAuth: Auth & CredentialsProvider {
 		loginRepository = provideLoginRepository(config, tokensStore: tokensStore)
 		tokenRepository = provideTokenRepository(config, tokensStore: tokensStore)
 		
-		// if logger is not provided, use logger that does nothing
-		let logHandlerFactory = config.logHandlerFactory ?? { _ in SwiftLogNoOpLogHandler() }
-		LoggingSystem.bootstrap(logHandlerFactory)
 	}
 	
 	private func provideLoginRepository(_ config: AuthConfig, tokensStore: TokensStore) -> LoginRepository {

--- a/Sources/Auth/TidalAuth.swift
+++ b/Sources/Auth/TidalAuth.swift
@@ -18,6 +18,7 @@ public class TidalAuth: Auth & CredentialsProvider {
 		loginRepository = provideLoginRepository(config, tokensStore: tokensStore)
 		tokenRepository = provideTokenRepository(config, tokensStore: tokensStore)
 		
+		AuthLoggable.enableLogging = config.enableLogging
 	}
 	
 	private func provideLoginRepository(_ config: AuthConfig, tokensStore: TokensStore) -> LoginRepository {


### PR DESCRIPTION
We're going to set it up (set a log handler) on clients instead, since it is a static property which may be called just once.

Instead, we introduce `isLoggingEnabled`, in case a client doesn't need logging