### PR TITLE
Add logging in Player

### DIFF
--- a/Sources/Player/Common/Authentication/CredentialsProvider+Player.swift
+++ b/Sources/Player/Common/Authentication/CredentialsProvider+Player.swift
@@ -13,11 +13,12 @@ extension CredentialsProvider {
 		do {
 			credentials = try await getCredentials()
 		} catch {
+			PlayerWorld.logger()?.log(loggable: PlayerLoggable.getAuthBearerTokenCredentialFailed(error: error))
 			throw error
 		}
 
 		guard let token = credentials.toBearerToken() else {
-			PlayerWorld.logger?.log(loggable: PlayerLoggable.getAuthBearerToken)
+			PlayerWorld.logger()?.log(loggable: PlayerLoggable.getAuthBearerTokenToBearerTokenFailed)
 			// TODO: What error should we throw?
 			throw PlayerInternalError(errorId: .EUnexpected, errorType: .authError, code: 0)
 		}

--- a/Sources/Player/Common/Authentication/CredentialsProvider+Player.swift
+++ b/Sources/Player/Common/Authentication/CredentialsProvider+Player.swift
@@ -17,6 +17,7 @@ extension CredentialsProvider {
 		}
 
 		guard let token = credentials.toBearerToken() else {
+			PlayerWorld.logger?.log(loggable: PlayerLoggable.getAuthBearerToken)
 			// TODO: What error should we throw?
 			throw PlayerInternalError(errorId: .EUnexpected, errorType: .authError, code: 0)
 		}

--- a/Sources/Player/Common/Authentication/CredentialsSuccessDataParser.swift
+++ b/Sources/Player/Common/Authentication/CredentialsSuccessDataParser.swift
@@ -16,7 +16,7 @@ struct CredentialsSuccessDataParser {
 					let credentialsSuccessData = try decoder.decode(CredentialsSuccessData.self, from: jsonCredentialsSuccessData)
 					clientId = credentialsSuccessData.clientId
 				} catch {
-					PlayerWorld.logger?.log(loggable: PlayerLoggable.clientIdFromToken(error: error))
+					PlayerWorld.logger()?.log(loggable: PlayerLoggable.credentialsSuccessParserParsingFailed(error: error))
 					print("Error when trying to get client id from token from successData from credentials: \(error)")
 				}
 			}

--- a/Sources/Player/Common/Authentication/CredentialsSuccessDataParser.swift
+++ b/Sources/Player/Common/Authentication/CredentialsSuccessDataParser.swift
@@ -16,6 +16,7 @@ struct CredentialsSuccessDataParser {
 					let credentialsSuccessData = try decoder.decode(CredentialsSuccessData.self, from: jsonCredentialsSuccessData)
 					clientId = credentialsSuccessData.clientId
 				} catch {
+					PlayerWorld.logger?.log(loggable: PlayerLoggable.clientIdFromToken(error: error))
 					print("Error when trying to get client id from token from successData from credentials: \(error)")
 				}
 			}

--- a/Sources/Player/Common/DRM/FairPlayLicenseFetcher.swift
+++ b/Sources/Player/Common/DRM/FairPlayLicenseFetcher.swift
@@ -113,8 +113,8 @@ private extension FairPlayLicenseFetcher {
 			return license
 
 		} catch {
-			PlayerWorld.logger?.log(loggable: PlayerLoggable.getPlaybackInfo(error: error))
-			
+			PlayerWorld.logger()?.log(loggable: PlayerLoggable.getLicenseFailed(error: error))
+
 			// TODO: Should we update this to handle proper conversion from TidalError, otherwise they will always be EUnexpected
 			let playerError = PlayerInternalError.from(error)
 

--- a/Sources/Player/Common/DRM/FairPlayLicenseFetcher.swift
+++ b/Sources/Player/Common/DRM/FairPlayLicenseFetcher.swift
@@ -113,6 +113,8 @@ private extension FairPlayLicenseFetcher {
 			return license
 
 		} catch {
+			PlayerWorld.logger?.log(loggable: PlayerLoggable.getPlaybackInfo(error: error))
+			
 			// TODO: Should we update this to handle proper conversion from TidalError, otherwise they will always be EUnexpected
 			let playerError = PlayerInternalError.from(error)
 

--- a/Sources/Player/Common/DRM/StoredLicenseLoader.swift
+++ b/Sources/Player/Common/DRM/StoredLicenseLoader.swift
@@ -32,6 +32,7 @@ extension StoredLicenseLoader: AVContentKeySessionDelegate {
 				try keyRequest.respondByRequestingPersistableContentKeyRequest()
 			#endif
 		} catch {
+			PlayerWorld.logger()?.log(loggable: PlayerLoggable.licenseLoaderContentKeyRequestFailed(error: error))
 			keyRequest.processContentKeyResponseError(error)
 		}
 	}
@@ -45,6 +46,7 @@ extension StoredLicenseLoader: AVContentKeySessionDelegate {
 				let license = try await getLicense()
 				keyRequest.processContentKeyResponse(AVContentKeyResponse(fairPlayStreamingKeyResponseData: license))
 			} catch {
+				PlayerWorld.logger()?.log(loggable: PlayerLoggable.licenseLoaderProcessContentKeyResponseFailed(error: error))
 				keyRequest.processContentKeyResponseError(error)
 			}
 		}

--- a/Sources/Player/Common/DRM/StreamingLicenseLoader.swift
+++ b/Sources/Player/Common/DRM/StreamingLicenseLoader.swift
@@ -43,6 +43,7 @@ extension StreamingLicenseLoader: AVContentKeySessionDelegate {
 				let license = try await getLicense()
 				keyRequest.processContentKeyResponse(AVContentKeyResponse(fairPlayStreamingKeyResponseData: license))
 			} catch {
+				PlayerWorld.logger()?.log(loggable: PlayerLoggable.streamingGetLicenseFailed(error: error))
 				keyRequest.processContentKeyResponseError(error)
 			}
 		}

--- a/Sources/Player/Common/HttpClient/HttpClient.swift
+++ b/Sources/Player/Common/HttpClient/HttpClient.swift
@@ -165,6 +165,7 @@ private extension HttpClient {
 		do {
 			return try encoder.encode(data)
 		} catch {
+			PlayerWorld.logger()?.log(loggable: PlayerLoggable.payloadEncodingFailed(error: error))
 			throw ErrorCode.encodeFailed.toPlayerInternalError(description: String(describing: error))
 		}
 	}
@@ -173,6 +174,7 @@ private extension HttpClient {
 		do {
 			return try decoder.decode(T.self, from: data)
 		} catch {
+			PlayerWorld.logger()?.log(loggable: PlayerLoggable.payloadDecodingFailed(error: error))
 			throw ErrorCode.decodeFailed.toPlayerInternalError(description: String(describing: error))
 		}
 	}
@@ -231,6 +233,7 @@ extension URLSession {
 			let (data, response) = try await self.data(for: request)
 			return (response as? HTTPURLResponse, data)
 		} catch {
+			PlayerWorld.logger()?.log(loggable: PlayerLoggable.loadDataForRequestFailed(error: error))
 			throw HttpClient.mapURLError(error)
 		}
 	}

--- a/Sources/Player/Common/HttpClient/ResponseHandler.swift
+++ b/Sources/Player/Common/HttpClient/ResponseHandler.swift
@@ -36,6 +36,7 @@ final class ResponseHandler {
 		do {
 			return try await executionBlock(request)
 		} catch {
+			PlayerWorld.logger()?.log(loggable: PlayerLoggable.backoffHandleResponseFailed(error: error))
 			let retryStrategy: RetryStrategy = if isTimeoutError(error: error) {
 				timeoutErrorManager.onError(error, attemptCount: attemptCount)
 			} else {

--- a/Sources/Player/Common/Logging/PlayerLoggable.swift
+++ b/Sources/Player/Common/Logging/PlayerLoggable.swift
@@ -1,0 +1,169 @@
+import Common
+import Foundation
+
+private enum Constants {
+	static let metadataErrorKey = "error"
+}
+
+enum PlayerLoggable: TidalLoggable {
+	
+	// MARK: Event Sender
+	case sendEventOfflinePlay(error: Error)
+	case sendLegacyEvent(error: Error)
+	case migrateLegacyDirectory(error: Error)
+	case writeEventNotAuthorized
+	case writeEvent(error: Error)
+	case sendToEventProducerSerializationFail
+	case sendToEventProducer(error: Error)
+	case sendEventsNotAuthorized
+	case sendEvents(error: Error)
+
+	// MARK: Streaming Privileges
+	case streamingNotify(error: Error)
+	case streamingConnect(error: Error)
+
+	// MARK: Playback Info Fetcher
+	case getPlaybackInfo(error: Error)
+
+	// MARK: FairPlay License Fetcher
+	case getLicense(error: Error)
+
+	// MARK: Credentials Provider
+	case getAuthBearerToken
+
+	// MARK: Credentials Success Data Parser
+	case clientIdFromToken(error: Error)
+
+	// MARK: Download Task
+	case downloadFailed(error: Error)
+	case downloadFinalizeFailed(error: Error)
+
+	// MARK: Offline Engine
+	case deleteOfflineItem(error: Error)
+
+	// MARK: Asset Cache Legacy
+	case deleteAssetCache(error: Error)
+}
+
+// MARK: - Logging
+extension PlayerLoggable {
+
+	var loggingMessage: String {
+		return switch self {
+		// Event Sender
+		case .sendEventOfflinePlay:
+			"EventSender-sendEventOfflinePlay"
+		case .sendLegacyEvent:
+			"EventSender-sendLegacyEvent"
+		case .migrateLegacyDirectory:
+			"EventSender-migrateLegacyDirectory"
+		case .writeEventNotAuthorized:
+			"EventSender-writeEventNotAuthorized"
+		case .writeEvent:
+			"EventSender-writeEvent"
+		case .sendToEventProducerSerializationFail:
+			"EventSender-sendToEventProducerSerializationFail"
+		case .sendToEventProducer:
+			"EventSender-sendToEventProducer"
+		case .sendEventsNotAuthorized:
+			"EventSender-sendEventsNotAuthorized"
+		case .sendEvents:
+			"EventSender-sendEvents"
+
+		// Streaming Privileges
+		case .streamingNotify:
+			"StreamingPrivileges-streamingNotify"
+		case .streamingConnect:
+			"StreamingPrivileges-streamingConnect"
+
+		// Playback Info Fetcher
+		case .getPlaybackInfo:
+			"PlaybackInfoFetcher-getPlaybackInfo"
+
+		// FairPlay License Fetcher
+		case .getLicense:
+			"FairPlayLicenseFetcher-getLicense"
+
+		// Credentials Provider
+		case .getAuthBearerToken:
+			"CredentialsProvider-getAuthBearerToken"
+
+		// Credentials Success Data Parser
+		case .clientIdFromToken:
+			"CredentialsSuccessDataParser-clientIdFromToken"
+
+		// Download Task
+		case .downloadFailed:
+			"DownloadTask-downloadFailed"
+		case .downloadFinalizeFailed:
+			"DownloadTask-downloadFinalizeFailed"
+
+		// Offline Engine
+		case .deleteOfflineItem:
+			"OfflineEngine-deleteOfflineItem"
+
+		// Asset Cache Legacy
+		case .deleteAssetCache:
+			"AssetCacheLegacy-deleteAssetCache"
+		}
+	}
+
+	var loggingMetadata: [String: String] {
+		var metadata = [String: String]()
+
+		switch self {
+		case let .sendEventOfflinePlay(error), 
+			let .sendLegacyEvent(error),
+			let .migrateLegacyDirectory(error),
+			let .writeEvent(error), 
+			let .sendToEventProducer(error),
+			let .sendEvents(error),
+			let .streamingNotify(error),
+			let .streamingConnect(error),
+			let .getPlaybackInfo(error),
+			let .getLicense(error),
+			let .clientIdFromToken(error),
+			let .downloadFailed(error),
+			let .downloadFinalizeFailed(error),
+			let .deleteOfflineItem(error),
+			let .deleteAssetCache(error):
+			metadata[Constants.metadataErrorKey] = String(describing: error)
+		case .writeEventNotAuthorized,
+				.sendToEventProducerSerializationFail,
+				.sendEventsNotAuthorized,
+				.getAuthBearerToken:
+			break
+		}
+
+		return metadata
+	}
+
+	var logLevel: LoggingLevel {
+		switch self {
+		case .sendEventOfflinePlay,
+				.sendLegacyEvent,
+				.migrateLegacyDirectory,
+				.writeEventNotAuthorized,
+				.writeEvent,
+				.sendToEventProducer,
+				.sendToEventProducerSerializationFail,
+				.sendEventsNotAuthorized,
+				.sendEvents, 
+				.streamingNotify,
+				.streamingConnect,
+				.getPlaybackInfo,
+				.getLicense,
+				.getAuthBearerToken,
+				.clientIdFromToken,
+				.downloadFailed,
+				.downloadFinalizeFailed,
+				.deleteOfflineItem,
+				.deleteAssetCache:
+			return .error
+		}
+	}
+
+	var source: String {
+		"Player"
+	}
+}

--- a/Sources/Player/Common/Logging/PlayerLoggable.swift
+++ b/Sources/Player/Common/Logging/PlayerLoggable.swift
@@ -8,41 +8,91 @@ private enum Constants {
 enum PlayerLoggable: TidalLoggable {
 	
 	// MARK: Event Sender
-	case sendEventOfflinePlay(error: Error)
-	case sendLegacyEvent(error: Error)
-	case migrateLegacyDirectory(error: Error)
+	case sendEventOfflinePlayFailed(error: Error)
+	case sendLegacyEventFailed(error: Error)
+	case migrateLegacyDirectoryFailed(error: Error)
 	case writeEventNotAuthorized
-	case writeEvent(error: Error)
-	case sendToEventProducerSerializationFail
-	case sendToEventProducer(error: Error)
+	case writeEventFailed(error: Error)
+	case sendToEventProducerSerializationFailed
+	case sendToEventProducerFailed(error: Error)
 	case sendEventsNotAuthorized
-	case sendEvents(error: Error)
+	case sendEventsFailed(error: Error)
+	case urlForDirectoryFailed(error: Error)
+	case initializeDirectoryFailed(error: Error)
 
 	// MARK: Streaming Privileges
-	case streamingNotify(error: Error)
-	case streamingConnect(error: Error)
+	case streamingNotifyNotAuthorized(error: Error)
+	case streamingConnectNotAuthorized(error: Error)
+	case webSocketSendMessageFailed(error: Error)
+	case webSocketReceiveMessageFailed(error: Error)
+	case webSocketHandleErrorSleepAndReconnectionFailed(error: Error)
 
 	// MARK: Playback Info Fetcher
-	case getPlaybackInfo(error: Error)
+	case getPlaybackInfoFailed(error: Error)
 
 	// MARK: FairPlay License Fetcher
-	case getLicense(error: Error)
+	case getLicenseFailed(error: Error)
 
 	// MARK: Credentials Provider
-	case getAuthBearerToken
+	case getAuthBearerTokenCredentialFailed(error: Error)
+	case getAuthBearerTokenToBearerTokenFailed
 
 	// MARK: Credentials Success Data Parser
-	case clientIdFromToken(error: Error)
+	case credentialsSuccessParserParsingFailed(error: Error)
 
 	// MARK: Download Task
 	case downloadFailed(error: Error)
 	case downloadFinalizeFailed(error: Error)
 
 	// MARK: Offline Engine
-	case deleteOfflineItem(error: Error)
+	case deleteOfflinedItem(error: Error)
 
 	// MARK: Asset Cache Legacy
-	case deleteAssetCache(error: Error)
+	case deleteAssetCacheFailed(error: Error)
+
+	// MARK: StoredLicenseLoader
+	case licenseLoaderContentKeyRequestFailed(error: Error)
+	case licenseLoaderProcessContentKeyResponseFailed(error: Error) // swiftlint:disable:this identifier_name
+
+	// MARK: StreamingLicenseLoader
+	case streamingGetLicenseFailed(error: Error)
+
+	// MARK: HttpClient
+	case payloadEncodingFailed(error: Error)
+	case payloadDecodingFailed(error: Error)
+
+	// MARK: URLSession
+	case loadDataForRequestFailed(error: Error)
+
+	// MARK: ResponseHandler
+	case backoffHandleResponseFailed(error: Error)
+
+	// MARK: Downloader
+	case startDownloadFailed(error: Error)
+
+	// MARK: LicenseDownloader
+	case licenseDownloaderContentKeyRequestFailed(error: Error)
+	case licenseDownloaderGetLicenseFailed(error: Error)
+
+	// MARK: MediaDownloader
+	case downloadFinishedMovingFileFailed(error: Error)
+
+	// MARK: AVQueuePlayerWrapperLegacy
+	case legacyReadPlaybackMetadataFailed(error: Error)
+
+	// MARK: AVQueuePlayerWrapper
+	case readPlaybackMetadataFailed(error: Error)
+
+	// MARK: DJProducer
+	case djSessionStartFailed(error: Error)
+	case djSessionSendCommandFailed(error: Error)
+
+	// MARK: InternalPlayerLoader
+	case loadUCFailed(error: Error)
+
+	// MARK: PlayerEngine
+	case loadPlayerItemFailed(error: Error)
+
 }
 
 // MARK: - Logging
@@ -51,46 +101,58 @@ extension PlayerLoggable {
 	var loggingMessage: String {
 		return switch self {
 		// Event Sender
-		case .sendEventOfflinePlay:
-			"EventSender-sendEventOfflinePlay"
-		case .sendLegacyEvent:
-			"EventSender-sendLegacyEvent"
-		case .migrateLegacyDirectory:
-			"EventSender-migrateLegacyDirectory"
+		case .sendEventOfflinePlayFailed:
+			"EventSender-sendEventOfflinePlayFailed"
+		case .sendLegacyEventFailed:
+			"EventSender-sendLegacyEventFailed"
+		case .migrateLegacyDirectoryFailed:
+			"EventSender-migrateLegacyDirectoryFailed"
 		case .writeEventNotAuthorized:
 			"EventSender-writeEventNotAuthorized"
-		case .writeEvent:
-			"EventSender-writeEvent"
-		case .sendToEventProducerSerializationFail:
-			"EventSender-sendToEventProducerSerializationFail"
-		case .sendToEventProducer:
-			"EventSender-sendToEventProducer"
+		case .writeEventFailed:
+			"EventSender-writeEventFailed"
+		case .sendToEventProducerSerializationFailed:
+			"EventSender-sendToEventProducerSerializationFailed"
+		case .sendToEventProducerFailed:
+			"EventSender-sendToEventProducerFailed"
 		case .sendEventsNotAuthorized:
 			"EventSender-sendEventsNotAuthorized"
-		case .sendEvents:
-			"EventSender-sendEvents"
+		case .sendEventsFailed:
+			"EventSender-sendEventsFailed"
+		case .urlForDirectoryFailed:
+			"EventSender-urlForDirectoryFailed"
+		case .initializeDirectoryFailed:
+			"EventSender-initializeDirectoryFailed"
 
 		// Streaming Privileges
-		case .streamingNotify:
-			"StreamingPrivileges-streamingNotify"
-		case .streamingConnect:
-			"StreamingPrivileges-streamingConnect"
+		case .streamingNotifyNotAuthorized:
+			"StreamingPrivileges-streamingNotifyNotAuthorized"
+		case .streamingConnectNotAuthorized:
+			"StreamingPrivileges-streamingConnectNotAuthorized"
+		case .webSocketSendMessageFailed:
+			"StreamingPrivileges-webSocketSendMessageFailed"
+		case .webSocketReceiveMessageFailed:
+			"StreamingPrivileges-webSocketReceiveMessageFailed"
+		case .webSocketHandleErrorSleepAndReconnectionFailed:
+			"StreamingPrivileges-webSocketHandleErrorSleepAndReconnectionFailed"
 
 		// Playback Info Fetcher
-		case .getPlaybackInfo:
-			"PlaybackInfoFetcher-getPlaybackInfo"
+		case .getPlaybackInfoFailed:
+			"PlaybackInfoFetcher-getPlaybackInfoFailed"
 
 		// FairPlay License Fetcher
-		case .getLicense:
-			"FairPlayLicenseFetcher-getLicense"
+		case .getLicenseFailed:
+			"FairPlayLicenseFetcher-getLicenseFailed"
 
 		// Credentials Provider
-		case .getAuthBearerToken:
-			"CredentialsProvider-getAuthBearerToken"
+		case .getAuthBearerTokenCredentialFailed:
+			"CredentialsProvider-getAuthBearerTokenCredentialFailed"
+		case .getAuthBearerTokenToBearerTokenFailed:
+			"CredentialsProvider-getAuthBearerTokenToBearerTokenFailed"
 
 		// Credentials Success Data Parser
-		case .clientIdFromToken:
-			"CredentialsSuccessDataParser-clientIdFromToken"
+		case .credentialsSuccessParserParsingFailed:
+			"CredentialsSuccessDataParser-parsingFailed"
 
 		// Download Task
 		case .downloadFailed:
@@ -99,12 +161,72 @@ extension PlayerLoggable {
 			"DownloadTask-downloadFinalizeFailed"
 
 		// Offline Engine
-		case .deleteOfflineItem:
-			"OfflineEngine-deleteOfflineItem"
+		case .deleteOfflinedItem:
+			"OfflineEngine-deleteOfflinedItem"
 
 		// Asset Cache Legacy
-		case .deleteAssetCache:
-			"AssetCacheLegacy-deleteAssetCache"
+		case .deleteAssetCacheFailed:
+			"AssetCacheLegacy-deleteAssetCacheFailed"
+
+		// StoredLicenseLoader
+		case .licenseLoaderContentKeyRequestFailed:
+			"StoredLicenseLoader-contentKeyRequestFailed"
+		case .licenseLoaderProcessContentKeyResponseFailed:
+			"StoredLicenseLoader-processContentKeyResponseFailed"
+
+		// StreamingLicenseLoader
+		case .streamingGetLicenseFailed:
+			"StreamingLicenseLoader-streamingGetLicense"
+
+		// HttpClient
+		case .payloadEncodingFailed:
+			"HttpClient-payloadEncodingFailed"
+		case .payloadDecodingFailed:
+			"HttpClient-payloadDecodingFailed"
+
+		// URLSession
+		case .loadDataForRequestFailed:
+			"URLSession-loadDataForRequestFailed"
+
+		// ResponseHandler
+		case .backoffHandleResponseFailed:
+			"ResponseHandler-backoffHandleResponseFailed"
+
+		// Downloader
+		case .startDownloadFailed:
+			"Downloader-startDownloadFailed"
+
+		// LicenseDownloader
+		case .licenseDownloaderContentKeyRequestFailed:
+			"LicenseDownloader-contentKeyRequestFailed"
+		case .licenseDownloaderGetLicenseFailed:
+			"LicenseDownloader-getLicenseFailed"
+
+		// MediaDownloader
+		case .downloadFinishedMovingFileFailed:
+			"MediaDownloader-downloadFinishedMovingFileFailed"
+
+		// AVQueuePlayerWrapperLegacy
+		case .legacyReadPlaybackMetadataFailed:
+			"AVQueuePlayerWrapperLegacy-legacyReadPlaybackMetadataFailed"
+
+		// AVQueuePlayerWrapper
+		case .readPlaybackMetadataFailed:
+			"AVQueuePlayerWrapper-readPlaybackMetadataFailed"
+
+		// DJProducer
+		case .djSessionStartFailed:
+			"DJProducer-djSessionStartFailed"
+		case .djSessionSendCommandFailed:
+			"DJProducer-djSessionSendCommandFailed"
+
+		// InternalPlayerLoader
+		case .loadUCFailed:
+			"InternalPlayerLoader-loadUCFailed"
+
+		// PlayerEngine
+		case .loadPlayerItemFailed:
+			"PlayerEngine-loadPlayerItemFailed"
 		}
 	}
 
@@ -112,26 +234,49 @@ extension PlayerLoggable {
 		var metadata = [String: String]()
 
 		switch self {
-		case let .sendEventOfflinePlay(error), 
-			let .sendLegacyEvent(error),
-			let .migrateLegacyDirectory(error),
-			let .writeEvent(error), 
-			let .sendToEventProducer(error),
-			let .sendEvents(error),
-			let .streamingNotify(error),
-			let .streamingConnect(error),
-			let .getPlaybackInfo(error),
-			let .getLicense(error),
-			let .clientIdFromToken(error),
+		case let .sendEventOfflinePlayFailed(error), 
+			let .sendLegacyEventFailed(error),
+			let .migrateLegacyDirectoryFailed(error),
+			let .writeEventFailed(error), 
+			let .sendToEventProducerFailed(error),
+			let .sendEventsFailed(error),
+			let .urlForDirectoryFailed(error),
+			let .initializeDirectoryFailed(error),
+			let .streamingNotifyNotAuthorized(error),
+			let .streamingConnectNotAuthorized(error),
+			let .webSocketSendMessageFailed(error),
+			let .webSocketReceiveMessageFailed(error),
+			let .webSocketHandleErrorSleepAndReconnectionFailed(error),
+			let .getPlaybackInfoFailed(error),
+			let .getLicenseFailed(error),
+			let .credentialsSuccessParserParsingFailed(error),
 			let .downloadFailed(error),
 			let .downloadFinalizeFailed(error),
-			let .deleteOfflineItem(error),
-			let .deleteAssetCache(error):
+			let .deleteOfflinedItem(error),
+			let .deleteAssetCacheFailed(error),
+			let .getAuthBearerTokenCredentialFailed(error),
+			let .licenseLoaderContentKeyRequestFailed(error),
+			let .licenseLoaderProcessContentKeyResponseFailed(error),
+			let .streamingGetLicenseFailed(error),
+			let .payloadEncodingFailed(error),
+			let .payloadDecodingFailed(error),
+			let .loadDataForRequestFailed(error),
+			let .backoffHandleResponseFailed(error),
+			let .startDownloadFailed(error),
+			let .licenseDownloaderContentKeyRequestFailed(error),
+			let .licenseDownloaderGetLicenseFailed(error),
+			let .downloadFinishedMovingFileFailed(error),
+			let .legacyReadPlaybackMetadataFailed(error),
+			let .readPlaybackMetadataFailed(error),
+			let .djSessionStartFailed(error),
+			let .djSessionSendCommandFailed(error),
+			let .loadUCFailed(error),
+			let .loadPlayerItemFailed(error):
 			metadata[Constants.metadataErrorKey] = String(describing: error)
 		case .writeEventNotAuthorized,
-				.sendToEventProducerSerializationFail,
+				.sendToEventProducerSerializationFailed,
 				.sendEventsNotAuthorized,
-				.getAuthBearerToken:
+				.getAuthBearerTokenToBearerTokenFailed:
 			break
 		}
 
@@ -140,25 +285,48 @@ extension PlayerLoggable {
 
 	var logLevel: LoggingLevel {
 		switch self {
-		case .sendEventOfflinePlay,
-				.sendLegacyEvent,
-				.migrateLegacyDirectory,
+		case .sendEventOfflinePlayFailed,
+				.sendLegacyEventFailed,
+				.migrateLegacyDirectoryFailed,
 				.writeEventNotAuthorized,
-				.writeEvent,
-				.sendToEventProducer,
-				.sendToEventProducerSerializationFail,
+				.writeEventFailed,
+				.sendToEventProducerFailed,
+				.sendToEventProducerSerializationFailed,
 				.sendEventsNotAuthorized,
-				.sendEvents, 
-				.streamingNotify,
-				.streamingConnect,
-				.getPlaybackInfo,
-				.getLicense,
-				.getAuthBearerToken,
-				.clientIdFromToken,
+				.sendEventsFailed, 
+				.urlForDirectoryFailed,
+				.initializeDirectoryFailed,
+				.streamingNotifyNotAuthorized,
+				.streamingConnectNotAuthorized,
+				.webSocketSendMessageFailed,
+				.webSocketReceiveMessageFailed,
+				.webSocketHandleErrorSleepAndReconnectionFailed,
+				.getPlaybackInfoFailed,
+				.getLicenseFailed,
+				.getAuthBearerTokenCredentialFailed,
+				.credentialsSuccessParserParsingFailed,
 				.downloadFailed,
 				.downloadFinalizeFailed,
-				.deleteOfflineItem,
-				.deleteAssetCache:
+				.deleteOfflinedItem,
+				.deleteAssetCacheFailed,
+				.getAuthBearerTokenToBearerTokenFailed,
+				.licenseLoaderContentKeyRequestFailed,
+				.licenseLoaderProcessContentKeyResponseFailed,
+				.streamingGetLicenseFailed,
+				.payloadEncodingFailed,
+				.payloadDecodingFailed,
+				.loadDataForRequestFailed,
+				.backoffHandleResponseFailed,
+				.startDownloadFailed,
+				.licenseDownloaderContentKeyRequestFailed,
+				.licenseDownloaderGetLicenseFailed,
+				.downloadFinishedMovingFileFailed,
+				.legacyReadPlaybackMetadataFailed,
+				.readPlaybackMetadataFailed,
+				.djSessionStartFailed,
+				.djSessionSendCommandFailed,
+				.loadUCFailed,
+				.loadPlayerItemFailed:
 			return .error
 		}
 	}

--- a/Sources/Player/Common/Logging/TidalLogger+Noop.swift
+++ b/Sources/Player/Common/Logging/TidalLogger+Noop.swift
@@ -1,0 +1,5 @@
+import Common
+
+extension TidalLogger {
+	static let noop: () -> TidalLogger? = { nil }
+}

--- a/Sources/Player/Common/PlaybackInfo/PlaybackInfoFetcher.swift
+++ b/Sources/Player/Common/PlaybackInfo/PlaybackInfoFetcher.swift
@@ -303,7 +303,7 @@ private extension PlaybackInfoFetcher {
 			return playbackInfo
 
 		} catch {
-			PlayerWorld.logger?.log(loggable: PlayerLoggable.getPlaybackInfo(error: error))
+			PlayerWorld.logger()?.log(loggable: PlayerLoggable.getPlaybackInfoFailed(error: error))
 
 			// TODO: Should we update this to handle proper conversion from TidalError, otherwise they will always be EUnexpected
 			let error = PlaybackInfoErrorResponseConverter.convert(error)

--- a/Sources/Player/Common/PlaybackInfo/PlaybackInfoFetcher.swift
+++ b/Sources/Player/Common/PlaybackInfo/PlaybackInfoFetcher.swift
@@ -303,8 +303,10 @@ private extension PlaybackInfoFetcher {
 			return playbackInfo
 
 		} catch {
-			let error = PlaybackInfoErrorResponseConverter.convert(error)
+			PlayerWorld.logger?.log(loggable: PlayerLoggable.getPlaybackInfo(error: error))
+
 			// TODO: Should we update this to handle proper conversion from TidalError, otherwise they will always be EUnexpected
+			let error = PlaybackInfoErrorResponseConverter.convert(error)
 			let playerError = PlayerInternalError.from(error)
 
 			let endTimestamp = PlayerWorld.timeProvider.timestamp()

--- a/Sources/Player/Common/World/PlayerWorldClient.swift
+++ b/Sources/Player/Common/World/PlayerWorldClient.swift
@@ -13,16 +13,25 @@ struct PlayerWorldClient {
 	var developmentFeatureFlagProvider: DevelopmentFeatureFlagProvider
 	var fileManagerClient: FileManagerClient
 	var asyncSchedulerFactoryProvider: AsyncSchedulerFactoryProvider
+	/// Optional logger
+	var logger: TidalLogger?
 }
 
 extension PlayerWorldClient {
-	static let live = PlayerWorldClient(
-		audioInfoProvider: .live,
-		deviceInfoProvider: .live,
-		timeProvider: .live,
-		uuidProvider: .live,
-		developmentFeatureFlagProvider: .live,
-		fileManagerClient: .live,
-		asyncSchedulerFactoryProvider: .live
-	)
+	/// - Attention: If logging is not desired, use `nil` instead of `.live`, which is the default..
+	/// ```
+	/// PlayerWorldClient.live(logger: nil)
+	/// ```
+	static func live(logger: TidalLogger? = .live) -> PlayerWorldClient {
+		PlayerWorldClient(
+			audioInfoProvider: .live,
+			deviceInfoProvider: .live,
+			timeProvider: .live,
+			uuidProvider: .live,
+			developmentFeatureFlagProvider: .live,
+			fileManagerClient: .live,
+			asyncSchedulerFactoryProvider: .live,
+			logger: logger
+		)
+	}
 }

--- a/Sources/Player/Common/World/PlayerWorldClient.swift
+++ b/Sources/Player/Common/World/PlayerWorldClient.swift
@@ -13,16 +13,11 @@ struct PlayerWorldClient {
 	var developmentFeatureFlagProvider: DevelopmentFeatureFlagProvider
 	var fileManagerClient: FileManagerClient
 	var asyncSchedulerFactoryProvider: AsyncSchedulerFactoryProvider
-	/// Optional logger
-	var logger: TidalLogger?
+	var logger: () -> TidalLogger?
 }
 
 extension PlayerWorldClient {
-	/// - Attention: If logging is not desired, use `nil` instead of `.live`, which is the default..
-	/// ```
-	/// PlayerWorldClient.live(logger: nil)
-	/// ```
-	static func live(logger: TidalLogger? = .live) -> PlayerWorldClient {
+	static func live() -> PlayerWorldClient {
 		PlayerWorldClient(
 			audioInfoProvider: .live,
 			deviceInfoProvider: .live,
@@ -31,7 +26,7 @@ extension PlayerWorldClient {
 			developmentFeatureFlagProvider: .live,
 			fileManagerClient: .live,
 			asyncSchedulerFactoryProvider: .live,
-			logger: logger
+			logger: TidalLogger.noop
 		)
 	}
 }

--- a/Sources/Player/OfflineEngine/Internal/DownloadTask.swift
+++ b/Sources/Player/OfflineEngine/Internal/DownloadTask.swift
@@ -113,6 +113,7 @@ final class DownloadTask {
 			try fileManager.removeItem(at: localAssetUrl)
 			try fileManager.removeItem(at: localLicenseUrl)
 		} catch {
+			PlayerWorld.logger?.log(loggable: PlayerLoggable.downloadFailed(error: error))
 			print("Failed to remove item: \(error)")
 		}
 	}
@@ -133,6 +134,7 @@ private extension DownloadTask {
 			monitor?.completed(downloadTask: self, storageItem: storageItem)
 			endTimestamp = PlayerWorld.timeProvider.timestamp()
 		} catch {
+			PlayerWorld.logger?.log(loggable: PlayerLoggable.downloadFinalizeFailed(error: error))
 			failed(with: error)
 		}
 	}

--- a/Sources/Player/OfflineEngine/Internal/DownloadTask.swift
+++ b/Sources/Player/OfflineEngine/Internal/DownloadTask.swift
@@ -113,7 +113,7 @@ final class DownloadTask {
 			try fileManager.removeItem(at: localAssetUrl)
 			try fileManager.removeItem(at: localLicenseUrl)
 		} catch {
-			PlayerWorld.logger?.log(loggable: PlayerLoggable.downloadFailed(error: error))
+			PlayerWorld.logger()?.log(loggable: PlayerLoggable.downloadFailed(error: error))
 			print("Failed to remove item: \(error)")
 		}
 	}
@@ -134,7 +134,7 @@ private extension DownloadTask {
 			monitor?.completed(downloadTask: self, storageItem: storageItem)
 			endTimestamp = PlayerWorld.timeProvider.timestamp()
 		} catch {
-			PlayerWorld.logger?.log(loggable: PlayerLoggable.downloadFinalizeFailed(error: error))
+			PlayerWorld.logger()?.log(loggable: PlayerLoggable.downloadFinalizeFailed(error: error))
 			failed(with: error)
 		}
 	}

--- a/Sources/Player/OfflineEngine/Internal/Downloader.swift
+++ b/Sources/Player/OfflineEngine/Internal/Downloader.swift
@@ -60,6 +60,7 @@ private extension Downloader {
 			downloadMedia(for: downloadTask, using: playbackInfo)
 
 		} catch {
+			PlayerWorld.logger()?.log(loggable: PlayerLoggable.startDownloadFailed(error: error))
 			failed(downloadTask: downloadTask, with: error)
 		}
 	}

--- a/Sources/Player/OfflineEngine/Internal/LicenseDownloader.swift
+++ b/Sources/Player/OfflineEngine/Internal/LicenseDownloader.swift
@@ -40,6 +40,7 @@ extension LicenseDownloader: AVContentKeySessionDelegate {
 				try keyRequest.respondByRequestingPersistableContentKeyRequest()
 			#endif
 		} catch {
+			PlayerWorld.logger()?.log(loggable: PlayerLoggable.licenseDownloaderContentKeyRequestFailed(error: error))
 			downloadTask.failed(with: error)
 		}
 	}
@@ -59,6 +60,7 @@ extension LicenseDownloader: AVContentKeySessionDelegate {
 				try self.store(license, for: downloadTask)
 
 			} catch {
+				PlayerWorld.logger()?.log(loggable: PlayerLoggable.licenseDownloaderGetLicenseFailed(error: error))
 				downloadTask?.failed(with: error)
 			}
 		}

--- a/Sources/Player/OfflineEngine/Internal/MediaDownloader.swift
+++ b/Sources/Player/OfflineEngine/Internal/MediaDownloader.swift
@@ -94,6 +94,7 @@ extension MediaDownloader: AVAssetDownloadDelegate, URLSessionDownloadDelegate {
 			try fileManager.moveFile(location, url)
 			tasks[downloadTask]?.setMediaUrl(url)
 		} catch {
+			PlayerWorld.logger()?.log(loggable: PlayerLoggable.downloadFinishedMovingFileFailed(error: error))
 			tasks[downloadTask]?.failed(with: error)
 		}
 	}

--- a/Sources/Player/OfflineEngine/OfflineEngine.swift
+++ b/Sources/Player/OfflineEngine/OfflineEngine.swift
@@ -95,7 +95,7 @@ private extension OfflineEngine {
 			try fileManager.removeItem(at: licenseUrl)
 			storage.delete(mediaProduct: mediaProduct)
 		} catch {
-			PlayerWorld.logger?.log(loggable: PlayerLoggable.deleteOfflineItem(error: error))
+			PlayerWorld.logger()?.log(loggable: PlayerLoggable.deleteOfflinedItem(error: error))
 			print("Failed to remove item: \(error)")
 		}
 	}

--- a/Sources/Player/OfflineEngine/OfflineEngine.swift
+++ b/Sources/Player/OfflineEngine/OfflineEngine.swift
@@ -95,6 +95,7 @@ private extension OfflineEngine {
 			try fileManager.removeItem(at: licenseUrl)
 			storage.delete(mediaProduct: mediaProduct)
 		} catch {
+			PlayerWorld.logger?.log(loggable: PlayerLoggable.deleteOfflineItem(error: error))
 			print("Failed to remove item: \(error)")
 		}
 	}

--- a/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/AVQueuePlayerWrapper.swift
+++ b/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/AVQueuePlayerWrapper.swift
@@ -459,6 +459,7 @@ private extension AVQueuePlayerWrapper {
 
 			return AssetPlaybackMetadata(sampleRate: sampleRate, formatFlags: bitdepthFlags)
 		} catch {
+			PlayerWorld.logger()?.log(loggable: PlayerLoggable.readPlaybackMetadataFailed(error: error))
 			return nil
 		}
 	}

--- a/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/Legacy/AVQueuePlayerWrapperLegacy.swift
+++ b/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/Legacy/AVQueuePlayerWrapperLegacy.swift
@@ -396,6 +396,7 @@ private extension AVQueuePlayerWrapperLegacy {
 
 			return AssetPlaybackMetadata(sampleRate: sampleRate, formatFlags: bitdepthFlags)
 		} catch {
+			PlayerWorld.logger()?.log(loggable: PlayerLoggable.legacyReadPlaybackMetadataFailed(error: error))
 			return nil
 		}
 	}

--- a/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/Legacy/AssetCacheLegacy.swift
+++ b/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/Legacy/AssetCacheLegacy.swift
@@ -43,6 +43,7 @@ private extension AssetCacheLegacy {
 			try fileManager.removeItem(at: url)
 			userDefaults.removeObjectForKey(key)
 		} catch {
+			PlayerWorld.logger?.log(loggable: PlayerLoggable.deleteAssetCache(error: error))
 			print("Failed to remove item: \(error)")
 		}
 	}

--- a/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/Legacy/AssetCacheLegacy.swift
+++ b/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/Legacy/AssetCacheLegacy.swift
@@ -43,7 +43,7 @@ private extension AssetCacheLegacy {
 			try fileManager.removeItem(at: url)
 			userDefaults.removeObjectForKey(key)
 		} catch {
-			PlayerWorld.logger?.log(loggable: PlayerLoggable.deleteAssetCache(error: error))
+			PlayerWorld.logger()?.log(loggable: PlayerLoggable.deleteAssetCacheFailed(error: error))
 			print("Failed to remove item: \(error)")
 		}
 	}

--- a/Sources/Player/PlaybackEngine/Internal/Broadcasting/DJProducer.swift
+++ b/Sources/Player/PlaybackEngine/Internal/Broadcasting/DJProducer.swift
@@ -56,6 +56,7 @@ final class DJProducer {
 				self.delegate?.djSessionStarted(metadata: sessionData)
 				self.curationUrl = response.curationUrl
 			} catch {
+				PlayerWorld.logger()?.log(loggable: PlayerLoggable.djSessionStartFailed(error: error))
 				self.delegate?.djSessionEnded(reason: .failedToStart(code: DJProducer.errorCode(from: error)))
 			}
 
@@ -134,6 +135,7 @@ private extension DJProducer {
 		do {
 			_ = try await httpClient.putJsonReceiveData(url: url, headers: [:], payload: command)
 		} catch {
+			PlayerWorld.logger()?.log(loggable: PlayerLoggable.djSessionSendCommandFailed(error: error))
 			endSession(with: DJProducer.reason(from: error))
 		}
 	}

--- a/Sources/Player/PlaybackEngine/Internal/Events/PlayerEventSender.swift
+++ b/Sources/Player/PlaybackEngine/Internal/Events/PlayerEventSender.swift
@@ -87,7 +87,7 @@ class PlayerEventSender {
 				let url = offlinePlaysDirectory.appendingPathComponent(uuid)
 				try dataWriter.write(data: data, to: url, options: .atomic)
 			} catch {
-				PlayerWorld.logger?.log(loggable: PlayerLoggable.sendEventOfflinePlay(error: error))
+				PlayerWorld.logger()?.log(loggable: PlayerLoggable.sendEventOfflinePlayFailed(error: error))
 			}
 		}
 	}
@@ -103,7 +103,7 @@ class PlayerEventSender {
 			let url = eventsDirectory.appendingPathComponent(uuid)
 			try dataWriter.write(data: data, to: url, options: .atomic)
 		} catch {
-			PlayerWorld.logger?.log(loggable: PlayerLoggable.sendLegacyEvent(error: error))
+			PlayerWorld.logger()?.log(loggable: PlayerLoggable.sendLegacyEventFailed(error: error))
 		}
 	}
 }
@@ -122,6 +122,7 @@ private extension PlayerEventSender {
 
 			return url
 		} catch {
+			PlayerWorld.logger()?.log(loggable: PlayerLoggable.urlForDirectoryFailed(error: error))
 			return nil
 		}
 	}
@@ -138,7 +139,7 @@ private extension PlayerEventSender {
 				try fileManager.copyItem(at: sourceURL, to: destURL)
 				try fileManager.removeItem(at: sourceURL)
 			} catch {
-				PlayerWorld.logger?.log(loggable: PlayerLoggable.migrateLegacyDirectory(error: error))
+				PlayerWorld.logger()?.log(loggable: PlayerLoggable.migrateLegacyDirectoryFailed(error: error))
 				print("Could not migrate legacy events folder. \(String(describing: error))")
 			}
 		}
@@ -155,6 +156,7 @@ private extension PlayerEventSender {
 			}
 			return url
 		} catch {
+			PlayerWorld.logger()?.log(loggable: PlayerLoggable.initializeDirectoryFailed(error: error))
 			return nil
 		}
 	}
@@ -200,12 +202,12 @@ private extension PlayerEventSender {
 				token = authToken.toBearerToken()
 
 				guard authToken.isAuthorized else {
-					PlayerWorld.logger?.log(loggable: PlayerLoggable.writeEventNotAuthorized)
+					PlayerWorld.logger()?.log(loggable: PlayerLoggable.writeEventNotAuthorized)
 					print("EventSender succeeded to get credentials but user is not authorized.")
 					return
 				}
 			} catch {
-				PlayerWorld.logger?.log(loggable: PlayerLoggable.writeEvent(error: error))
+				PlayerWorld.logger()?.log(loggable: PlayerLoggable.writeEventFailed(error: error))
 				print("StreamingPrivilegesHandler failed to get credentials")
 				return
 			}
@@ -264,7 +266,7 @@ private extension PlayerEventSender {
 		do {
 			let data = try encoder.encode(event)
 			guard let serializedString = String(data: data, encoding: .utf8) else {
-				PlayerWorld.logger?.log(loggable: PlayerLoggable.sendToEventProducerSerializationFail)
+				PlayerWorld.logger()?.log(loggable: PlayerLoggable.sendToEventProducerSerializationFailed)
 				print("Unable to encode data from encoded event: \(event)")
 				return
 			}
@@ -276,7 +278,7 @@ private extension PlayerEventSender {
 				payload: serializedString
 			)
 		} catch {
-			PlayerWorld.logger?.log(loggable: PlayerLoggable.sendToEventProducer(error: error))
+			PlayerWorld.logger()?.log(loggable: PlayerLoggable.sendToEventProducerFailed(error: error))
 			print("Error when encoding event: \(event)")
 		}
 	}
@@ -309,7 +311,7 @@ private extension PlayerEventSender {
 				token = authToken.toBearerToken()
 
 				guard authToken.isAuthorized else {
-					PlayerWorld.logger?.log(loggable: PlayerLoggable.sendEventsNotAuthorized)
+					PlayerWorld.logger()?.log(loggable: PlayerLoggable.sendEventsNotAuthorized)
 					print("EventSender succeeded to get credentials but user is not authorized.")
 					return
 				}
@@ -327,7 +329,7 @@ private extension PlayerEventSender {
 				urls.forEach { try? self.fileManager.removeItem(at: $0) }
 
 			} catch {
-				PlayerWorld.logger?.log(loggable: PlayerLoggable.sendEvents(error: error))
+				PlayerWorld.logger()?.log(loggable: PlayerLoggable.sendEventsFailed(error: error))
 				print("Failed to send data to \(url) [\(String(describing: error))")
 			}
 		}

--- a/Sources/Player/PlaybackEngine/Internal/Events/PlayerEventSender.swift
+++ b/Sources/Player/PlaybackEngine/Internal/Events/PlayerEventSender.swift
@@ -87,7 +87,7 @@ class PlayerEventSender {
 				let url = offlinePlaysDirectory.appendingPathComponent(uuid)
 				try dataWriter.write(data: data, to: url, options: .atomic)
 			} catch {
-				// TODO: This error should be centrally logged
+				PlayerWorld.logger?.log(loggable: PlayerLoggable.sendEventOfflinePlay(error: error))
 			}
 		}
 	}
@@ -103,7 +103,7 @@ class PlayerEventSender {
 			let url = eventsDirectory.appendingPathComponent(uuid)
 			try dataWriter.write(data: data, to: url, options: .atomic)
 		} catch {
-			// TODO: This error should be centrally logged
+			PlayerWorld.logger?.log(loggable: PlayerLoggable.sendLegacyEvent(error: error))
 		}
 	}
 }
@@ -138,7 +138,7 @@ private extension PlayerEventSender {
 				try fileManager.copyItem(at: sourceURL, to: destURL)
 				try fileManager.removeItem(at: sourceURL)
 			} catch {
-				// TODO: This error should be centrally logged
+				PlayerWorld.logger?.log(loggable: PlayerLoggable.migrateLegacyDirectory(error: error))
 				print("Could not migrate legacy events folder. \(String(describing: error))")
 			}
 		}
@@ -200,12 +200,12 @@ private extension PlayerEventSender {
 				token = authToken.toBearerToken()
 
 				guard authToken.isAuthorized else {
-					// TODO: Should we log this error?
+					PlayerWorld.logger?.log(loggable: PlayerLoggable.writeEventNotAuthorized)
 					print("EventSender succeeded to get credentials but user is not authorized.")
 					return
 				}
 			} catch {
-				// TODO: Should we log this error?
+				PlayerWorld.logger?.log(loggable: PlayerLoggable.writeEvent(error: error))
 				print("StreamingPrivilegesHandler failed to get credentials")
 				return
 			}
@@ -264,7 +264,7 @@ private extension PlayerEventSender {
 		do {
 			let data = try encoder.encode(event)
 			guard let serializedString = String(data: data, encoding: .utf8) else {
-				// TODO: Should we log this error?
+				PlayerWorld.logger?.log(loggable: PlayerLoggable.sendToEventProducerSerializationFail)
 				print("Unable to encode data from encoded event: \(event)")
 				return
 			}
@@ -276,7 +276,7 @@ private extension PlayerEventSender {
 				payload: serializedString
 			)
 		} catch {
-			// TODO: Should we log this error?
+			PlayerWorld.logger?.log(loggable: PlayerLoggable.sendToEventProducer(error: error))
 			print("Error when encoding event: \(event)")
 		}
 	}
@@ -309,7 +309,7 @@ private extension PlayerEventSender {
 				token = authToken.toBearerToken()
 
 				guard authToken.isAuthorized else {
-					// TODO: Should we log this error?
+					PlayerWorld.logger?.log(loggable: PlayerLoggable.sendEventsNotAuthorized)
 					print("EventSender succeeded to get credentials but user is not authorized.")
 					return
 				}
@@ -327,7 +327,7 @@ private extension PlayerEventSender {
 				urls.forEach { try? self.fileManager.removeItem(at: $0) }
 
 			} catch {
-				// TODO: This error should be centrally logged
+				PlayerWorld.logger?.log(loggable: PlayerLoggable.sendEvents(error: error))
 				print("Failed to send data to \(url) [\(String(describing: error))")
 			}
 		}

--- a/Sources/Player/PlaybackEngine/Internal/InternalPlayerLoader.swift
+++ b/Sources/Player/PlaybackEngine/Internal/InternalPlayerLoader.swift
@@ -247,6 +247,7 @@ private extension InternalPlayerLoader {
 			)
 
 		} catch {
+			PlayerWorld.logger()?.log(loggable: PlayerLoggable.loadUCFailed(error: error))
 			throw error
 		}
 	}

--- a/Sources/Player/PlaybackEngine/Internal/StreamingPrivileges/StreamingPrivilegesHandler.swift
+++ b/Sources/Player/PlaybackEngine/Internal/StreamingPrivileges/StreamingPrivilegesHandler.swift
@@ -54,7 +54,7 @@ extension StreamingPrivilegesHandler {
 				return
 			}
 		} catch {
-			PlayerWorld.logger?.log(loggable: PlayerLoggable.streamingNotify(error: error))
+			PlayerWorld.logger()?.log(loggable: PlayerLoggable.streamingNotifyNotAuthorized(error: error))
 			print("StreamingPrivilegesHandler failed to get credentials")
 			return
 		}
@@ -100,6 +100,7 @@ private extension StreamingPrivilegesHandler {
 				await receive()
 			}
 		} catch {
+			PlayerWorld.logger()?.log(loggable: PlayerLoggable.webSocketSendMessageFailed(error: error))
 			self.webSocketTask = nil
 		}
 	}
@@ -118,7 +119,7 @@ private extension StreamingPrivilegesHandler {
 			let authToken = try await credentialsProvider.getCredentials()
 			token = authToken.toBearerToken()
 		} catch {
-			PlayerWorld.logger?.log(loggable: PlayerLoggable.streamingConnect(error: error))
+			PlayerWorld.logger()?.log(loggable: PlayerLoggable.streamingConnectNotAuthorized(error: error))
 			print("StreamingPrivilegesHandler failed to get credentials")
 		}
 
@@ -146,6 +147,7 @@ private extension StreamingPrivilegesHandler {
 			await handle(message)
 			await receive()
 		} catch {
+			PlayerWorld.logger()?.log(loggable: PlayerLoggable.webSocketReceiveMessageFailed(error: error))
 			await handleError(error: error)
 		}
 	}
@@ -162,6 +164,7 @@ private extension StreamingPrivilegesHandler {
 				try await Task.sleep(seconds: duration)
 				await reconnectAfterFailures()
 			} catch {
+				PlayerWorld.logger()?.log(loggable: PlayerLoggable.webSocketHandleErrorSleepAndReconnectionFailed(error: error))
 				print(
 					"Sleep for \(duration)s when reconnecting (attempt count \(reconnectAttemptCount)) got cancelled, stopping. Error: \(error)"
 				)

--- a/Sources/Player/PlaybackEngine/Internal/StreamingPrivileges/StreamingPrivilegesHandler.swift
+++ b/Sources/Player/PlaybackEngine/Internal/StreamingPrivileges/StreamingPrivilegesHandler.swift
@@ -54,7 +54,7 @@ extension StreamingPrivilegesHandler {
 				return
 			}
 		} catch {
-			// TODO: Should we log this error?
+			PlayerWorld.logger?.log(loggable: PlayerLoggable.streamingNotify(error: error))
 			print("StreamingPrivilegesHandler failed to get credentials")
 			return
 		}
@@ -118,7 +118,7 @@ private extension StreamingPrivilegesHandler {
 			let authToken = try await credentialsProvider.getCredentials()
 			token = authToken.toBearerToken()
 		} catch {
-			// TODO: Should we log this error?
+			PlayerWorld.logger?.log(loggable: PlayerLoggable.streamingConnect(error: error))
 			print("StreamingPrivilegesHandler failed to get credentials")
 		}
 

--- a/Sources/Player/PlaybackEngine/PlayerEngine.swift
+++ b/Sources/Player/PlaybackEngine/PlayerEngine.swift
@@ -520,6 +520,7 @@ private extension PlayerEngine {
 		do {
 			try await playerItemLoader.load(playerItem)
 		} catch {
+			PlayerWorld.logger()?.log(loggable: PlayerLoggable.loadPlayerItemFailed(error: error))
 			handle(error, in: playerItem)
 		}
 	}

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -70,7 +70,8 @@ public final class Player {
 		offlineEngine: OfflineEngine?,
 		featureFlagProvider: FeatureFlagProvider,
 		externalPlayers: [GenericMediaPlayer.Type],
-		credentialsProvider: CredentialsProvider
+		credentialsProvider: CredentialsProvider,
+		logger: @escaping () -> TidalLogger?
 	) {
 		self.queue = queue
 		playerURLSession = urlSession
@@ -87,6 +88,8 @@ public final class Player {
 		self.featureFlagProvider = featureFlagProvider
 		registeredPlayers = externalPlayers
 		self.credentialsProvider = credentialsProvider
+
+		PlayerWorld.logger = logger
 	}
 }
 
@@ -99,6 +102,7 @@ public extension Player {
 	///   - listenerQueue: Queue in which the listener post notifications of relevant changes if Player instance.
 	///   - featureFlagProvider: A provider of feature flags.
 	///   - externalPlayers: Array with external players to be used
+	///   - logger: Callback which returns an optional logger. As a default, no logging is done.
 	///   - credentialsProvider: Provider of credentials used to authenticate the user.
 	///   - eventSender: Event sender to which events are sent.
 	/// - Returns: Instance of Player if not initialized yet, or nil if initized already.
@@ -107,6 +111,7 @@ public extension Player {
 		listenerQueue: DispatchQueue = .main,
 		featureFlagProvider: FeatureFlagProvider = .standard,
 		externalPlayers: [GenericMediaPlayer.Type] = [],
+		logger: @escaping () -> TidalLogger? = { nil },
 		credentialsProvider: CredentialsProvider,
 		eventSender: EventSender
 	) -> Player? {
@@ -207,7 +212,8 @@ public extension Player {
 			offlineEngine: offlineEngine,
 			featureFlagProvider: featureFlagProvider,
 			externalPlayers: externalPlayers,
-			credentialsProvider: credentialsProvider
+			credentialsProvider: credentialsProvider, 
+			logger: logger
 		)
 
 		return shared

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -5,7 +5,7 @@ import Foundation
 
 // swiftlint:disable file_length
 // swiftlint:disable:next identifier_name
-var PlayerWorld = PlayerWorldClient.live
+var PlayerWorld = PlayerWorldClient.live()
 
 // MARK: - Player
 


### PR DESCRIPTION
As a continuation of the logging, in this PR I show how we can implement it in Player. Although implementation details can change, it serves to show how we can integrate it, and although the point is not to agree on the levels now, reviewers can still suggest them (I've added all as error for now, which already can provide us data to help with debugging), since even if we change the logging system, the usage and logging types will remain.

There are still many more places to add, this is just the beginning.

---

This pull request introduces a comprehensive logging mechanism throughout the Player module to improve error tracking and debugging. The most significant changes include the addition of a `PlayerLoggable` enumeration for structured logging, and the integration of logging calls at various error handling points across multiple files.

### Logging Enhancements:

* **New Logging Enum:**
  - [`Sources/Player/Common/Logging/PlayerLoggable.swift`](diffhunk://#diff-241c41ad3dff9ee36736f5b5fc913320fd065b24ed9aeba7e1016bcf2345ef49R1-R169): Introduced `PlayerLoggable` enum with cases for different error scenarios and associated metadata.

* **Integration of Logging:**
  - [`Sources/Player/Common/Authentication/CredentialsProvider+Player.swift`](diffhunk://#diff-bd58f9fbf2a2a8e53fdc8f4a92425e4517ce46457abbfde37bd28aa6cf959acaR20): Added logging for bearer token retrieval errors using `PlayerLoggable.getAuthBearerToken`.
  - [`Sources/Player/Common/Authentication/CredentialsSuccessDataParser.swift`](diffhunk://#diff-b42d733f8b656e467cf9e282b194a8ad7265288f17e28e4c5c6431bb421b7be0R19): Added logging for client ID extraction errors using `PlayerLoggable.clientIdFromToken`.
  - [`Sources/Player/Common/DRM/FairPlayLicenseFetcher.swift`](diffhunk://#diff-5e6ac44115d32c3000091124c15de6b878eaadb027622d1963e8170163017037R116-R117): Added logging for license fetching errors using `PlayerLoggable.getPlaybackInfo`.
  - [`Sources/Player/Common/PlaybackInfo/PlaybackInfoFetcher.swift`](diffhunk://#diff-45d3fd7d1bcac922fb0186925ad191716c620dc029e6932a7ace09911792223dL306-R309): Added logging for playback info fetching errors using `PlayerLoggable.getPlaybackInfo`.
  - [`Sources/Player/OfflineEngine/Internal/DownloadTask.swift`](diffhunk://#diff-b50645adbd7e57968139bc1048f2c4fa12db73e54e45e90d109373a1e08458fcR116): Added logging for download task errors using `PlayerLoggable.downloadFailed` and `PlayerLoggable.downloadFinalizeFailed`. [[1]](diffhunk://#diff-b50645adbd7e57968139bc1048f2c4fa12db73e54e45e90d109373a1e08458fcR116) [[2]](diffhunk://#diff-b50645adbd7e57968139bc1048f2c4fa12db73e54e45e90d109373a1e08458fcR137)
  - [`Sources/Player/OfflineEngine/OfflineEngine.swift`](diffhunk://#diff-c25638cfdf9a5799584b59c57b4e374a03e64536da9e6dd5db37c53a33605ec8R98): Added logging for offline item deletion errors using `PlayerLoggable.deleteOfflineItem`.
  - [`Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/Legacy/AssetCacheLegacy.swift`](diffhunk://#diff-2f0eccdabf6716f080499656db5d25f1b09f4e8406296d322fa438d8b4555eedR46): Added logging for asset cache deletion errors using `PlayerLoggable.deleteAssetCache`.
  - [`Sources/Player/PlaybackEngine/Internal/Events/PlayerEventSender.swift`](diffhunk://#diff-5534977861dab01764efdf1dc1f56f11a38e633e845cfa392e746be232ad8a54L90-R90): Added logging for various event sending errors using `PlayerLoggable` cases like `sendEventOfflinePlay`, `sendLegacyEvent`, `migrateLegacyDirectory`, etc. [[1]](diffhunk://#diff-5534977861dab01764efdf1dc1f56f11a38e633e845cfa392e746be232ad8a54L90-R90) [[2]](diffhunk://#diff-5534977861dab01764efdf1dc1f56f11a38e633e845cfa392e746be232ad8a54L106-R106) [[3]](diffhunk://#diff-5534977861dab01764efdf1dc1f56f11a38e633e845cfa392e746be232ad8a54L141-R141) [[4]](diffhunk://#diff-5534977861dab01764efdf1dc1f56f11a38e633e845cfa392e746be232ad8a54L203-R208) [[5]](diffhunk://#diff-5534977861dab01764efdf1dc1f56f11a38e633e845cfa392e746be232ad8a54L267-R267) [[6]](diffhunk://#diff-5534977861dab01764efdf1dc1f56f11a38e633e845cfa392e746be232ad8a54L279-R279) [[7]](diffhunk://#diff-5534977861dab01764efdf1dc1f56f11a38e633e845cfa392e746be232ad8a54L312-R312) [[8]](diffhunk://#diff-5534977861dab01764efdf1dc1f56f11a38e633e845cfa392e746be232ad8a54L330-R330)
  - [`Sources/Player/PlaybackEngine/Internal/StreamingPrivileges/StreamingPrivilegesHandler.swift`](diffhunk://#diff-40cea017a7c026528562d8f427e1731ac40589411ac2b9879710ea582ba6c7f8L57-R57): Added logging for streaming privilege handling errors using `PlayerLoggable.streamingNotify` and `PlayerLoggable.streamingConnect`. [[1]](diffhunk://#diff-40cea017a7c026528562d8f427e1731ac40589411ac2b9879710ea582ba6c7f8L57-R57) [[2]](diffhunk://#diff-40cea017a7c026528562d8f427e1731ac40589411ac2b9879710ea582ba6c7f8L121-R121)

* **PlayerWorld Client Update:**
  - [`Sources/Player/Common/World/PlayerWorldClient.swift`](diffhunk://#diff-e93ff12ff899401df71646980605ab0bc4a489ffe43087ad2d8ff199515b9bb4R16-R37): Updated `PlayerWorldClient` to include an optional logger, with a default implementation provided.

* **Global PlayerWorld Initialization:**
  - [`Sources/Player/Player.swift`](diffhunk://#diff-72e70940517220269766d198841cbbf4de3f49b358ebf7a4f4f1ec169be022cbL8-R8): Modified the global `PlayerWorld` initialization to use the updated `PlayerWorldClient` with logging support.