### PR TITLE
Removing setupUserConfiguration from Player

### DIFF
--- a/Sources/Player/Mocks/PlaybackEngine/UserConfiguration+Mock.swift
+++ b/Sources/Player/Mocks/PlaybackEngine/UserConfiguration+Mock.swift
@@ -1,8 +1,0 @@
-public extension UserConfiguration {
-	static func mock(
-		userId: Int = 19,
-		userClientId: Int = 10
-	) -> UserConfiguration {
-		UserConfiguration(userId: userId, userClientId: userClientId)
-	}
-}

--- a/Sources/Player/PlaybackEngine/Internal/Events/PlayerEventSender.swift
+++ b/Sources/Player/PlaybackEngine/Internal/Events/PlayerEventSender.swift
@@ -210,11 +210,7 @@ private extension PlayerEventSender {
 				return
 			}
 			
-			let userClientId: Int? = if let userClientIdSupplier {
-				userClientIdSupplier()
-			} else {
-				nil
-			}
+			let userClientId = userClientIdSupplier?()
 		
 			let user = User(
 				id: Int(userId!) ?? -1,

--- a/Sources/Player/PlaybackEngine/Internal/Events/User.swift
+++ b/Sources/Player/PlaybackEngine/Internal/Events/User.swift
@@ -1,5 +1,5 @@
 struct User: Codable, Equatable {
 	let id: Int
 	let accessToken: String
-	let clientId: Int
+	let clientId: Int?
 }

--- a/Tests/PlayerTests/Mocks/PlaybackEngine/Internal/Events/PlayerEventSenderMock.swift
+++ b/Tests/PlayerTests/Mocks/PlaybackEngine/Internal/Events/PlayerEventSenderMock.swift
@@ -7,7 +7,6 @@ final class PlayerEventSenderMock: PlayerEventSender {
 	var streamingMetricsEvents = [any StreamingMetricsEvent]()
 	var playLogEvents = [PlayLogEvent]()
 	var offlinePlays = [OfflinePlay]()
-	var userConfigurations = [UserConfiguration]()
 	var writtenEvents = [AnyObject]()
 
 	override init(
@@ -16,7 +15,8 @@ final class PlayerEventSenderMock: PlayerEventSender {
 		credentialsProvider: CredentialsProvider = CredentialsProviderMock(),
 		dataWriter: DataWriterProtocol = DataWriterMock(),
 		featureFlagProvider: FeatureFlagProvider = .mock,
-		eventSender: EventSender = EventSenderMock()
+		eventSender: EventSender = EventSenderMock(),
+		userClientIdSupplier: (() -> Int)? = nil
 	) {
 		super.init(
 			configuration: configuration,
@@ -24,7 +24,8 @@ final class PlayerEventSenderMock: PlayerEventSender {
 			credentialsProvider: credentialsProvider,
 			dataWriter: dataWriter,
 			featureFlagProvider: featureFlagProvider,
-			eventSender: eventSender
+			eventSender: eventSender,
+			userClientIdSupplier: userClientIdSupplier
 		)
 	}
 
@@ -44,11 +45,6 @@ final class PlayerEventSenderMock: PlayerEventSender {
 
 	override func send(_ offlinePlay: OfflinePlay) {
 		offlinePlays.append(offlinePlay)
-	}
-
-	override func updateUserConfiguration(userConfiguration: UserConfiguration) {
-		userConfigurations.append(userConfiguration)
-		super.updateUserConfiguration(userConfiguration: userConfiguration)
 	}
 
 	override func writeEvent<T: Codable & Equatable>(event: LegacyEvent<T>) {

--- a/Tests/PlayerTests/Player/PlaybackEngine/Internal/PlayerItemTests.swift
+++ b/Tests/PlayerTests/Player/PlaybackEngine/Internal/PlayerItemTests.swift
@@ -7,6 +7,9 @@ private enum Constants {
 	static let token = "token"
 	static let deviceType = DeviceInfoProvider.Constants.deviceTypeMobile
 	static let uuid = "uuid"
+	static let userId = 9
+	static let userClientId = 11
+	static let cid = "cid"
 }
 
 // MARK: - PlayerItemTests
@@ -24,7 +27,7 @@ final class PlayerItemTests: XCTestCase {
 	private var user: User!
 	private var client: Client {
 		Client(
-			token: String(user.clientId),
+			token: Constants.cid,
 			version: configuration.clientVersion,
 			deviceType: Constants.deviceType
 		)
@@ -60,11 +63,10 @@ final class PlayerItemTests: XCTestCase {
 
 		player = PlayerMock()
 
-		let userConfiguration = UserConfiguration.mock()
 		user = User(
-			id: userConfiguration.userId,
+			id: Constants.userId,
 			accessToken: "Bearer \(Constants.token)",
-			clientId: userConfiguration.userClientId
+			clientId: Constants.userClientId
 		)
 	}
 

--- a/Tests/PlayerTests/Player/PlayerTests.swift
+++ b/Tests/PlayerTests/Player/PlayerTests.swift
@@ -68,14 +68,3 @@ final class PlayerTests: XCTestCase {
 		)
 	}
 }
-
-extension PlayerTests {
-	// MARK: - setUpUserConfiguration(_)
-
-	func test_setUpUserConfiguration_calls_EventSender_updateuserConfiguration() {
-		let userConfiguration = UserConfiguration.mock(userId: 100, userClientId: 200)
-		player.setUpUserConfiguration(userConfiguration)
-
-		XCTAssertEqual(playerEventSender.userConfigurations, [userConfiguration])
-	}
-}


### PR DESCRIPTION
- The user id is now fetched from the auth's `CredentialsProvider`. 
- The user client id is now supplied through a function block. 
- User's clientId is now made nullable.