### PR TITLE
Fix parsing error in clientIdFromToken

### DIFF
--- a/Sources/Common/Extensions/String+Extensions.swift
+++ b/Sources/Common/Extensions/String+Extensions.swift
@@ -20,4 +20,10 @@ extension String {
 		allowedCharacterSet.remove(charactersIn: "\(generalDelimitersToEncode)\(subDelimitersToEncode)")
 		return self.addingPercentEncoding(withAllowedCharacters: allowedCharacterSet) ?? ""
 	}
+	
+	public func base64WithPadding() -> String {
+		let offset = count % 4
+		guard offset != 0 else { return self }
+		return padding(toLength: count + 4 - offset, withPad: "=", startingAt: 0)
+	}
 }

--- a/Sources/Player/Common/Authentication/CredentialsSuccessDataParser.swift
+++ b/Sources/Player/Common/Authentication/CredentialsSuccessDataParser.swift
@@ -6,7 +6,7 @@ struct CredentialsSuccessDataParser {
 
 		let credentialStrings = token.components(separatedBy: ".")
 		if credentialStrings.count > 2 {
-			let credentialsSuccessBase64EncodedString = credentialStrings[1]
+			let credentialsSuccessBase64EncodedString = credentialStrings[1].base64WithPadding()
 			if let decodedCredentialsSuccessData = Data(base64Encoded: credentialsSuccessBase64EncodedString),
 			   let jsonCredentialsSuccessString = String(data: decodedCredentialsSuccessData, encoding: .utf8),
 			   let jsonCredentialsSuccessData = jsonCredentialsSuccessString.data(using: .utf8)

--- a/Tests/PlayerTests/Player/Common/Authentication/CredentialsSuccessDataParserTests.swift
+++ b/Tests/PlayerTests/Player/Common/Authentication/CredentialsSuccessDataParserTests.swift
@@ -29,6 +29,12 @@ extension CredentialsSuccessDataParserTests {
 		let clientId = credentialsSuccessDataParser.clientIdFromToken(token)
 		XCTAssertEqual(clientId, nil)
 	}
+	
+	func test_clientIdFromToken_when_StringRequiresPadding() async throws {
+		let token = "Bearer blabla.eyJjaWQiOjEyMzQ1fQ.blahblah"
+		let clientId = credentialsSuccessDataParser.clientIdFromToken(token)
+		XCTAssertEqual(clientId, 12345)
+	}
 
 	func test_clientIdFromToken_when_StringIsNotEncodedInBase64() async throws {
 		let token = "Bearer yada.abcd.yada"


### PR DESCRIPTION
Current the client id can result to null if the string is not a perfect base 64 encoded string. This PR fixes this issue.