### PR TITLE
[Player] StreamingMetrics support for new offliner

### DIFF
--- a/Sources/Player/PlaybackEngine/Internal/Events/StreamingMetrics/PlaybackStatistics.swift
+++ b/Sources/Player/PlaybackEngine/Internal/Events/StreamingMetrics/PlaybackStatistics.swift
@@ -5,6 +5,7 @@ import Foundation
 struct PlaybackStatistics: StreamingMetricsEvent {
 	enum EventTag: String, Codable {
 		case CACHED
+		case OFFLINER_V2
 	}
 
 	// MARK: - StreamingMetricsEvent

--- a/Sources/Player/PlaybackEngine/Internal/Metadata.swift
+++ b/Sources/Player/PlaybackEngine/Internal/Metadata.swift
@@ -10,4 +10,5 @@ struct Metadata: Equatable {
 	let audioSampleRate: Int?
 	let audioBitDepth: Int?
 	let videoQuality: VideoQuality?
+	let playbackSource: PlaybackSource
 }

--- a/Sources/Player/PlaybackEngine/Internal/PlaybackSource.swift
+++ b/Sources/Player/PlaybackEngine/Internal/PlaybackSource.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+enum PlaybackSource {
+	case INTERNET
+	case LOCAL_STORAGE
+	case LOCAL_STORAGE_LEGACY
+}

--- a/Sources/Player/PlaybackEngine/Internal/PlayerItem.swift
+++ b/Sources/Player/PlaybackEngine/Internal/PlayerItem.swift
@@ -375,10 +375,12 @@ private extension PlayerItem {
 
 		let endTimestamp = metrics.endTime ?? now
 
-		let tags: [PlaybackStatistics.EventTag]? = if case .cached = asset?.getCacheState()?.status {
-			[PlaybackStatistics.EventTag.CACHED]
-		} else {
-			nil
+		var tags = [PlaybackStatistics.EventTag]()
+		if case .cached = asset?.getCacheState()?.status {
+			tags.append(PlaybackStatistics.EventTag.CACHED)
+		}
+		if metadata.playbackSource == .LOCAL_STORAGE {
+			tags.append(PlaybackStatistics.EventTag.OFFLINER_V2)
 		}
 
 		let endInfo = metrics.endInfo

--- a/Sources/Player/PlaybackEngine/Internal/PlayerItemLoader.swift
+++ b/Sources/Player/PlaybackEngine/Internal/PlayerItemLoader.swift
@@ -67,7 +67,8 @@ private extension PlayerItemLoader {
 			audioCodec: playableStorageMediaProduct.audioCodec,
 			audioSampleRate: playableStorageMediaProduct.audioSampleRate,
 			audioBitDepth: playableStorageMediaProduct.audioBitDepth,
-			videoQuality: playableStorageMediaProduct.videoQuality
+			videoQuality: playableStorageMediaProduct.videoQuality,
+			playbackSource: .LOCAL_STORAGE
 		)
 	}
 
@@ -81,7 +82,8 @@ private extension PlayerItemLoader {
 			audioCodec: storedMediaProduct.audioCodec,
 			audioSampleRate: storedMediaProduct.audioSampleRate,
 			audioBitDepth: storedMediaProduct.audioBitDepth,
-			videoQuality: storedMediaProduct.videoQuality
+			videoQuality: storedMediaProduct.videoQuality,
+			playbackSource: .LOCAL_STORAGE_LEGACY
 		)
 	}
 
@@ -95,7 +97,8 @@ private extension PlayerItemLoader {
 			audioCodec: playbackInfo.audioCodec,
 			audioSampleRate: playbackInfo.audioSampleRate,
 			audioBitDepth: playbackInfo.audioBitDepth,
-			videoQuality: playbackInfo.videoQuality
+			videoQuality: playbackInfo.videoQuality,
+			playbackSource: .INTERNET
 		)
 	}
 }

--- a/Tests/PlayerTests/Mocks/PlaybackEngine/Internal/Events/StreamingMetrics/PlaybackStatistics+Mock.swift
+++ b/Tests/PlayerTests/Mocks/PlaybackEngine/Internal/Events/StreamingMetrics/PlaybackStatistics+Mock.swift
@@ -15,6 +15,7 @@ extension PlaybackStatistics {
 		startReason: StartReason = StartReason.EXPLICIT,
 		endReason: String = EndReason.COMPLETE.rawValue,
 		endTimestamp: UInt64 = 1,
+		tags: [PlaybackStatistics.EventTag] = [],
 		errorMessage: String? = nil,
 		errorCode: String? = nil
 	) -> Self {
@@ -32,6 +33,7 @@ extension PlaybackStatistics {
 			startReason: startReason,
 			endReason: endReason,
 			endTimestamp: endTimestamp,
+			tags: tags,
 			errorMessage: errorMessage,
 			errorCode: errorCode
 		)

--- a/Tests/PlayerTests/Mocks/PlaybackEngine/Internal/Metadata+Mock.swift
+++ b/Tests/PlayerTests/Mocks/PlaybackEngine/Internal/Metadata+Mock.swift
@@ -10,7 +10,8 @@ extension Metadata {
 		audioCodec: AudioCodec? = nil,
 		audioSampleRate: Int? = 44100,
 		audioBitDepth: Int? = 15,
-		videoQuality: VideoQuality? = nil
+		videoQuality: VideoQuality? = nil,
+		playbackSource: PlaybackSource = .INTERNET
 	) -> Self {
 		Metadata(
 			productId: productId,
@@ -21,7 +22,8 @@ extension Metadata {
 			audioCodec: audioCodec,
 			audioSampleRate: audioSampleRate,
 			audioBitDepth: audioBitDepth,
-			videoQuality: videoQuality
+			videoQuality: videoQuality,
+			playbackSource: playbackSource
 		)
 	}
 


### PR DESCRIPTION
We needed a way to differentiate plays coming from our new offliner implementations vs the legacy ones we are substituting, to track the health of the new feature during the rollout..

For that, I added a tag in the `PlaybackStatistics` event when the playback is coming from an object stored in the new offliner format.