### PR TITLE
Update unit test action

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Run tests
       run: |-
-        swift test --skip PlayerTests | xcbeautify --renderer github-actions
+        set -o pipefail && swift test --skip PlayerTests | xcbeautify --renderer github-actions
 
   run-xcodebuild-tests:
     name: Run xcodebuild Unit Tests


### PR DESCRIPTION
We are getting false positives in unit tests (even if they don't build). As pointed out by Alberto, we were missing a command to actually fail with proper exit status.