### PR TITLE
Add Common product, replace #file with #fileID in logging

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,10 +30,6 @@ let package = Package(
 			name: "Player",
 			targets: ["Player"]
 		),
-		.library(
-			name: "Common",
-			targets: ["Common"]
-		),
 	],
 	dependencies: [
 		.package(url: "https://github.com/groue/GRDB.swift.git", from: "6.27.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -30,6 +30,10 @@ let package = Package(
 			name: "Player",
 			targets: ["Player"]
 		),
+		.library(
+			name: "Common",
+			targets: ["Common"]
+		),
 	],
 	dependencies: [
 		.package(url: "https://github.com/groue/GRDB.swift.git", from: "6.27.0"),

--- a/Sources/Common/Logger/TidalLogger.swift
+++ b/Sources/Common/Logger/TidalLogger.swift
@@ -12,7 +12,7 @@ public struct TidalLogger {
 
 private extension TidalLogger {
 	func log(level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata? = nil, source: String? = nil, file: String, function: String, line: UInt) {
-		self.logger.log(level: level, message, metadata: metadata, file: file, function: function, line: line)
+		self.logger.log(level: level, message, metadata: metadata, source: source, file: file, function: function, line: line)
 	}
 }
 

--- a/Sources/Common/Logger/TidalLogger.swift
+++ b/Sources/Common/Logger/TidalLogger.swift
@@ -12,12 +12,12 @@ public struct TidalLogger {
 
 private extension TidalLogger {
 	func log(level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata? = nil, source: String? = nil, file: String, function: String, line: UInt) {
-		self.logger.log(level: level, message, metadata: metadata, source: source, file: file, function: function, line: line)
+		self.logger.log(level: level, message, metadata: metadata, file: file, function: function, line: line)
 	}
 }
 
 public extension TidalLogger {
-	func log(loggable: TidalLoggable, file: String = #file, function: String = #function, line: UInt = #line) {
+	func log(loggable: TidalLoggable, file: String = #fileID, function: String = #function, line: UInt = #line) {
 		self.log(
 			level: loggable.logLevel,
 			message: loggable.loggingMessage,


### PR DESCRIPTION
Per discussions, it makes more sense to keep `#fileID` instead of `#file` as the default for the file in logging. 

---

This pull request includes a small but important change to the `TidalLogger` class in the `Sources/Common/Logger/TidalLogger.swift` file. The change updates the `log` method to use `#fileID` instead of `#file` for the `file` parameter.

* [`Sources/Common/Logger/TidalLogger.swift`](diffhunk://#diff-2aa1cc4116b0d5e2839fc86b7bc79f401500a84389d631342411376a3fe26e6dL20-R20): Updated the `log` method to use `#fileID` instead of `#file` for the `file` parameter.