### PR TITLE
[Player] Better OfflineStorage and OfflineEngine initialization

### DIFF
--- a/Sources/Player/Common/Logging/PlayerLoggable.swift
+++ b/Sources/Player/Common/Logging/PlayerLoggable.swift
@@ -189,7 +189,7 @@ extension PlayerLoggable {
 		case .downloadFinalizeFailed:
 			"DownloadTask-downloadFinalizeFailed"
 
-		// Offline Engine
+		// GRDBOfflineStorage
 		case .withDefaultDatabase:
 			"GRDBOfflineStorage-withDefaultDatabase"
 

--- a/Sources/Player/Common/Logging/PlayerLoggable.swift
+++ b/Sources/Player/Common/Logging/PlayerLoggable.swift
@@ -2,13 +2,17 @@ import Common
 import Foundation
 import Logging
 
+// MARK: - Constants
+
 private enum Constants {
 	static let metadataErrorKey = "error"
 }
 
+// MARK: - PlayerLoggable
+
 enum PlayerLoggable: TidalLoggable {
-	
 	// MARK: Event Sender
+
 	case sendEventOfflinePlayFailed(error: Error)
 	case sendLegacyEventFailed(error: Error)
 	case migrateLegacyDirectoryFailed(error: Error)
@@ -22,6 +26,7 @@ enum PlayerLoggable: TidalLoggable {
 	case initializeDirectoryFailed(error: Error)
 
 	// MARK: Streaming Privileges
+
 	case streamingNotifyNotAuthorized(error: Error)
 	case streamingConnectNotAuthorized(error: Error)
 	case webSocketSendMessageFailed(error: Error)
@@ -29,77 +34,101 @@ enum PlayerLoggable: TidalLoggable {
 	case webSocketHandleErrorSleepAndReconnectionFailed(error: Error) // swiftlint:disable:this identifier_name
 
 	// MARK: Playback Info Fetcher
+
 	case getPlaybackInfoFailed(error: Error)
 
 	// MARK: FairPlay License Fetcher
+
 	case getLicenseFailed(error: Error)
 
 	// MARK: Credentials Provider
+
 	case getAuthBearerTokenCredentialFailed(error: Error)
 	case getAuthBearerTokenToBearerTokenFailed
 
 	// MARK: Credentials Success Data Parser
+
 	case credentialsSuccessParserParsingFailed(error: Error)
 
 	// MARK: Download Task
+
 	case downloadFailed(error: Error)
 	case downloadFinalizeFailed(error: Error)
 
+	// MARK: Offline Storage
+
+	case withDefaultDatabase(error: Error)
+
 	// MARK: Offline Engine
+
 	case deleteOfflinedItem(error: Error)
 
 	// MARK: Asset Cache Legacy
+
 	case deleteAssetCacheFailed(error: Error)
 
 	// MARK: StoredLicenseLoader
+
 	case licenseLoaderContentKeyRequestFailed(error: Error)
 	case licenseLoaderProcessContentKeyResponseFailed(error: Error) // swiftlint:disable:this identifier_name
 
 	// MARK: StreamingLicenseLoader
+
 	case streamingGetLicenseFailed(error: Error)
 
 	// MARK: HttpClient
+
 	case payloadEncodingFailed(error: Error)
 	case payloadDecodingFailed(error: Error)
 
 	// MARK: URLSession
+
 	case loadDataForRequestFailed(error: Error)
 
 	// MARK: ResponseHandler
+
 	case backoffHandleResponseFailed(error: Error)
 
 	// MARK: Downloader
+
 	case startDownloadFailed(error: Error)
 
 	// MARK: LicenseDownloader
+
 	case licenseDownloaderContentKeyRequestFailed(error: Error)
 	case licenseDownloaderGetLicenseFailed(error: Error)
 
 	// MARK: MediaDownloader
+
 	case downloadFinishedMovingFileFailed(error: Error)
 
 	// MARK: AVQueuePlayerWrapperLegacy
+
 	case legacyReadPlaybackMetadataFailed(error: Error)
 
 	// MARK: AVQueuePlayerWrapper
+
 	case readPlaybackMetadataFailed(error: Error)
 
 	// MARK: DJProducer
+
 	case djSessionStartFailed(error: Error)
 	case djSessionSendCommandFailed(error: Error)
 
 	// MARK: InternalPlayerLoader
+
 	case loadUCFailed(error: Error)
 
 	// MARK: PlayerEngine
+
 	case loadPlayerItemFailed(error: Error)
 }
 
 // MARK: - Logging
-extension PlayerLoggable {
 
+extension PlayerLoggable {
 	var loggingMessage: Logger.Message {
-		return switch self {
+		switch self {
 		// Event Sender
 		case .sendEventOfflinePlayFailed:
 			"EventSender-sendEventOfflinePlayFailed"
@@ -159,6 +188,10 @@ extension PlayerLoggable {
 			"DownloadTask-downloadFailed"
 		case .downloadFinalizeFailed:
 			"DownloadTask-downloadFinalizeFailed"
+
+		// Offline Engine
+		case .withDefaultDatabase:
+			"GRDBOfflineStorage-withDefaultDatabase"
 
 		// Offline Engine
 		case .deleteOfflinedItem:
@@ -234,49 +267,50 @@ extension PlayerLoggable {
 		var metadata = [String: Logger.MetadataValue]()
 
 		switch self {
-		case let .sendEventOfflinePlayFailed(error), 
-			let .sendLegacyEventFailed(error),
-			let .migrateLegacyDirectoryFailed(error),
-			let .writeEventFailed(error), 
-			let .sendToEventProducerFailed(error),
-			let .sendEventsFailed(error),
-			let .urlForDirectoryFailed(error),
-			let .initializeDirectoryFailed(error),
-			let .streamingNotifyNotAuthorized(error),
-			let .streamingConnectNotAuthorized(error),
-			let .webSocketSendMessageFailed(error),
-			let .webSocketReceiveMessageFailed(error),
-			let .webSocketHandleErrorSleepAndReconnectionFailed(error),
-			let .getPlaybackInfoFailed(error),
-			let .getLicenseFailed(error),
-			let .credentialsSuccessParserParsingFailed(error),
-			let .downloadFailed(error),
-			let .downloadFinalizeFailed(error),
-			let .deleteOfflinedItem(error),
-			let .deleteAssetCacheFailed(error),
-			let .getAuthBearerTokenCredentialFailed(error),
-			let .licenseLoaderContentKeyRequestFailed(error),
-			let .licenseLoaderProcessContentKeyResponseFailed(error),
-			let .streamingGetLicenseFailed(error),
-			let .payloadEncodingFailed(error),
-			let .payloadDecodingFailed(error),
-			let .loadDataForRequestFailed(error),
-			let .backoffHandleResponseFailed(error),
-			let .startDownloadFailed(error),
-			let .licenseDownloaderContentKeyRequestFailed(error),
-			let .licenseDownloaderGetLicenseFailed(error),
-			let .downloadFinishedMovingFileFailed(error),
-			let .legacyReadPlaybackMetadataFailed(error),
-			let .readPlaybackMetadataFailed(error),
-			let .djSessionStartFailed(error),
-			let .djSessionSendCommandFailed(error),
-			let .loadUCFailed(error),
-			let .loadPlayerItemFailed(error):
+		case let .sendEventOfflinePlayFailed(error),
+		     let .sendLegacyEventFailed(error),
+		     let .migrateLegacyDirectoryFailed(error),
+		     let .writeEventFailed(error),
+		     let .sendToEventProducerFailed(error),
+		     let .sendEventsFailed(error),
+		     let .urlForDirectoryFailed(error),
+		     let .initializeDirectoryFailed(error),
+		     let .streamingNotifyNotAuthorized(error),
+		     let .streamingConnectNotAuthorized(error),
+		     let .webSocketSendMessageFailed(error),
+		     let .webSocketReceiveMessageFailed(error),
+		     let .webSocketHandleErrorSleepAndReconnectionFailed(error),
+		     let .getPlaybackInfoFailed(error),
+		     let .getLicenseFailed(error),
+		     let .credentialsSuccessParserParsingFailed(error),
+		     let .downloadFailed(error),
+		     let .downloadFinalizeFailed(error),
+		     let .withDefaultDatabase(error),
+		     let .deleteOfflinedItem(error),
+		     let .deleteAssetCacheFailed(error),
+		     let .getAuthBearerTokenCredentialFailed(error),
+		     let .licenseLoaderContentKeyRequestFailed(error),
+		     let .licenseLoaderProcessContentKeyResponseFailed(error),
+		     let .streamingGetLicenseFailed(error),
+		     let .payloadEncodingFailed(error),
+		     let .payloadDecodingFailed(error),
+		     let .loadDataForRequestFailed(error),
+		     let .backoffHandleResponseFailed(error),
+		     let .startDownloadFailed(error),
+		     let .licenseDownloaderContentKeyRequestFailed(error),
+		     let .licenseDownloaderGetLicenseFailed(error),
+		     let .downloadFinishedMovingFileFailed(error),
+		     let .legacyReadPlaybackMetadataFailed(error),
+		     let .readPlaybackMetadataFailed(error),
+		     let .djSessionStartFailed(error),
+		     let .djSessionSendCommandFailed(error),
+		     let .loadUCFailed(error),
+		     let .loadPlayerItemFailed(error):
 			metadata[Constants.metadataErrorKey] = "\(String(describing: error))"
 		case .writeEventNotAuthorized,
-				.sendToEventProducerSerializationFailed,
-				.sendEventsNotAuthorized,
-				.getAuthBearerTokenToBearerTokenFailed:
+		     .sendToEventProducerSerializationFailed,
+		     .sendEventsNotAuthorized,
+		     .getAuthBearerTokenToBearerTokenFailed:
 			break
 		}
 
@@ -286,48 +320,49 @@ extension PlayerLoggable {
 	var logLevel: Logger.Level {
 		switch self {
 		case .sendEventOfflinePlayFailed,
-				.sendLegacyEventFailed,
-				.migrateLegacyDirectoryFailed,
-				.writeEventNotAuthorized,
-				.writeEventFailed,
-				.sendToEventProducerFailed,
-				.sendToEventProducerSerializationFailed,
-				.sendEventsNotAuthorized,
-				.sendEventsFailed, 
-				.urlForDirectoryFailed,
-				.initializeDirectoryFailed,
-				.streamingNotifyNotAuthorized,
-				.streamingConnectNotAuthorized,
-				.webSocketSendMessageFailed,
-				.webSocketReceiveMessageFailed,
-				.webSocketHandleErrorSleepAndReconnectionFailed,
-				.getPlaybackInfoFailed,
-				.getLicenseFailed,
-				.getAuthBearerTokenCredentialFailed,
-				.credentialsSuccessParserParsingFailed,
-				.downloadFailed,
-				.downloadFinalizeFailed,
-				.deleteOfflinedItem,
-				.deleteAssetCacheFailed,
-				.getAuthBearerTokenToBearerTokenFailed,
-				.licenseLoaderContentKeyRequestFailed,
-				.licenseLoaderProcessContentKeyResponseFailed,
-				.streamingGetLicenseFailed,
-				.payloadEncodingFailed,
-				.payloadDecodingFailed,
-				.loadDataForRequestFailed,
-				.backoffHandleResponseFailed,
-				.startDownloadFailed,
-				.licenseDownloaderContentKeyRequestFailed,
-				.licenseDownloaderGetLicenseFailed,
-				.downloadFinishedMovingFileFailed,
-				.legacyReadPlaybackMetadataFailed,
-				.readPlaybackMetadataFailed,
-				.djSessionStartFailed,
-				.djSessionSendCommandFailed,
-				.loadUCFailed,
-				.loadPlayerItemFailed:
-			return .error
+		     .sendLegacyEventFailed,
+		     .migrateLegacyDirectoryFailed,
+		     .writeEventNotAuthorized,
+		     .writeEventFailed,
+		     .sendToEventProducerFailed,
+		     .sendToEventProducerSerializationFailed,
+		     .sendEventsNotAuthorized,
+		     .sendEventsFailed,
+		     .urlForDirectoryFailed,
+		     .initializeDirectoryFailed,
+		     .streamingNotifyNotAuthorized,
+		     .streamingConnectNotAuthorized,
+		     .webSocketSendMessageFailed,
+		     .webSocketReceiveMessageFailed,
+		     .webSocketHandleErrorSleepAndReconnectionFailed,
+		     .getPlaybackInfoFailed,
+		     .getLicenseFailed,
+		     .getAuthBearerTokenCredentialFailed,
+		     .credentialsSuccessParserParsingFailed,
+		     .downloadFailed,
+		     .downloadFinalizeFailed,
+		     .withDefaultDatabase,
+		     .deleteOfflinedItem,
+		     .deleteAssetCacheFailed,
+		     .getAuthBearerTokenToBearerTokenFailed,
+		     .licenseLoaderContentKeyRequestFailed,
+		     .licenseLoaderProcessContentKeyResponseFailed,
+		     .streamingGetLicenseFailed,
+		     .payloadEncodingFailed,
+		     .payloadDecodingFailed,
+		     .loadDataForRequestFailed,
+		     .backoffHandleResponseFailed,
+		     .startDownloadFailed,
+		     .licenseDownloaderContentKeyRequestFailed,
+		     .licenseDownloaderGetLicenseFailed,
+		     .downloadFinishedMovingFileFailed,
+		     .legacyReadPlaybackMetadataFailed,
+		     .readPlaybackMetadataFailed,
+		     .djSessionStartFailed,
+		     .djSessionSendCommandFailed,
+		     .loadUCFailed,
+		     .loadPlayerItemFailed:
+			.error
 		}
 	}
 

--- a/Sources/Player/Common/Utils/FileManager/FileManagerClient+Live.swift
+++ b/Sources/Player/Common/Utils/FileManager/FileManagerClient+Live.swift
@@ -8,6 +8,9 @@ extension FileManagerClient {
 		cachesDirectory: {
 			FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
 		},
+		applicationSupportDirectory: {
+			FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+		},
 		fileExistsIsDirectory: { path, isDirectory in
 			FileManager.default.fileExists(atPath: path, isDirectory: isDirectory)
 		},

--- a/Sources/Player/Common/Utils/FileManager/FileManagerClient.swift
+++ b/Sources/Player/Common/Utils/FileManager/FileManagerClient.swift
@@ -5,6 +5,7 @@ import Foundation
 struct FileManagerClient {
 	var documentsDirectory: () -> URL
 	var cachesDirectory: () -> URL
+	var applicationSupportDirectory: () -> URL
 	var fileExistsIsDirectory: (_ path: String, _ isDirectory: UnsafeMutablePointer<ObjCBool>?) -> Bool
 	var fileExistsAtPath: (_ path: String) -> Bool
 	var copyItemAtURL: (_ source: URL, _ destination: URL) throws -> Void

--- a/Sources/Player/PlaybackEngine/Internal/PlayerItemLoader.swift
+++ b/Sources/Player/PlaybackEngine/Internal/PlayerItemLoader.swift
@@ -4,11 +4,11 @@ import Foundation
 // MARK: - PlayerItemLoader
 
 final class PlayerItemLoader {
-	private let offlineStorage: OfflineStorage
+	private let offlineStorage: OfflineStorage?
 	private let playbackInfoFetcher: PlaybackInfoFetcher
 	private var playerLoader: PlayerLoader
 
-	init(with offlineStorage: OfflineStorage, _ playbackInfoFetcher: PlaybackInfoFetcher, and playerLoader: PlayerLoader) {
+	init(with offlineStorage: OfflineStorage?, _ playbackInfoFetcher: PlaybackInfoFetcher, and playerLoader: PlayerLoader) {
 		self.offlineStorage = offlineStorage
 		self.playbackInfoFetcher = playbackInfoFetcher
 		self.playerLoader = playerLoader
@@ -40,7 +40,8 @@ private extension PlayerItemLoader {
 			return try await (metadata(of: storedMediaProduct), playerLoader.load(storedMediaProduct))
 		}
 
-		if let offlineEntry = try? offlineStorage.get(key: mediaProduct.productId),
+		if PlayerWorld.developmentFeatureFlagProvider.isOffliningEnabled,
+		   let offlineEntry = try? offlineStorage?.get(key: mediaProduct.productId),
 		   let offlinedMediaProduct = PlayableOfflinedMediaProduct(from: offlineEntry)
 		{
 			return try await (metadata(of: offlinedMediaProduct), playerLoader.load(offlinedMediaProduct))

--- a/Sources/Player/PlaybackEngine/PlayerEngine.swift
+++ b/Sources/Player/PlaybackEngine/PlayerEngine.swift
@@ -107,7 +107,7 @@ final class PlayerEngine {
 		_ configuration: Configuration,
 		_ playerEventSender: PlayerEventSender,
 		_ networkMonitor: NetworkMonitor,
-		_ offlineStorage: OfflineStorage,
+		_ offlineStorage: OfflineStorage?,
 		_ playerLoader: PlayerLoader,
 		_ featureFlagProvider: FeatureFlagProvider,
 		_ notificationsHandler: NotificationsHandler?

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -167,8 +167,8 @@ public extension Player {
 		let networkMonitor = NetworkMonitor()
 		let notificationsHandler = NotificationsHandler(listener: listener, queue: listenerQueue)
 
-		// For now, OfflineStorage and OfflineEngine are optional.
-		// Once the functionality is final it should not be, as Player can't work with a working OfflineEngine.
+		// For now, OfflineStorage and OfflineEngine can be optional.
+		// Once the functionality is finalized, Player should not work with a missing OfflineEngine.
 		var offlineStorage: GRDBOfflineStorage?
 		var offlineEngine: OfflineEngine?
 		if PlayerWorld.developmentFeatureFlagProvider.isOffliningEnabled {

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -41,7 +41,7 @@ public final class Player {
 		}
 	}
 
-	private var offlineStorage: OfflineStorage
+	private var offlineStorage: OfflineStorage?
 	private var djProducer: DJProducer
 	private var playerEventSender: PlayerEventSender
 	private var fairplayLicenseFetcher: FairPlayLicenseFetcher
@@ -58,7 +58,7 @@ public final class Player {
 		queue: OperationQueue,
 		urlSession: URLSession,
 		configuration: Configuration,
-		offlineStorage: OfflineStorage,
+		offlineStorage: OfflineStorage?,
 		djProducer: DJProducer,
 		playerEventSender: PlayerEventSender,
 		fairplayLicenseFetcher: FairPlayLicenseFetcher,
@@ -101,7 +101,8 @@ public extension Player {
 	///   - credentialsProvider: Provider of credentials used to authenticate the user.
 	///   - eventSender: Event sender to which events are sent.
 	///   - userClientIdSupplier: Optional function block to supply user cliend id.
-	///   - shouldAddLogging: Flag whether we should add logging. Default is false, meaning in places where logger is used, no logging is actually performed.
+	///   - shouldAddLogging: Flag whether we should add logging. Default is false, meaning in places where logger is used, no
+	/// logging is actually performed.
 	/// - Returns: Instance of Player if not initialized yet, or nil if initized already.
 	static func bootstrap(
 		listener: PlayerListener,
@@ -128,17 +129,10 @@ public extension Player {
 		let sharedPlayerURLSession = URLSession.new(with: timeoutPolicy, name: "Player Player", serviceType: .responsiveAV)
 		let configuration = Configuration()
 
-		let databaseURL = PlayerWorldClient.live.fileManagerClient.documentsDirectory().appendingPathComponent("dbPlayer.sqlite")
-		guard let dbQueue = try? DatabaseQueue(path: databaseURL.path) else {
-			return nil
-		}
-
-		let offlineStorage = GRDBOfflineStorage(dbQueue: dbQueue)
-
+		// DJProducer Initialization
 		let djProducerTimeoutPolicy = TimeoutPolicy.shortLived
 		let djProducerSession = URLSession.new(with: djProducerTimeoutPolicy, name: "Player DJ Session")
 		let djProducerHTTPClient = HttpClient(using: djProducerSession)
-
 		let djProducer = DJProducer(
 			httpClient: djProducerHTTPClient,
 			credentialsProvider: credentialsProvider,
@@ -173,6 +167,39 @@ public extension Player {
 		let networkMonitor = NetworkMonitor()
 		let notificationsHandler = NotificationsHandler(listener: listener, queue: listenerQueue)
 
+		// For now, OfflineStorage and OfflineEngine are optional.
+		// Once the functionality is final it should not be, as Player can't work with a working OfflineEngine.
+		var offlineStorage: GRDBOfflineStorage?
+		var offlineEngine: OfflineEngine?
+		if PlayerWorld.developmentFeatureFlagProvider.isOffliningEnabled {
+			guard let storage = GRDBOfflineStorage.withDefaultDatabase() else {
+				return nil
+			}
+
+			let offlinerHttpClient = HttpClient(using: URLSession.new(with: timeoutPolicy))
+			let offlinerPlaybackInfoFetcher = PlaybackInfoFetcher(
+				with: configuration,
+				offlinerHttpClient,
+				credentialsProvider,
+				networkMonitor,
+				and: playerEventSender,
+				featureFlagProvider: featureFlagProvider
+			)
+
+			let downloader = Downloader(
+				playbackInfoFetcher: offlinerPlaybackInfoFetcher,
+				fairPlayLicenseFetcher: fairplayLicenseFetcher,
+				networkMonitor: networkMonitor
+			)
+
+			offlineStorage = storage
+			offlineEngine = OfflineEngine(
+				downloader: downloader,
+				offlineStorage: storage,
+				playerEventSender: playerEventSender
+			)
+		}
+
 		let playerEngine = Player.newPlayerEngine(
 			sharedPlayerURLSession,
 			configuration,
@@ -186,30 +213,6 @@ public extension Player {
 			externalPlayers,
 			credentialsProvider
 		)
-
-		var offlineEngine: OfflineEngine?
-		if PlayerWorld.developmentFeatureFlagProvider.isOffliningEnabled {
-			let offlinerHttpClient = HttpClient(using: URLSession.new(with: timeoutPolicy))
-			let playbackInfoFetcher = PlaybackInfoFetcher(
-				with: configuration,
-				offlinerHttpClient,
-				credentialsProvider,
-				networkMonitor,
-				and: playerEventSender,
-				featureFlagProvider: featureFlagProvider
-			)
-			let downloader = Downloader(
-				playbackInfoFetcher: playbackInfoFetcher,
-				fairPlayLicenseFetcher: fairplayLicenseFetcher,
-				networkMonitor: networkMonitor
-			)
-
-			offlineEngine = OfflineEngine(
-				downloader: downloader,
-				offlineStorage: offlineStorage,
-				playerEventSender: playerEventSender
-			)
-		}
 
 		shared = Player(
 			queue: OperationQueue.new(),
@@ -433,7 +436,7 @@ private extension Player {
 	static func newPlayerEngine(
 		_ urlSession: URLSession,
 		_ configuration: Configuration,
-		_ offlineStorage: OfflineStorage,
+		_ offlineStorage: OfflineStorage?,
 		_ djProducer: DJProducer,
 		_ fairplayLicenseFetcher: FairPlayLicenseFetcher,
 		_ networkMonitor: NetworkMonitor,

--- a/Tests/PlayerTests/Mocks/Common/Utils/FileManager/FileManagerClient+Mock.swift
+++ b/Tests/PlayerTests/Mocks/Common/Utils/FileManager/FileManagerClient+Mock.swift
@@ -9,6 +9,9 @@ extension FileManagerClient {
 		cachesDirectory: {
 			FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
 		},
+		applicationSupportDirectory: {
+			FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+		},
 		fileExistsIsDirectory: { path, isDirectory in
 			FileManager.default.fileExists(atPath: path, isDirectory: isDirectory)
 		},

--- a/Tests/PlayerTests/Player/OfflineEngine/Internal/Storage/DBStorage/GRDBOfflineStorageTests.swift
+++ b/Tests/PlayerTests/Player/OfflineEngine/Internal/Storage/DBStorage/GRDBOfflineStorageTests.swift
@@ -32,7 +32,7 @@ final class GRDBOfflineStorageTests: XCTestCase {
 	override func setUpWithError() throws {
 		// Create an in-memory database for testing
 		dbQueue = try DatabaseQueue()
-
+		try GRDBOfflineStorage.initializeDatabase(dbQueue: dbQueue)
 		offlineStorage = GRDBOfflineStorage(dbQueue: dbQueue)
 	}
 


### PR DESCRIPTION
While `OfflineEngine` is still under a development flag, both `OfflineEngine` and `OfflineStorage` should be optional, and the lack of any should not affect Player functionality.

This way we isolate better any possible issues with the new code.

I've also improved the database initialization for the `OfflineStorage` layer, by creating it in the Application Support directory, which follows the platform's recommended suggestions, and the database is inside a specific folder, making it easy to remove it or move it in the future, as the SQLite database creates multiple files for it.