### PR TITLE
[Player] Add OfflinePrivilegeCheck to bootstrap process

### DIFF
--- a/Sources/Player/Common/Errors/ErrorId.swift
+++ b/Sources/Player/Common/Errors/ErrorId.swift
@@ -9,6 +9,7 @@ public enum ErrorId: String {
 	case PERetryable
 	case PENetwork
 	case PENotSupported
+	case PENotAllowedInOfflineMode
 	case OEContentNotAvailableInLocation
 	case OEContentNotAvailableForSubscription
 	case OEOffliningNotAllowedOnDevice

--- a/Sources/Player/Common/Errors/PlayerInternalError.swift
+++ b/Sources/Player/Common/Errors/PlayerInternalError.swift
@@ -22,6 +22,7 @@ public struct PlayerInternalError: Error, CustomStringConvertible, Equatable {
 		case unknown
 		case playerLoaderError
 		case mediaServicesWereReset
+		case playerItemLoaderError
 	}
 
 	let errorId: ErrorId

--- a/Sources/Player/PlaybackEngine/Internal/PlayerItemLoader.swift
+++ b/Sources/Player/PlaybackEngine/Internal/PlayerItemLoader.swift
@@ -5,15 +5,18 @@ import Foundation
 
 final class PlayerItemLoader {
 	private let offlineStorage: OfflineStorage?
+	private let offlinePlaybackPrivilegeCheck: (() -> Bool)?
 	private let playbackInfoFetcher: PlaybackInfoFetcher
 	private var playerLoader: PlayerLoader
 
 	init(
 		with offlineStorage: OfflineStorage?,
+		_ offlinePlaybackPrivilegeCheck: (() -> Bool)?,
 		_ playbackInfoFetcher: PlaybackInfoFetcher,
 		and playerLoader: PlayerLoader
 	) {
 		self.offlineStorage = offlineStorage
+		self.offlinePlaybackPrivilegeCheck = offlinePlaybackPrivilegeCheck
 		self.playbackInfoFetcher = playbackInfoFetcher
 		self.playerLoader = playerLoader
 	}
@@ -44,8 +47,10 @@ private extension PlayerItemLoader {
 			return try await (metadata(of: storedMediaProduct), playerLoader.load(storedMediaProduct))
 		}
 
+		let offlinePlaybackAllowed = offlinePlaybackPrivilegeCheck?() ?? true
 		if let offlineEntry = try? offlineStorage?.get(key: mediaProduct.productId),
-		   let offlinedMediaProduct = PlayableOfflinedMediaProduct(from: offlineEntry)
+		   let offlinedMediaProduct = PlayableOfflinedMediaProduct(from: offlineEntry),
+		   offlinePlaybackAllowed
 		{
 			return try await (metadata(of: offlinedMediaProduct), playerLoader.load(offlinedMediaProduct))
 		}

--- a/Sources/Player/PlaybackEngine/Internal/PlayerItemLoader.swift
+++ b/Sources/Player/PlaybackEngine/Internal/PlayerItemLoader.swift
@@ -50,14 +50,14 @@ final class PlayerItemLoader {
 
 private extension PlayerItemLoader {
 	func load(_ mediaProduct: MediaProduct, with streamingSessionId: String) async throws -> (Metadata, Asset) {
-		let offlinePlaybackAllowed = offlinePlaybackPrivilegeCheck?() ?? true
-		if let storedMediaProduct = mediaProduct as? StoredMediaProduct, offlinePlaybackAllowed {
+		let offlinePlaybackAllowed = offlinePlaybackPrivilegeCheck?() ?? false
+		if offlinePlaybackAllowed, let storedMediaProduct = mediaProduct as? StoredMediaProduct {
 			return try await (metadata(of: storedMediaProduct), playerLoader.load(storedMediaProduct))
 		}
 
-		if let offlineEntry = try? offlineStorage?.get(key: mediaProduct.productId),
-		   let offlinedMediaProduct = PlayableOfflinedMediaProduct(from: offlineEntry),
-		   offlinePlaybackAllowed
+		if offlinePlaybackAllowed,
+		   let offlineEntry = try? offlineStorage?.get(key: mediaProduct.productId),
+		   let offlinedMediaProduct = PlayableOfflinedMediaProduct(from: offlineEntry)
 		{
 			return try await (metadata(of: offlinedMediaProduct), playerLoader.load(offlinedMediaProduct))
 		}

--- a/Sources/Player/PlaybackEngine/Internal/PlayerItemLoaderError.swift
+++ b/Sources/Player/PlaybackEngine/Internal/PlayerItemLoaderError.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+enum PlayerItemLoaderError: Int {
+	case streamNotAllowedInOfflineMode = 1
+
+	func error(_ errorId: ErrorId) -> Error {
+		PlayerInternalError(
+			errorId: errorId,
+			errorType: .playerItemLoaderError,
+			code: rawValue
+		)
+	}
+}

--- a/Sources/Player/PlaybackEngine/PlayerEngine.swift
+++ b/Sources/Player/PlaybackEngine/PlayerEngine.swift
@@ -2,9 +2,9 @@ import Auth
 import AVFoundation
 import Foundation
 
-// swiftlint:disable file_length
-
 // MARK: - PlayerEngine
+
+// swiftlint:disable file_length
 
 final class PlayerEngine {
 	private let queue: OperationQueue
@@ -18,6 +18,7 @@ final class PlayerEngine {
 		// After receiving a new value, we need to update the loudness normalization of the current and next items.
 		didSet {
 			updateLoudnessNormalizationMode(configuration.loudnessNormalizationMode)
+			playerItemLoader.updateConfiguration(configuration)
 		}
 	}
 
@@ -136,6 +137,7 @@ final class PlayerEngine {
 			with: offlineStorage,
 			offlinePlaybackPrivilegeCheck,
 			playbackInfoFetcher,
+			configuration,
 			and: playerLoader
 		)
 
@@ -358,7 +360,7 @@ final class PlayerEngine {
 		// When media services are reset, Apple recommends to reinitialize the app's audio objects, which is out case is the player,
 		// and which is performed directly by the SDK. It's also recommended to reset the audio session’s category, options, and mode
 		// configuration. This is performed below.
-		self.reset()
+		reset()
 
 		// Then we should also set it up again the audio session as done initially. Since this is done outside the SDK, we delegate it
 		// to the notification handler to do it.

--- a/Sources/Player/PlaybackEngine/PlayerEngine.swift
+++ b/Sources/Player/PlaybackEngine/PlayerEngine.swift
@@ -110,6 +110,7 @@ final class PlayerEngine {
 		_ playerEventSender: PlayerEventSender,
 		_ networkMonitor: NetworkMonitor,
 		_ offlineStorage: OfflineStorage?,
+		_ offlinePlaybackPrivilegeCheck: (() -> Bool)?,
 		_ playerLoader: PlayerLoader,
 		_ featureFlagProvider: FeatureFlagProvider,
 		_ notificationsHandler: NotificationsHandler?
@@ -131,7 +132,12 @@ final class PlayerEngine {
 		self.notificationsHandler = notificationsHandler
 		self.featureFlagProvider = featureFlagProvider
 
-		playerItemLoader = PlayerItemLoader(with: offlineStorage, playbackInfoFetcher, and: playerLoader)
+		playerItemLoader = PlayerItemLoader(
+			with: offlineStorage,
+			offlinePlaybackPrivilegeCheck,
+			playbackInfoFetcher,
+			and: playerLoader
+		)
 
 		state = .IDLE
 		currentItem = nil

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -117,7 +117,8 @@ public extension Player {
 		eventSender: EventSender,
 		externalPlayersSupplier: (() -> [GenericMediaPlayer.Type])? = nil,
 		userClientIdSupplier: (() -> Int)? = nil,
-		shouldAddLogging: Bool = false
+		shouldAddLogging: Bool = false,
+		offlinePlaybackPrivilegeCheck: (() -> Bool)? = nil
 	) -> Player? {
 		if shared != nil {
 			return nil
@@ -424,7 +425,8 @@ private extension Player {
 		_ notificationsHandler: NotificationsHandler?,
 		_ featureFlagProvider: FeatureFlagProvider,
 		_ externalPlayersSupplier: (() -> [GenericMediaPlayer.Type])? = nil,
-		_ credentialsProvider: CredentialsProvider
+		_ credentialsProvider: CredentialsProvider,
+		_ offlinePlaybackPrivilegeCheck: (() -> Bool)? = nil
 	) -> PlayerEngine {
 		let internalPlayerLoader = InternalPlayerLoader(
 			with: configuration,
@@ -445,6 +447,7 @@ private extension Player {
 			playerEventSender,
 			networkMonitor,
 			offlineStorage,
+			offlinePlaybackPrivilegeCheck,
 			internalPlayerLoader,
 			featureFlagProvider,
 			notificationsHandler

--- a/Tests/PlayerTests/Mocks/Player+Mock.swift
+++ b/Tests/PlayerTests/Mocks/Player+Mock.swift
@@ -31,6 +31,7 @@ extension PlayerEngine {
 			playerEventSender,
 			networkMonitor,
 			storage,
+			nil,
 			playerLoader,
 			featureFlagProvider,
 			notificationsHandler


### PR DESCRIPTION
We want to be able to check inside `PlaybackEngine` if the user has permissions to play an offlined track.