### PR TITLE
Removed recent SwiftLint warnings

### DIFF
--- a/Sources/Auth/Storage/DefaultTokensStore.swift
+++ b/Sources/Auth/Storage/DefaultTokensStore.swift
@@ -68,7 +68,7 @@ final class DefaultTokensStore: TokensStore {
 
 	private func saveTokensUnsafe(tokens: Tokens) throws {
 		let data = try JSONEncoder().encode(tokens)
-		encryptedStorage[credentialsKey] = String(data: data, encoding: .utf8)
+		encryptedStorage[credentialsKey] = String(decoding: data, as: UTF8.self)
 		latestTokens = tokens
 		// TODO: emit credentails update:  `bus.emit(CredentialsUpdatedMessage)`
 	}

--- a/Sources/Common/Extensions/Dictionary+Extensions.swift
+++ b/Sources/Common/Extensions/Dictionary+Extensions.swift
@@ -5,6 +5,6 @@ extension [String: String] {
 		guard let data = try? JSONEncoder().encode(self) else {
 			return nil
 		}
-		return String(data: data, encoding: .utf8)
+		return String(decoding: data, as: UTF8.self)
 	}
 }

--- a/Sources/Common/Extensions/String+Extensions.swift
+++ b/Sources/Common/Extensions/String+Extensions.swift
@@ -20,10 +20,12 @@ public extension String {
 		allowedCharacterSet.remove(charactersIn: "\(generalDelimitersToEncode)\(subDelimitersToEncode)")
 		return addingPercentEncoding(withAllowedCharacters: allowedCharacterSet) ?? ""
 	}
-	
-	public func base64WithPadding() -> String {
+
+	func base64WithPadding() -> String {
 		let offset = count % 4
-		guard offset != 0 else { return self }
+		guard offset != 0 else {
+			return self
+		}
 		return padding(toLength: count + 4 - offset, withPad: "=", startingAt: 0)
 	}
 }

--- a/Sources/EventProducer/Monitoring/Monitoring.swift
+++ b/Sources/EventProducer/Monitoring/Monitoring.swift
@@ -28,11 +28,10 @@ struct Monitoring {
 	}
 
 	func getMonitoringEvent(from monitoringInfo: MonitoringInfo, headerHelper: HeaderHelper) async -> Event? {
-		guard let monitoringInfoData = try? JSONEncoder().encode(monitoringInfo),
-		      let monitoringPayload = String(data: monitoringInfoData, encoding: .utf8)
-		else {
+		guard let monitoringInfoData = try? JSONEncoder().encode(monitoringInfo) else {
 			return nil
 		}
+		let monitoringPayload = String(decoding: monitoringInfoData, as: UTF8.self)
 		let headers = await headerHelper.getDefaultHeaders(with: .necessary, isMonitoringEvent: true)
 		return Event(name: Self.eventName, headers: headers, payload: monitoringPayload)
 	}

--- a/Sources/Player/Common/Authentication/CredentialsSuccessDataParser.swift
+++ b/Sources/Player/Common/Authentication/CredentialsSuccessDataParser.swift
@@ -7,10 +7,10 @@ struct CredentialsSuccessDataParser {
 		let credentialStrings = token.components(separatedBy: ".")
 		if credentialStrings.count > 2 {
 			let credentialsSuccessBase64EncodedString = credentialStrings[1].base64WithPadding()
-			if let decodedCredentialsSuccessData = Data(base64Encoded: credentialsSuccessBase64EncodedString),
-			   let jsonCredentialsSuccessString = String(data: decodedCredentialsSuccessData, encoding: .utf8),
-			   let jsonCredentialsSuccessData = jsonCredentialsSuccessString.data(using: .utf8)
-			{
+			if let decodedCredentialsSuccessData = Data(base64Encoded: credentialsSuccessBase64EncodedString) {
+				let jsonCredentialsSuccessString = String(decoding: decodedCredentialsSuccessData, as: UTF8.self)
+				let jsonCredentialsSuccessData = Data(jsonCredentialsSuccessString.utf8)
+
 				let decoder = JSONDecoder()
 				do {
 					let credentialsSuccessData = try decoder.decode(CredentialsSuccessData.self, from: jsonCredentialsSuccessData)

--- a/Sources/Player/PlaybackEngine/Internal/Events/PlayerEventSender.swift
+++ b/Sources/Player/PlaybackEngine/Internal/Events/PlayerEventSender.swift
@@ -211,9 +211,9 @@ private extension PlayerEventSender {
 				print("StreamingPrivilegesHandler failed to get credentials")
 				return
 			}
-			
+
 			let userClientId = userClientIdSupplier?()
-		
+
 			let user = User(
 				id: Int(userId!) ?? -1,
 				accessToken: token ?? "N/A",
@@ -267,11 +267,7 @@ private extension PlayerEventSender {
 	) async {
 		do {
 			let data = try encoder.encode(event)
-			guard let serializedString = String(data: data, encoding: .utf8) else {
-				PlayerWorld.logger?.log(loggable: PlayerLoggable.sendToEventProducerSerializationFailed)
-				print("Unable to encode data from encoded event: \(event)")
-				return
-			}
+			let serializedString = String(decoding: data, as: UTF8.self)
 
 			try await eventSender.sendEvent(
 				name: name,

--- a/Sources/Player/PlaybackEngine/Internal/StreamingPrivileges/StreamingPrivilegesHandler.swift
+++ b/Sources/Player/PlaybackEngine/Internal/StreamingPrivileges/StreamingPrivilegesHandler.swift
@@ -196,7 +196,7 @@ private extension StreamingPrivilegesHandler {
 
 	func createMessage() throws -> String? {
 		let data = try encoder.encode(UserAction())
-		return String(data: data, encoding: .utf8)
+		return String(decoding: data, as: UTF8.self)
 	}
 
 	func handle(_ message: URLSessionWebSocketTask.Message) async {

--- a/Tests/PlayerTests/Playlog/PlayLogTests.swift
+++ b/Tests/PlayerTests/Playlog/PlayLogTests.swift
@@ -134,7 +134,6 @@ final class PlayLogTests: XCTestCase {
 
 		let djProducerTimeoutPolicy = TimeoutPolicy.shortLived
 		let djProducerSession = URLSession.new(with: djProducerTimeoutPolicy, name: "Player DJ Session")
-		let djProducerHTTPClient = HttpClient(using: djProducerSession)
 
 		djProducer = DJProducer(
 			httpClient: HttpClient.mock(),

--- a/Tests/PlayerTests/Playlog/PlayLogTestsWithDeinit.swift
+++ b/Tests/PlayerTests/Playlog/PlayLogTestsWithDeinit.swift
@@ -128,7 +128,6 @@ final class PlayLogWithDeinitTests: XCTestCase {
 
 		let djProducerTimeoutPolicy = TimeoutPolicy.shortLived
 		let djProducerSession = URLSession.new(with: djProducerTimeoutPolicy, name: "Player DJ Session")
-		let djProducerHTTPClient = HttpClient(using: djProducerSession)
 
 		djProducer = DJProducer(
 			httpClient: HttpClient.mock(),


### PR DESCRIPTION
As the title says.

[One of the warnings](https://realm.github.io/SwiftLint/non_optional_string_data_conversion.html) was related to how we were doing Data <-> String conversions, because if we use UTF8 encoding, it can never fail, so we can change to a non-optional way of doing it.

[More info here](https://github.com/realm/SwiftLint/issues/5263) and [here](https://www.swiftbysundell.com/tips/converting-between-string-and-data-without-optionals/)