### PR TITLE
[Player] Calculate size of downloaded MediaProducts

### DIFF
--- a/Sources/Player/Common/Logging/PlayerLoggable.swift
+++ b/Sources/Player/Common/Logging/PlayerLoggable.swift
@@ -120,6 +120,8 @@ enum PlayerLoggable: TidalLoggable {
 	// MARK: MediaDownloader
 
 	case downloadFinishedMovingFileFailed(error: Error)
+	case failedToCalculateSizeForHLSDownload(error: Error)
+	case failedToCalculateSizeForProgressiveDownload(error: Error)
 
 	// MARK: AVQueuePlayerWrapperLegacy
 
@@ -192,8 +194,8 @@ enum PlayerLoggable: TidalLoggable {
 	// MARK: Metrics
 
 	case metricsNoIdealStartTime
-
 }
+
 // swiftlint:enable identifier_name
 
 // MARK: - Logging
@@ -334,6 +336,10 @@ extension PlayerLoggable {
 		// MediaDownloader
 		case .downloadFinishedMovingFileFailed:
 			"MediaDownloader-downloadFinishedMovingFileFailed"
+		case .failedToCalculateSizeForHLSDownload:
+			"MediaDownloader-failedToCalculateSizeForHLSDownload"
+		case .failedToCalculateSizeForProgressiveDownload:
+			"MediaDownloader-failedToCalculateSizeForProgressiveDownload"
 
 		// AVQueuePlayerWrapperLegacy
 		case .legacyReadPlaybackMetadataFailed:
@@ -469,6 +475,8 @@ extension PlayerLoggable {
 		     let .licenseDownloaderContentKeyRequestFailed(error),
 		     let .licenseDownloaderGetLicenseFailed(error),
 		     let .downloadFinishedMovingFileFailed(error),
+		     let .failedToCalculateSizeForHLSDownload(error),
+		     let .failedToCalculateSizeForProgressiveDownload(error),
 		     let .legacyReadPlaybackMetadataFailed(error),
 		     let .readPlaybackMetadataFailed(error),
 		     let .djSessionStartFailed(error),
@@ -490,46 +498,46 @@ extension PlayerLoggable {
 		case let .changeMonitorHandleNotificationDefaultReason(reason):
 			metadata[Constants.metadataRouteChangeReasonKey] = "\(String(describing: reason))"
 		case .streamingNotifyGetCredentialFailed,
-				.streamingConnectOfflineMode,
-				.streamingConnectNoToken,
-				.webSocketSendMessageInvalidData,
-				.webSocketReceiveMessageInvalidData,
-				.webSocketHandleErrorRetryStrategyNone,
-				.streamingHandleInvalidMessage,
-				.streamingInterpretInvalidData,
-				.writeEventNotAuthorized,
-				.sendToEventProducerSerializationFailed,
-				.sendEventsNotAuthorized,
-				.getAuthBearerTokenToBearerTokenFailed,
-				.audioCodecInitWithEmpty,
-				.audioCodecInitWithNilQuality,
-				.audioCodecInitWithLowQualityAndNilMode,
-				.avplayerSeekWithoutCurrentItem,
-				.interruptionMonitorHandleNotificationWithoutRequiredData,
-				.interruptionMonitorHandleNotificationEndedNoOptions,
-				.interruptionMonitorHandleNotificationEndedNoShouldResume,
-				.interruptionMonitorHandleNotificationEndedNotPlayingWhenInterrupted,
-				.interruptionMonitorHandleNotificationUnknownType,
-				.changeMonitorHandleNotificationWithoutRequiredData,
-				.changeMonitorUpdateVolumeWithoutRequiredData,
-				.eventSenderInitEventsDirectoryFailed,
-				.eventSenderInitOfflinePlaysDirectoryFailed,
-				.eventSenderInitializeDirectoryNoURLPath,
-				.writeEventNoClientId,
-				.assetPlaybackMetadataInitWithoutRateAndDepthData,
-				.assetPlaybackMetadataInitWithoutRequiredData,
-				.djSessionStartNoCurationURL,
-				.djSessionPlayProductNotTrack,
-				.djSessionPauseNoCurationURL,
-				.djSessionStopNoCurationURL,
-				.djSessionStopOnNextCommand,
-				.djSessionResetNoCurationURL,
-				.djSessionSendStopOnNextCommand,
-				.metricsNoIdealStartTime,
-				.handleErrorNoNotificationsHandler,
-				.handleErrorCancellation,
-				.handleErrorPlayerItemNotCurrent,
-				.handleErrorPlayerItemNotNext:
+		     .streamingConnectOfflineMode,
+		     .streamingConnectNoToken,
+		     .webSocketSendMessageInvalidData,
+		     .webSocketReceiveMessageInvalidData,
+		     .webSocketHandleErrorRetryStrategyNone,
+		     .streamingHandleInvalidMessage,
+		     .streamingInterpretInvalidData,
+		     .writeEventNotAuthorized,
+		     .sendToEventProducerSerializationFailed,
+		     .sendEventsNotAuthorized,
+		     .getAuthBearerTokenToBearerTokenFailed,
+		     .audioCodecInitWithEmpty,
+		     .audioCodecInitWithNilQuality,
+		     .audioCodecInitWithLowQualityAndNilMode,
+		     .avplayerSeekWithoutCurrentItem,
+		     .interruptionMonitorHandleNotificationWithoutRequiredData,
+		     .interruptionMonitorHandleNotificationEndedNoOptions,
+		     .interruptionMonitorHandleNotificationEndedNoShouldResume,
+		     .interruptionMonitorHandleNotificationEndedNotPlayingWhenInterrupted,
+		     .interruptionMonitorHandleNotificationUnknownType,
+		     .changeMonitorHandleNotificationWithoutRequiredData,
+		     .changeMonitorUpdateVolumeWithoutRequiredData,
+		     .eventSenderInitEventsDirectoryFailed,
+		     .eventSenderInitOfflinePlaysDirectoryFailed,
+		     .eventSenderInitializeDirectoryNoURLPath,
+		     .writeEventNoClientId,
+		     .assetPlaybackMetadataInitWithoutRateAndDepthData,
+		     .assetPlaybackMetadataInitWithoutRequiredData,
+		     .djSessionStartNoCurationURL,
+		     .djSessionPlayProductNotTrack,
+		     .djSessionPauseNoCurationURL,
+		     .djSessionStopNoCurationURL,
+		     .djSessionStopOnNextCommand,
+		     .djSessionResetNoCurationURL,
+		     .djSessionSendStopOnNextCommand,
+		     .metricsNoIdealStartTime,
+		     .handleErrorNoNotificationsHandler,
+		     .handleErrorCancellation,
+		     .handleErrorPlayerItemNotCurrent,
+		     .handleErrorPlayerItemNotNext:
 			break
 		}
 
@@ -575,6 +583,8 @@ extension PlayerLoggable {
 		     .licenseDownloaderContentKeyRequestFailed,
 		     .licenseDownloaderGetLicenseFailed,
 		     .downloadFinishedMovingFileFailed,
+		     .failedToCalculateSizeForHLSDownload,
+		     .failedToCalculateSizeForProgressiveDownload,
 		     .legacyReadPlaybackMetadataFailed,
 		     .readPlaybackMetadataFailed,
 		     .djSessionStartFailed,
@@ -583,47 +593,47 @@ extension PlayerLoggable {
 		     .loadPlayerItemFailed:
 			.error
 		case .streamingNotifyGetCredentialFailed,
-				.streamingConnectOfflineMode,
-				.streamingConnectNoToken,
-				.webSocketReceiveMessageInvalidData,
-				.webSocketSendMessageInvalidData,
-				.webSocketHandleErrorRetryStrategyNone,
-				.streamingHandleInvalidMessage,
-				.streamingInterpretInvalidData,
-				.audioCodecInitWithEmpty,
-				.audioCodecInitWithUnknown,
-				.audioCodecInitWithNilQuality,
-				.audioCodecInitWithLowQualityAndNilMode,
-				.audioCodecInitWithLowQualityAndUnsupportedMode,
-				.playbackErrorIdFromSubstatus,
-				.avplayerSeekWithoutCurrentItem,
-				.interruptionMonitorHandleNotificationWithoutRequiredData,
-				.interruptionMonitorHandleNotificationEndedNoOptions,
-				.interruptionMonitorHandleNotificationEndedNoShouldResume,
-				.interruptionMonitorHandleNotificationEndedNotPlayingWhenInterrupted,
-				.interruptionMonitorHandleNotificationUnknownType,
-				.changeMonitorHandleNotificationWithoutRequiredData,
-				.changeMonitorHandleNotificationDefaultReason,
-				.changeMonitorUpdateVolumeWithoutRequiredData,
-				.eventSenderInitEventsDirectoryFailed,
-				.eventSenderInitOfflinePlaysDirectoryFailed,
-				.eventSenderInitializeDirectoryNoURLPath,
-				.writeEventNoClientId,
-				.assetPlaybackMetadataInitWithoutRateAndDepthData,
-				.assetPlaybackMetadataInitWithoutRequiredData,
-				.assetPlaybackMetadataInitWithInvalidFormatFlags,
-				.djSessionStartNoCurationURL,
-				.djSessionPlayProductNotTrack,
-				.djSessionPauseNoCurationURL,
-				.djSessionStopNoCurationURL,
-				.djSessionStopOnNextCommand,
-				.djSessionResetNoCurationURL,
-				.djSessionSendStopOnNextCommand,
-				.metricsNoIdealStartTime,
-				.handleErrorNoNotificationsHandler,
-				.handleErrorCancellation,
-				.handleErrorPlayerItemNotCurrent,
-				.handleErrorPlayerItemNotNext:
+		     .streamingConnectOfflineMode,
+		     .streamingConnectNoToken,
+		     .webSocketReceiveMessageInvalidData,
+		     .webSocketSendMessageInvalidData,
+		     .webSocketHandleErrorRetryStrategyNone,
+		     .streamingHandleInvalidMessage,
+		     .streamingInterpretInvalidData,
+		     .audioCodecInitWithEmpty,
+		     .audioCodecInitWithUnknown,
+		     .audioCodecInitWithNilQuality,
+		     .audioCodecInitWithLowQualityAndNilMode,
+		     .audioCodecInitWithLowQualityAndUnsupportedMode,
+		     .playbackErrorIdFromSubstatus,
+		     .avplayerSeekWithoutCurrentItem,
+		     .interruptionMonitorHandleNotificationWithoutRequiredData,
+		     .interruptionMonitorHandleNotificationEndedNoOptions,
+		     .interruptionMonitorHandleNotificationEndedNoShouldResume,
+		     .interruptionMonitorHandleNotificationEndedNotPlayingWhenInterrupted,
+		     .interruptionMonitorHandleNotificationUnknownType,
+		     .changeMonitorHandleNotificationWithoutRequiredData,
+		     .changeMonitorHandleNotificationDefaultReason,
+		     .changeMonitorUpdateVolumeWithoutRequiredData,
+		     .eventSenderInitEventsDirectoryFailed,
+		     .eventSenderInitOfflinePlaysDirectoryFailed,
+		     .eventSenderInitializeDirectoryNoURLPath,
+		     .writeEventNoClientId,
+		     .assetPlaybackMetadataInitWithoutRateAndDepthData,
+		     .assetPlaybackMetadataInitWithoutRequiredData,
+		     .assetPlaybackMetadataInitWithInvalidFormatFlags,
+		     .djSessionStartNoCurationURL,
+		     .djSessionPlayProductNotTrack,
+		     .djSessionPauseNoCurationURL,
+		     .djSessionStopNoCurationURL,
+		     .djSessionStopOnNextCommand,
+		     .djSessionResetNoCurationURL,
+		     .djSessionSendStopOnNextCommand,
+		     .metricsNoIdealStartTime,
+		     .handleErrorNoNotificationsHandler,
+		     .handleErrorCancellation,
+		     .handleErrorPlayerItemNotCurrent,
+		     .handleErrorPlayerItemNotNext:
 			.debug
 		}
 	}

--- a/Sources/Player/Common/Utils/FileManager/FileManagerClient+Live.swift
+++ b/Sources/Player/Common/Utils/FileManager/FileManagerClient+Live.swift
@@ -38,6 +38,9 @@ extension FileManagerClient {
 		},
 		contentsOfDirectory: { url, keys, options in
 			try FileManager.default.contentsOfDirectory(at: url, includingPropertiesForKeys: keys, options: options)
+		},
+		enumerator: { url, keys, options, handler in
+			FileManager.default.enumerator(at: url, includingPropertiesForKeys: keys, options: options, errorHandler: handler)
 		}
 	)
 }

--- a/Sources/Player/Common/Utils/FileManager/FileManagerClient.swift
+++ b/Sources/Player/Common/Utils/FileManager/FileManagerClient.swift
@@ -20,6 +20,12 @@ struct FileManagerClient {
 	var createDirectory: (_ url: URL, _ createIntermediates: Bool, _ attributes: [FileAttributeKey: Any]?) throws -> Void
 	var contentsOfDirectory: (_ url: URL, _ keys: [URLResourceKey]?, _ options: FileManager.DirectoryEnumerationOptions) throws
 		-> [URL]
+	var enumerator: (
+		_ url: URL,
+		_ includingPropertiesForKeys: [URLResourceKey]?,
+		_ options: FileManager.DirectoryEnumerationOptions,
+		_ handler: ((URL, any Error) -> Bool)?
+	) -> FileManager.DirectoryEnumerator?
 }
 
 extension FileManagerClient {
@@ -62,5 +68,14 @@ extension FileManagerClient {
 		options mask: FileManager.DirectoryEnumerationOptions = []
 	) throws -> [URL] {
 		try contentsOfDirectory(url, keys, mask)
+	}
+
+	func enumerator(
+		at url: URL,
+		includingPropertiesForKeys keys: [URLResourceKey]?,
+		options mask: FileManager.DirectoryEnumerationOptions = [],
+		errorHandler handler: ((URL, any Error) -> Bool)? = nil
+	) -> FileManager.DirectoryEnumerator? {
+		enumerator(url, keys, mask, handler)
 	}
 }

--- a/Sources/Player/OfflineEngine/Internal/DownloadTask.swift
+++ b/Sources/Player/OfflineEngine/Internal/DownloadTask.swift
@@ -29,6 +29,7 @@ final class DownloadTask {
 
 	private var localAssetUrl: URL?
 	private var localLicenseUrl: URL?
+	private var localAssetSize: Int?
 
 	init(
 		mediaProduct: MediaProduct,
@@ -95,6 +96,11 @@ final class DownloadTask {
 		finalize()
 	}
 
+	func setSize(_ size: Int) {
+		localAssetSize = size
+		finalize()
+	}
+
 	func reportProgress(_ progress: Double) {
 		monitor?.progress(downloadTask: self, progress: progress)
 	}
@@ -122,7 +128,7 @@ final class DownloadTask {
 
 private extension DownloadTask {
 	func finalize() {
-		guard let playbackInfo, let localAssetUrl else {
+		guard let playbackInfo, let localAssetUrl, let localAssetSize else {
 			return
 		}
 
@@ -131,8 +137,12 @@ private extension DownloadTask {
 		}
 
 		do {
-			// TODO: Alberto - Calculate real size of download content
-			let offlineEntry = try OfflineEntry(from: playbackInfo, with: localAssetUrl, and: localLicenseUrl, size: 0)
+			let offlineEntry = try OfflineEntry(
+				from: playbackInfo,
+				with: localAssetUrl,
+				and: localLicenseUrl,
+				size: localAssetSize
+			)
 			monitor?.completed(downloadTask: self, offlineEntry: offlineEntry)
 			endTimestamp = PlayerWorld.timeProvider.timestamp()
 		} catch {

--- a/Sources/Player/OfflineEngine/Internal/MediaDownloader.swift
+++ b/Sources/Player/OfflineEngine/Internal/MediaDownloader.swift
@@ -62,18 +62,15 @@ private extension MediaDownloader {
 	}
 
 	func calculateHLSStreamSize(for path: URL) -> UInt64 {
-		let fileManager = FileManager.default
 		var totalSize: UInt64 = 0
 
-		if let enumerator = fileManager.enumerator(
+		if let enumerator = PlayerWorld.fileManagerClient.enumerator(
 			at: path,
-			includingPropertiesForKeys: [.fileSizeKey],
-			options: [],
-			errorHandler: nil
+			includingPropertiesForKeys: [URLResourceKey.fileSizeKey]
 		) {
 			for case let fileURL as URL in enumerator {
 				do {
-					let fileAttributes = try fileURL.resourceValues(forKeys: [.fileSizeKey])
+					let fileAttributes = try fileURL.resourceValues(forKeys: [URLResourceKey.fileSizeKey])
 					if let fileSize = fileAttributes.fileSize {
 						totalSize += UInt64(fileSize)
 					}

--- a/Sources/Player/OfflineEngine/Internal/MediaDownloader.swift
+++ b/Sources/Player/OfflineEngine/Internal/MediaDownloader.swift
@@ -95,7 +95,7 @@ private extension MediaDownloader {
 		} catch {
 			print("Error getting file size: \(error.localizedDescription)")
 		}
-		return total0Size
+		return 0
 	}
 }
 

--- a/Sources/Player/OfflineEngine/Internal/MediaDownloader.swift
+++ b/Sources/Player/OfflineEngine/Internal/MediaDownloader.swift
@@ -75,7 +75,7 @@ private extension MediaDownloader {
 						totalSize += UInt64(fileSize)
 					}
 				} catch {
-					print("Error reading file size: \(error.localizedDescription)")
+					PlayerWorld.logger?.log(loggable: PlayerLoggable.failedToCalculateSizeForHLSDownload(error: error))
 				}
 			}
 		}
@@ -90,7 +90,7 @@ private extension MediaDownloader {
 				return fileSize
 			}
 		} catch {
-			print("Error getting file size: \(error.localizedDescription)")
+			PlayerWorld.logger?.log(loggable: PlayerLoggable.failedToCalculateSizeForProgressiveDownload(error: error))
 		}
 		return 0
 	}

--- a/Sources/Player/OfflineEngine/Internal/MediaDownloader.swift
+++ b/Sources/Player/OfflineEngine/Internal/MediaDownloader.swift
@@ -60,6 +60,43 @@ private extension MediaDownloader {
 	func createTask(for url: URL) -> URLSessionDownloadTask {
 		urlDownloadSession.downloadTask(with: url)
 	}
+
+	func calculateHLSStreamSize(for path: URL) -> UInt64 {
+		let fileManager = FileManager.default
+		var totalSize: UInt64 = 0
+
+		if let enumerator = fileManager.enumerator(
+			at: path,
+			includingPropertiesForKeys: [.fileSizeKey],
+			options: [],
+			errorHandler: nil
+		) {
+			for case let fileURL as URL in enumerator {
+				do {
+					let fileAttributes = try fileURL.resourceValues(forKeys: [.fileSizeKey])
+					if let fileSize = fileAttributes.fileSize {
+						totalSize += UInt64(fileSize)
+					}
+				} catch {
+					print("Error reading file size: \(error.localizedDescription)")
+				}
+			}
+		}
+
+		return totalSize
+	}
+
+	func calculateProgressiveFileSize(for path: URL) -> UInt64 {
+		do {
+			let fileAttributes = try FileManager.default.attributesOfItem(atPath: path.path)
+			if let fileSize = fileAttributes[.size] as? UInt64 {
+				return fileSize
+			}
+		} catch {
+			print("Error getting file size: \(error.localizedDescription)")
+		}
+		return total0Size
+	}
 }
 
 // MARK: AVAssetDownloadDelegate, URLSessionDownloadDelegate
@@ -82,6 +119,7 @@ extension MediaDownloader: AVAssetDownloadDelegate, URLSessionDownloadDelegate {
 			activeTasks.removeValue(forKey: assetDownloadTask)
 		}
 
+		activeTasks[assetDownloadTask]?.setSize(Int(calculateHLSStreamSize(for: location)))
 		activeTasks[assetDownloadTask]?.setMediaUrl(location)
 	}
 
@@ -95,6 +133,7 @@ extension MediaDownloader: AVAssetDownloadDelegate, URLSessionDownloadDelegate {
 			let fileManager = PlayerWorld.fileManagerClient
 			let url = fileManager.cachesDirectory().appendingPathComponent(uuid)
 			try fileManager.moveFile(location, url)
+			activeTasks[downloadTask]?.setSize(Int(calculateProgressiveFileSize(for: location)))
 			activeTasks[downloadTask]?.setMediaUrl(url)
 		} catch {
 			PlayerWorld.logger?.log(loggable: PlayerLoggable.downloadFinishedMovingFileFailed(error: error))

--- a/Tests/PlayerTests/Mocks/Common/Utils/FileManager/FileManagerClient+Mock.swift
+++ b/Tests/PlayerTests/Mocks/Common/Utils/FileManager/FileManagerClient+Mock.swift
@@ -39,6 +39,9 @@ extension FileManagerClient {
 		},
 		contentsOfDirectory: { url, keys, options in
 			try FileManager.default.contentsOfDirectory(at: url, includingPropertiesForKeys: keys, options: options)
+		},
+		enumerator: { url, keys, options, handler in
+			FileManager.default.enumerator(at: url, includingPropertiesForKeys: keys, options: options, errorHandler: handler)
 		}
 	)
 }


### PR DESCRIPTION
## Context
As part of the new `OfflineEngine`, we want to calculate the total size of the downloaded Media so we can expose it to our users.

## Description
This PRs adds functionality to calculate both the size of progressive files downloaded, as well as the size of HLS streams downloaded.

HLS streams are stored as a folder with a bunch of files and subfolders, and we need to calculate the total size of all of those files.