### PR TITLE
Simple logging API

### DIFF
--- a/Sources/Common/Logger/LoggerMetadata+Extension.swift
+++ b/Sources/Common/Logger/LoggerMetadata+Extension.swift
@@ -1,0 +1,8 @@
+import Foundation
+import Logging
+
+public extension Logger.Metadata {
+	init(stringDict: [String: String]) {
+		self = stringDict.mapValues { .string($0) }
+	}
+}

--- a/Sources/Common/Logger/TidalLogger.swift
+++ b/Sources/Common/Logger/TidalLogger.swift
@@ -33,21 +33,18 @@ public extension TidalLogger {
 		message: String,
 		source: String,
 		level: Logger.Level? = nil,
-		metadata: [String: String]? = nil,
+		metadata: Logger.Metadata? = nil,
 		file: String = #fileID,
 		function: String = #function,
 		line: UInt = #line
 	) {
 		let level = level ?? logger.logLevel
 		let loggerMessage = Logger.Message(stringLiteral: message)
-		let loggerMetadata: Logger.Metadata? = metadata?.mapValues {
-			.string($0)
-		}
 	
 		self.log(
 			level: level,
 			message: loggerMessage,
-			metadata: loggerMetadata,
+			metadata: metadata,
 			source: source,
 			file: file,
 			function: function,

--- a/Sources/Common/Logger/TidalLogger.swift
+++ b/Sources/Common/Logger/TidalLogger.swift
@@ -11,7 +11,7 @@ public struct TidalLogger {
 }
 
 private extension TidalLogger {
-	func log(level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata? = nil, source: String? = nil, file: String, function: String, line: UInt) {
+	func log(level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata? = nil, source: String, file: String, function: String, line: UInt) {
 		self.logger.log(level: level, message, metadata: metadata, source: source, file: file, function: function, line: line)
 	}
 }
@@ -23,6 +23,32 @@ public extension TidalLogger {
 			message: loggable.loggingMessage,
 			metadata: loggable.loggingMetadata,
 			source: loggable.source,
+			file: file,
+			function: function,
+			line: line
+		)
+	}
+	
+	func log(
+		message: String,
+		source: String,
+		level: Logger.Level? = nil,
+		metadata: [String: String]? = nil,
+		file: String = #fileID,
+		function: String = #function,
+		line: UInt = #line
+	) {
+		let level = level ?? logger.logLevel
+		let loggerMessage = Logger.Message(stringLiteral: message)
+		let loggerMetadata: Logger.Metadata? = metadata?.mapValues {
+			.string($0)
+		}
+	
+		self.log(
+			level: level,
+			message: loggerMessage,
+			metadata: loggerMetadata,
+			source: source,
 			file: file,
 			function: function,
 			line: line


### PR DESCRIPTION
There is no need to create `TidalLoggable` in simple scenarios.

This function allows to log without it.

Also, I made a `source` mandatory