### PR TITLE
Better error descriptions

### DIFF
--- a/Sources/Auth/Model/AuthLoggable.swift
+++ b/Sources/Auth/Model/AuthLoggable.swift
@@ -65,15 +65,15 @@ extension AuthLoggable {
 			 let .finalizeLoginNetworkError(error),
 			 let .finalizeDeviceLoginNetworkError(error),
 			 let .getCredentialsUpgradeTokenNetworkError(error):
-			metadata[Self.metadataErrorKey] = "\(error.localizedDescription)"
+			metadata[Self.metadataErrorKey] = .string(.init(describing: error))
 		case let .getCredentialsRefreshTokenNetworkError(error, previousSubstatus),
 			 let .getCredentialsRefreshTokenWithClientCredentialsNetworkError(error, previousSubstatus):
-			metadata[Self.metadataErrorKey] = "\(error.localizedDescription)"
+			metadata[Self.metadataErrorKey] = .string(.init(describing: error))
 			metadata[Self.metadataPreviousSubstatusKey] = "\(previousSubstatus ?? "nil")"
 		case let .authLogout(reason, error, previousSubstatus):
 			metadata[Self.metadataReasonKey] = "\(reason)"
 			if let error = error {
-				metadata[Self.metadataErrorKey] = "\(error.localizedDescription)"
+				metadata[Self.metadataErrorKey] = .string(.init(describing: error))
 			}
 			metadata[Self.metadataPreviousSubstatusKey] = "\(previousSubstatus ?? "nil")"
 			return metadata

--- a/Sources/Common/TidalError.swift
+++ b/Sources/Common/TidalError.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-open class TidalError: LocalizedError {
+open class TidalError: Error, CustomStringConvertible {
 	public let code: String
 	public let subStatus: Int?
 	public let message: String?
@@ -18,7 +18,7 @@ open class TidalError: LocalizedError {
 		self.throwable = throwable
 	}
 
-	public var errorDescription: String? {
-		"\(self), code: \(code), substatus: \(subStatus?.description ?? "nil"), message: \(message ?? "nil"), throwable: \(throwable.map { "\($0)" } ?? "nil"), throwable description: \(throwable?.localizedDescription ?? "nil")"
+	public var description: String {
+		"\(String(describing: type(of: self))), code: \(code), substatus: \(subStatus?.description ?? "nil"), message: \(message ?? "nil"), throwable: \(String(describing: throwable))"
 	}
 }


### PR DESCRIPTION
Do not use localized description for errors. Instead, use `String(describing:)` and `CustomStringConvertible`