### PR TITLE
Remove djSessionPlayNoCurationURL logging which is not needed

### DIFF
--- a/Sources/Player/Common/Logging/PlayerLoggable.swift
+++ b/Sources/Player/Common/Logging/PlayerLoggable.swift
@@ -134,7 +134,6 @@ enum PlayerLoggable: TidalLoggable {
 	case djSessionStartFailed(error: Error)
 	case djSessionSendCommandFailed(error: Error)
 	case djSessionStartNoCurationURL
-	case djSessionPlayNoCurationURL
 	case djSessionPlayProductNotTrack
 	case djSessionPauseNoCurationURL
 	case djSessionStopNoCurationURL
@@ -351,8 +350,6 @@ extension PlayerLoggable {
 			"DJProducer-djSessionSendCommandFailed"
 		case .djSessionStartNoCurationURL:
 			"DJProducer-djSessionStartNoCurationURL"
-		case .djSessionPlayNoCurationURL:
-			"DJProducer-djSessionPlayNoCurationURL"
 		case .djSessionPlayProductNotTrack:
 			"DJProducer-djSessionPlayProductNotTrack"
 		case .djSessionPauseNoCurationURL:
@@ -522,7 +519,6 @@ extension PlayerLoggable {
 				.assetPlaybackMetadataInitWithoutRateAndDepthData,
 				.assetPlaybackMetadataInitWithoutRequiredData,
 				.djSessionStartNoCurationURL,
-				.djSessionPlayNoCurationURL,
 				.djSessionPlayProductNotTrack,
 				.djSessionPauseNoCurationURL,
 				.djSessionStopNoCurationURL,
@@ -617,7 +613,6 @@ extension PlayerLoggable {
 				.assetPlaybackMetadataInitWithoutRequiredData,
 				.assetPlaybackMetadataInitWithInvalidFormatFlags,
 				.djSessionStartNoCurationURL,
-				.djSessionPlayNoCurationURL,
 				.djSessionPlayProductNotTrack,
 				.djSessionPauseNoCurationURL,
 				.djSessionStopNoCurationURL,

--- a/Sources/Player/PlaybackEngine/Internal/Broadcasting/DJProducer.swift
+++ b/Sources/Player/PlaybackEngine/Internal/Broadcasting/DJProducer.swift
@@ -68,7 +68,6 @@ final class DJProducer {
 	func play(_ mediaProduct: MediaProduct, at position: Double) {
 		queue.dispatch {
 			guard let curationUrl = self.curationUrl else {
-				PlayerWorld.logger?.log(loggable: PlayerLoggable.djSessionPlayNoCurationURL)
 				return
 			}
 


### PR DESCRIPTION
We have added some overall logs in Player, and slowly we can notice if they provide value or not. One of them already proved it's not useful and can therefore be removed.

---

This pull request involves the removal of the `djSessionPlayNoCurationURL` case from the `PlayerLoggable` enum and its associated logging calls. This simplifies the logging by eliminating an unused case.

Changes to `PlayerLoggable`:

* Removed the `djSessionPlayNoCurationURL` case from the `PlayerLoggable` enum. (`Sources/Player/Common/Logging/PlayerLoggable.swift`)
* Removed the corresponding logging string for `djSessionPlayNoCurationURL` in the `PlayerLoggable` extension. (`Sources/Player/Common/Logging/PlayerLoggable.swift`)
* Removed `djSessionPlayNoCurationURL` from the list of loggable events in the `PlayerLoggable` extension. (`Sources/Player/Common/Logging/PlayerLoggable.swift`) [[1]](diffhunk://#diff-241c41ad3dff9ee36736f5b5fc913320fd065b24ed9aeba7e1016bcf2345ef49L525) [[2]](diffhunk://#diff-241c41ad3dff9ee36736f5b5fc913320fd065b24ed9aeba7e1016bcf2345ef49L620)

Changes to `DJProducer`:

* Removed the logging call for `djSessionPlayNoCurationURL` in the `play` method of the `DJProducer` class. (`Sources/Player/PlaybackEngine/Internal/Broadcasting/DJProducer.swift`)