### PR TITLE
As an attempt to fix a seek issue, add a FF which means we will pause and play around the seek call

### DIFF
--- a/Sources/Player/Common/FeatureFlags/FeatureFlagProvider+Standard.swift
+++ b/Sources/Player/Common/FeatureFlags/FeatureFlagProvider+Standard.swift
@@ -5,6 +5,7 @@ public extension FeatureFlagProvider {
 		shouldUseEventProducer: { false },
 		isContentCachingEnabled: { true },
 		shouldSendEventsInDeinit: { true },
-		shouldUseImprovedCaching: { false }
+		shouldUseImprovedCaching: { false },
+		shouldPauseAndPlayAroundSeek: { false }
 	)
 }

--- a/Sources/Player/Common/FeatureFlags/FeatureFlagProvider.swift
+++ b/Sources/Player/Common/FeatureFlags/FeatureFlagProvider.swift
@@ -3,16 +3,19 @@ public struct FeatureFlagProvider {
 	public var isContentCachingEnabled: () -> Bool
 	public var shouldSendEventsInDeinit: () -> Bool
 	public var shouldUseImprovedCaching: () -> Bool
+	public var shouldPauseAndPlayAroundSeek: () -> Bool
 
 	public init(
 		shouldUseEventProducer: @escaping () -> Bool,
 		isContentCachingEnabled: @escaping () -> Bool,
 		shouldSendEventsInDeinit: @escaping () -> Bool,
-		shouldUseImprovedCaching: @escaping () -> Bool
+		shouldUseImprovedCaching: @escaping () -> Bool,
+		shouldPauseAndPlayAroundSeek: @escaping () -> Bool
 	) {
 		self.shouldUseEventProducer = shouldUseEventProducer
 		self.isContentCachingEnabled = isContentCachingEnabled
 		self.shouldSendEventsInDeinit = shouldSendEventsInDeinit
 		self.shouldUseImprovedCaching = shouldUseImprovedCaching
+		self.shouldPauseAndPlayAroundSeek = shouldPauseAndPlayAroundSeek
 	}
 }

--- a/Sources/Player/Mocks/Common/FeatureFlags/FeatureFlagProvider+Mock.swift
+++ b/Sources/Player/Mocks/Common/FeatureFlags/FeatureFlagProvider+Mock.swift
@@ -5,6 +5,7 @@ public extension FeatureFlagProvider {
 		shouldUseEventProducer: { true },
 		isContentCachingEnabled: { true },
 		shouldSendEventsInDeinit: { true },
-		shouldUseImprovedCaching: { false }
+		shouldUseImprovedCaching: { false },
+		shouldPauseAndPlayAroundSeek: { false }
 	)
 }

--- a/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/AVQueuePlayerWrapper.swift
+++ b/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/AVQueuePlayerWrapper.swift
@@ -203,6 +203,7 @@ final class AVQueuePlayerWrapper: GenericMediaPlayer {
 					return
 				}
 
+				asset.setAssetPosition(currentItem)
 			} else {
 				let completed = await self.player.seek(to: time)
 				guard completed, currentItem == self.player.currentItem, self.player.timeControlStatus == .playing else {

--- a/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/AVQueuePlayerWrapper.swift
+++ b/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/AVQueuePlayerWrapper.swift
@@ -20,6 +20,7 @@ final class AVQueuePlayerWrapper: GenericMediaPlayer {
 
 	@Atomic private var player: AVQueuePlayer
 	private var playerMonitor: AVPlayerMonitor?
+	private var isSeeking = false
 
 	private let contentKeyDelegateQueue: DispatchQueue = DispatchQueue(label: "com.tidal.player.contentkeydelegate.queue")
 	private let playbackTimeProgressQueue: DispatchQueue = DispatchQueue(label: "com.tidal.player.playbacktimeprogress.queue")
@@ -32,6 +33,10 @@ final class AVQueuePlayerWrapper: GenericMediaPlayer {
 
 	private var isContentCachingEnabled: Bool {
 		featureFlagProvider.isContentCachingEnabled()
+	}
+
+	private var shouldPauseAndPlayAroundSeek: Bool {
+		featureFlagProvider.shouldPauseAndPlayAroundSeek()
 	}
 
 	private let supportedCodecs: [PlayerAudioCodec] = [
@@ -184,13 +189,29 @@ final class AVQueuePlayerWrapper: GenericMediaPlayer {
 
 			self.delegates.seeking(in: asset)
 
-			let completed = await self.player.seek(to: time)
-			guard completed, currentItem == self.player.currentItem, self.player.timeControlStatus == .playing else {
-				return
-			}
+			if self.shouldPauseAndPlayAroundSeek {
+				if self.player.timeControlStatus == .playing {
+					self.isSeeking = true
+					await self.player.pause()
+				}
 
-			asset.setAssetPosition(currentItem)
-			self.delegates.playing(asset: asset)
+				let completed = await self.player.seek(to: time)
+				self.isSeeking = false
+				await self.player.play()
+
+				guard completed, currentItem == self.player.currentItem else {
+					return
+				}
+
+			} else {
+				let completed = await self.player.seek(to: time)
+				guard completed, currentItem == self.player.currentItem, self.player.timeControlStatus == .playing else {
+					return
+				}
+
+				asset.setAssetPosition(currentItem)
+				self.delegates.playing(asset: asset)
+			}
 		}
 	}
 
@@ -512,6 +533,9 @@ private extension AVQueuePlayerWrapper {
 	}
 
 	func paused(playerItem: AVPlayerItem) {
+		guard !isSeeking else {
+			return
+		}
 		queue.dispatch {
 			guard let asset = self.playerItemAssets[playerItem] else {
 				return

--- a/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/Legacy/AVQueuePlayerWrapperLegacy.swift
+++ b/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/Legacy/AVQueuePlayerWrapperLegacy.swift
@@ -174,10 +174,9 @@ final class AVQueuePlayerWrapperLegacy: GenericMediaPlayer {
 					return
 				}
 			} else {
-				self.player.seek(to: seekTime) { completed in
-					guard completed, currentItem == self.player.currentItem, self.player.timeControlStatus == .playing else {
-						return
-					}
+				let completed = await self.player.seek(to: time)
+				guard completed, currentItem == self.player.currentItem, self.player.timeControlStatus == .playing else {
+					return
 				}
 			}
 

--- a/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/Legacy/AVQueuePlayerWrapperLegacy.swift
+++ b/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/Legacy/AVQueuePlayerWrapperLegacy.swift
@@ -159,7 +159,6 @@ final class AVQueuePlayerWrapperLegacy: GenericMediaPlayer {
 
 			self.delegates.seeking(in: asset)
 
-			let seekTime = CMTime(seconds: time, preferredTimescale: 1000)
 			if self.shouldPauseAndPlayAroundSeek {
 				if self.player.timeControlStatus == .playing {
 					self.isSeeking = true
@@ -173,15 +172,17 @@ final class AVQueuePlayerWrapperLegacy: GenericMediaPlayer {
 				guard completed, currentItem == self.player.currentItem else {
 					return
 				}
+
+				asset.setAssetPosition(currentItem)
 			} else {
 				let completed = await self.player.seek(to: time)
 				guard completed, currentItem == self.player.currentItem, self.player.timeControlStatus == .playing else {
 					return
 				}
-			}
 
-			asset.setAssetPosition(currentItem)
-			self.delegates.playing(asset: asset)
+				asset.setAssetPosition(currentItem)
+				self.delegates.playing(asset: asset)
+			}
 		}
 	}
 


### PR DESCRIPTION
Attempt to address an issue we have around seeking.

⚠️ I'm testing our metrics to make sure nothing gets broken because of this, so the code is not final. Also, because our playlog tests are flaky, we cannot fully rely on them, so I'm adapting and testing locally since they are less flaky than in CI.

---

This pull request introduces a new feature flag for pausing and playing around seek operations in the player, along with the necessary logic to handle this behavior in the `AVQueuePlayerWrapper` and `AVQueuePlayerWrapperLegacy` classes. The most important changes are as follows:

### Feature Flags Update:

* [`Sources/Player/Common/FeatureFlags/FeatureFlagProvider.swift`](diffhunk://#diff-4cd187606f8aae83fb59b73a080a87896fe6033ce7fed43af1bc02b0d4b5dfc5R6-R19): Added `shouldPauseAndPlayAroundSeek` to the `FeatureFlagProvider` struct and its initializer.
* [`Sources/Player/Common/FeatureFlags/FeatureFlagProvider+Standard.swift`](diffhunk://#diff-357b6e003c6e1c07f64bda0a4006d43ba8928ecc38a2c1b7e8c5848e6f6b9fecL8-R9): Updated the standard feature flag provider to include `shouldPauseAndPlayAroundSeek`.
* [`Sources/Player/Mocks/Common/FeatureFlags/FeatureFlagProvider+Mock.swift`](diffhunk://#diff-29ec55675dc54daf5487ce14e6350480fed65a1f0163e4d1bda67fe83128c6deL8-R9): Updated the mock feature flag provider to include `shouldPauseAndPlayAroundSeek`.

### Player Wrapper Logic:

* `Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/AVQueuePlayerWrapper.swift`: 
  * Introduced `isSeeking` property and `shouldPauseAndPlayAroundSeek` computed property. [[1]](diffhunk://#diff-b75f24d9a1db1bbe79fed5b71b9fd741a62df41c29d49643af0db04b36fe6985R23) [[2]](diffhunk://#diff-b75f24d9a1db1bbe79fed5b71b9fd741a62df41c29d49643af0db04b36fe6985R38-R41)
  * Modified seek logic to pause and play around seek if the new feature flag is enabled. [[1]](diffhunk://#diff-b75f24d9a1db1bbe79fed5b71b9fd741a62df41c29d49643af0db04b36fe6985R192-R206) [[2]](diffhunk://#diff-b75f24d9a1db1bbe79fed5b71b9fd741a62df41c29d49643af0db04b36fe6985R216)
  * Updated `paused` method to check `isSeeking` status.

* `Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/Legacy/AVQueuePlayerWrapperLegacy.swift`: 
  * Introduced `isSeeking` property and `shouldPauseAndPlayAroundSeek` computed property.
  * Modified seek logic to pause and play around seek if the new feature flag is enabled.
  * Updated `paused` method to check `isSeeking` status.