### PR TITLE
AnyCodable Extras

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -71,7 +71,7 @@ let package = Package(
 		.target(
 			name: "Common",
 			dependencies: [
-				.Logging
+				.Logging,
 			],
 			plugins: [
 				.plugin(name: "SwiftLint", package: "SwiftLintPlugin"),
@@ -128,6 +128,7 @@ let package = Package(
 				.auth,
 				.eventProducer,
 				.GRDB,
+				.AnyCodable,
 			],
 			resources: [
 				.process("README.md"),

--- a/Package.swift
+++ b/Package.swift
@@ -72,6 +72,7 @@ let package = Package(
 			name: "Common",
 			dependencies: [
 				.Logging,
+				.AnyCodable,
 			],
 			plugins: [
 				.plugin(name: "SwiftLint", package: "SwiftLintPlugin"),
@@ -128,7 +129,6 @@ let package = Package(
 				.auth,
 				.eventProducer,
 				.GRDB,
-				.AnyCodable,
 			],
 			resources: [
 				.process("README.md"),

--- a/Sources/Common/AnyCodableDictionary.swift
+++ b/Sources/Common/AnyCodableDictionary.swift
@@ -1,0 +1,3 @@
+import AnyCodable
+
+public typealias AnyCodableDictionary = [String: AnyCodable?]

--- a/Sources/Common/AnyCodableDictionary.swift
+++ b/Sources/Common/AnyCodableDictionary.swift
@@ -3,13 +3,7 @@ import Foundation
 
 public typealias AnyCodableDictionary = [String: AnyCodable?]
 
-// MARK: - AnyCodableDictionaryConvertible
-
-public protocol AnyCodableDictionaryConvertible: Codable {
-	func asAnyCodableDictionary() throws -> AnyCodableDictionary
-}
-
-public extension AnyCodableDictionaryConvertible {
+public extension Encodable {
 	func asAnyCodableDictionary() throws -> AnyCodableDictionary {
 		let dictionary = try JSONEncoder().encode(self)
 		return try JSONDecoder().decode(AnyCodableDictionary.self, from: dictionary)

--- a/Sources/Common/AnyCodableDictionary.swift
+++ b/Sources/Common/AnyCodableDictionary.swift
@@ -1,3 +1,17 @@
 import AnyCodable
+import Foundation
 
 public typealias AnyCodableDictionary = [String: AnyCodable?]
+
+// MARK: - AnyCodableDictionaryConvertible
+
+public protocol AnyCodableDictionaryConvertible: Codable {
+	func asAnyCodableDictionary() throws -> AnyCodableDictionary
+}
+
+public extension AnyCodableDictionaryConvertible {
+	func asAnyCodableDictionary() throws -> AnyCodableDictionary {
+		let dictionary = try JSONEncoder().encode(self)
+		return try JSONDecoder().decode(AnyCodableDictionary.self, from: dictionary)
+	}
+}

--- a/Sources/Player/Common/Types/MediaProduct.swift
+++ b/Sources/Player/Common/Types/MediaProduct.swift
@@ -1,10 +1,8 @@
-import Common
 import Foundation
 
 // MARK: - MediaProduct
 
 public class MediaProduct: Codable {
-	public typealias Extras = AnyCodableDictionary
 	public let productType: ProductType
 	public let productId: String
 	public let referenceId: String?

--- a/Sources/Player/Common/Types/MediaProduct.swift
+++ b/Sources/Player/Common/Types/MediaProduct.swift
@@ -1,14 +1,16 @@
+import Common
 import Foundation
 
 // MARK: - MediaProduct
 
 public class MediaProduct: Codable {
+	public typealias Extras = AnyCodableDictionary
 	public let productType: ProductType
 	public let productId: String
 	public let referenceId: String?
 	public let progressSource: Source?
 	public let playLogSource: Source?
-	public let extras: [String: String?]?
+	public let extras: Extras?
 
 	public init(
 		productType: ProductType,
@@ -16,7 +18,7 @@ public class MediaProduct: Codable {
 		referenceId: String?,
 		progressSource: Source?,
 		playLogSource: Source?,
-		extras: [String: String?]?
+		extras: Extras?
 	) {
 		self.productType = productType
 		self.productId = productId

--- a/Sources/Player/Common/Types/MediaProductExtras.swift
+++ b/Sources/Player/Common/Types/MediaProductExtras.swift
@@ -1,0 +1,13 @@
+import Common
+
+// MARK: - MediaProduct.Extras
+
+public extension MediaProduct {
+	typealias Extras = AnyCodableDictionary
+}
+
+public extension Encodable {
+	func asMediaProductExtras() throws -> MediaProduct.Extras {
+		try asAnyCodableDictionary()
+	}
+}

--- a/Sources/Player/Common/Types/StoredMediaProduct.swift
+++ b/Sources/Player/Common/Types/StoredMediaProduct.swift
@@ -20,7 +20,7 @@ public final class StoredMediaProduct: MediaProduct {
 		referenceId: String?,
 		progressSource: Source?,
 		playLogSource: Source?,
-		extras: [String: String?]?,
+		extras: Extras?,
 		assetPresentation: AssetPresentation,
 		audioMode: AudioMode?,
 		audioQuality: AudioQuality?,

--- a/Sources/Player/Mocks/Common/Types/MediaProduct+Mock.swift
+++ b/Sources/Player/Mocks/Common/Types/MediaProduct+Mock.swift
@@ -7,7 +7,7 @@ public extension MediaProduct {
 		referenceId: String? = nil,
 		progressSource: Source? = nil,
 		playLogSource: Source? = nil,
-		extras: [String: String?]? = nil
+		extras: Extras? = nil
 	) -> MediaProduct {
 		MediaProduct(
 			productType: productType,

--- a/Sources/Player/Mocks/Common/Types/StoredMediaProduct+Mock.swift
+++ b/Sources/Player/Mocks/Common/Types/StoredMediaProduct+Mock.swift
@@ -7,7 +7,7 @@ public extension StoredMediaProduct {
 		referenceId: String? = nil,
 		progressSource: Source? = nil,
 		playLogSource: Source? = nil,
-		extras: [String: String?]? = nil,
+		extras: Extras? = nil,
 		assetPresentation: AssetPresentation = .FULL,
 		audioMode: AudioMode? = nil,
 		audioQuality: AudioQuality? = nil,

--- a/Sources/Player/PlaybackEngine/Internal/Events/LegacyEvent.swift
+++ b/Sources/Player/PlaybackEngine/Internal/Events/LegacyEvent.swift
@@ -1,8 +1,10 @@
+import Common
 import Foundation
 
 // MARK: - LegacyEvent
 
 final class LegacyEvent<T: Codable & Equatable>: Codable {
+	typealias Extras = AnyCodableDictionary
 	let group: String
 	let name: String
 	let version: Int
@@ -11,9 +13,9 @@ final class LegacyEvent<T: Codable & Equatable>: Codable {
 	let user: User
 	let client: Client
 	let payload: T
-	let extras: [String: String?]?
+	let extras: Extras?
 
-	init(group: String, name: String, version: Int, ts: UInt64, user: User, client: Client, payload: T, extras: [String: String?]?) {
+	init(group: String, name: String, version: Int, ts: UInt64, user: User, client: Client, payload: T, extras: Extras?) {
 		self.group = group
 		self.name = name
 		self.version = version

--- a/Sources/Player/PlaybackEngine/Internal/Events/PlayerEvent.swift
+++ b/Sources/Player/PlaybackEngine/Internal/Events/PlayerEvent.swift
@@ -1,8 +1,10 @@
+import Common
 import EventProducer
 
 // MARK: - PlayerEvent
 
 final class PlayerEvent<T: Codable & Equatable>: Codable {
+	typealias Extras = AnyCodableDictionary
 	let group: String
 	let version: Int
 	let ts: UInt64
@@ -10,9 +12,9 @@ final class PlayerEvent<T: Codable & Equatable>: Codable {
 	let user: User
 	let client: Client
 	let payload: T
-	let extras: [String: String?]?
+	let extras: Extras?
 
-	init(group: String, version: Int, ts: UInt64, user: User, client: Client, payload: T, extras: [String: String?]?) {
+	init(group: String, version: Int, ts: UInt64, user: User, client: Client, payload: T, extras: Extras?) {
 		self.group = group
 		self.version = version
 		self.ts = ts

--- a/Sources/Player/PlaybackEngine/Internal/Events/PlayerEventSender.swift
+++ b/Sources/Player/PlaybackEngine/Internal/Events/PlayerEventSender.swift
@@ -1,4 +1,5 @@
 import Auth
+import Common
 import EventProducer
 import Foundation
 
@@ -75,7 +76,7 @@ class PlayerEventSender {
 		write(group: .streamingMetrics, name: event.name, payload: event, extras: nil)
 	}
 
-	func send(_ event: PlayLogEvent, extras: [String: String?]?) {
+	func send(_ event: PlayLogEvent, extras: PlayerEvent.Extras?) {
 		write(group: .playlog, name: EventNames.playbackSession, payload: event, extras: extras)
 	}
 
@@ -189,7 +190,12 @@ private extension PlayerEventSender {
 		self.timer = timer
 	}
 
-	func write<T: Codable & Equatable>(group: EventGroup, name: String, payload: T, extras: [String: String?]?) {
+	func write<T: Codable & Equatable>(
+		group: EventGroup,
+		name: String,
+		payload: T,
+		extras: PlayerEvent.Extras?
+	) {
 		let now = PlayerWorld.timeProvider.timestamp()
 		asyncSchedulerFactory.create { [weak self] in
 			guard let self else {

--- a/Tests/CommonTests/AnyCodableDictionaryConversionTests.swift
+++ b/Tests/CommonTests/AnyCodableDictionaryConversionTests.swift
@@ -3,9 +3,9 @@ import AnyCodable
 import Foundation
 import XCTest
 
-// MARK: - CommonTests
+// MARK: - AnyCodableDictionaryConversionTests
 
-final class CommonTests: XCTestCase {
+final class AnyCodableDictionaryConversionTests: XCTestCase {
 	func test_asAnyCodableDictionary_convertsToAnyCodableDictionary() throws {
 		let codableFixture = CodableFixture.anyCodableFixture
 
@@ -19,7 +19,7 @@ final class CommonTests: XCTestCase {
 
 // MARK: - CodableFixture
 
-private struct CodableFixture: AnyCodableDictionaryConvertible, Equatable {
+private struct CodableFixture: Codable, Equatable {
 	let optional: String?
 	let optionalString: String?
 	let string: String

--- a/Tests/CommonTests/CommonTests.swift
+++ b/Tests/CommonTests/CommonTests.swift
@@ -1,13 +1,48 @@
+import AnyCodable
 @testable import Common
+import Foundation
 import XCTest
 
-final class CommonTests: XCTestCase {
-	func testCommon() throws {
-		// This is an example of a functional test case.
-		// Use XCTAssert and related functions to verify your tests produce the correct
-		// results.
-		let common = Common()
+// MARK: - CommonTests
 
-		XCTAssertEqual(common.sayHello(), "Hello, World!")
+final class CommonTests: XCTestCase {
+	func test_asAnyCodableDictionary_convertsToAnyCodableDictionary() throws {
+		let codableFixture = CodableFixture.anyCodableFixture
+
+		let codableDictionary = try codableFixture.asAnyCodableDictionary()
+		let encodedDictionary = try JSONEncoder().encode(codableDictionary)
+		let decodedDictionary = try JSONDecoder().decode(CodableFixture.self, from: encodedDictionary)
+
+		XCTAssertEqual(codableFixture, decodedDictionary)
 	}
+}
+
+// MARK: - CodableFixture
+
+private struct CodableFixture: AnyCodableDictionaryConvertible, Equatable {
+	let optional: String?
+	let optionalString: String?
+	let string: String
+	let int: Int
+	let bool: Bool
+	let double: Double
+	let array: [String]
+	let dictionary: [String: String]
+	let innerStruct: InnerCodableStruct
+
+	struct InnerCodableStruct: Codable, Equatable {
+		let name: String
+	}
+
+	static let anyCodableFixture = CodableFixture(
+		optional: nil,
+		optionalString: "optionalStringValue",
+		string: "stringValue",
+		int: 1,
+		bool: true,
+		double: 1.2,
+		array: ["a", "b"],
+		dictionary: ["key": "value"],
+		innerStruct: .init(name: "Some-name")
+	)
 }

--- a/Tests/PlayerTests/Mocks/PlaybackEngine/Internal/Events/PlayerEventExtrasMock.swift
+++ b/Tests/PlayerTests/Mocks/PlaybackEngine/Internal/Events/PlayerEventExtrasMock.swift
@@ -1,0 +1,20 @@
+@testable import Player
+
+extension PlayerEvent.Extras {
+	static func mock() -> Self {
+		[
+			"string": "some-value",
+			"none": nil,
+			"boolean": true,
+			"integer": 1,
+			"double": 1.1,
+			"array": ["value1", "value2"],
+			"dictionary": [
+				"key": "value",
+				"anotherKey": 1,
+				"yetAnotherKey": true,
+				"nestedDictionary": ["nestedKey": "nestedValue"],
+			],
+		]
+	}
+}

--- a/Tests/PlayerTests/Mocks/PlaybackEngine/Internal/Events/PlayerEventSenderMock.swift
+++ b/Tests/PlayerTests/Mocks/PlaybackEngine/Internal/Events/PlayerEventSenderMock.swift
@@ -39,7 +39,7 @@ final class PlayerEventSenderMock: PlayerEventSender {
 		streamingMetricsEvents.append(event)
 	}
 
-	override func send(_ event: PlayLogEvent, extras: [String: String?]?) {
+	override func send(_ event: PlayLogEvent, extras: PlayerEvent.Extras?) {
 		playLogEvents.append(event)
 	}
 

--- a/Tests/PlayerTests/Player/PlaybackEngine/Internal/Events/PlayerEventSenderTests.swift
+++ b/Tests/PlayerTests/Player/PlaybackEngine/Internal/Events/PlayerEventSenderTests.swift
@@ -10,9 +10,12 @@ import XCTest
 private enum Constants {
 	static let token = "1234"
 	static let tokenEncodedBase64 = "blabla.eyJjaWQiOjEyMzR9.blahblah"
-	
+
 	static let userId = 19
-	static let successfulAuthResult: AuthResult = AuthResult.success(Credentials.mock(userId: String(userId), token: tokenEncodedBase64))
+	static let successfulAuthResult: AuthResult = AuthResult.success(Credentials.mock(
+		userId: String(userId),
+		token: tokenEncodedBase64
+	))
 	static let successfulAuthResultNoUserId: AuthResult = AuthResult.success(Credentials.mock(token: tokenEncodedBase64))
 	static let failedAuthResult: AuthResult = AuthResult<Credentials>.failure(TidalErrorMock(code: "81"))
 	static let userClientId = 10
@@ -450,7 +453,7 @@ private extension PlayerEventSenderTests {
 
 	func assertLegacyPlayLogEvent() async {
 		let playLogEvent = PlayLogEvent.mock()
-		let playLogEventExtras = ["field_1": "1", "field_2": nil]
+		let playLogEventExtras: PlayerEvent.Extras = .mock()
 		playerEventSender.send(playLogEvent, extras: playLogEventExtras)
 
 		await asyncSchedulerFactory.executeAll()
@@ -471,7 +474,7 @@ private extension PlayerEventSenderTests {
 
 	func assertPlayLogEvent() async {
 		let playLogEvent = PlayLogEvent.mock()
-		let playLogEventExtras = ["field_1": "1", "field_2": nil]
+		let playLogEventExtras: PlayerEvent.Extras = .mock()
 		playerEventSender.send(playLogEvent, extras: playLogEventExtras)
 
 		await asyncSchedulerFactory.executeAll()
@@ -487,7 +490,7 @@ private extension PlayerEventSenderTests {
 		group: EventGroup,
 		consentCategory: ConsentCategory,
 		playerEvent: T,
-		extras: [String: String?]?
+		extras: PlayerEvent.Extras?
 	) {
 		let expectedEvent = PlayerEvent(
 			group: group.rawValue,


### PR DESCRIPTION
## Context
This PR aims to introduce `AnyCodable` extras for the `MediaProduct` class, which will allow any aCodablea object from the client app to be passed as `extras`. 

## Description
- The [`AnyCodable`](https://github.com/Flight-School/AnyCodable) library was recently added to this project as part of the OpenAPI work being done. This simplified this piece of work quite a bit, as this library is exactly the solution that was proposed for this solution. 
- A new type (typealias for now) `AnyCodableDictionary = [String: AnyCodable?]` was introduced in the `Common` module. This was done to prevent the undesired spread of the `AnyCodable` type to the `Player` module. By doing this, the `Player` doesn't require new explicit dependencies at least. 
- In addition all `Encodable` types were extended with a `asAnyCodableDictionary()` adapter method to make it easy to convert any `Encodable` type to `AnyCodableDictionary`.
- A new type `MediaProduct.Extras` (`typealias` for `AnyCodableDictionary`  were introduced to further curb the spread of the new type for users of the `Player` module. With this type, users of the `Player` doesn't require any other imports other than the `Player`. This allows independent change and evolution of this type, without impacting users of the module too much.
- `MediaProduct.Extras` was also updated with its own `asMediaProductExtras()` conversion on `Encodable` types, which just uses `asAnyCodableDictionary()` under to hood. This is again to prevent the undesired spread of the `AnyCodable` type. 
- `PlayerEvent.Extras` was also updated accordingly with the same idea in mind. 
- Lastly, `AnyCodableDictionaryConversionTests` tests were added to prove the conversion to `AnyCodableDictionary` for any `Encodable` type. 