### PR TITLE
[PLAYER] Reworked AVQueuePlayerWrapper to solve enqueue crash

### DIFF
--- a/Sources/Player/Common/Logging/PlayerLoggable.swift
+++ b/Sources/Player/Common/Logging/PlayerLoggable.swift
@@ -130,6 +130,8 @@ enum PlayerLoggable: TidalLoggable {
 	// MARK: AVQueuePlayerWrapper
 
 	case readPlaybackMetadataFailed(error: Error)
+	case playWithoutQueuedItems
+	case itemChangedWithoutQueuedItems
 
 	// MARK: DJProducer
 
@@ -348,6 +350,10 @@ extension PlayerLoggable {
 		// AVQueuePlayerWrapper
 		case .readPlaybackMetadataFailed:
 			"AVQueuePlayerWrapper-readPlaybackMetadataFailed"
+		case .playWithoutQueuedItems:
+			"AVQueuePlayerWrapper-playWithoutQueuedItems"
+		case .itemChangedWithoutQueuedItems:
+			"AVQueuePlayerWrapper-itemChangedWithoutQueuedItems"
 
 		// DJProducer
 		case .djSessionStartFailed:
@@ -537,7 +543,9 @@ extension PlayerLoggable {
 		     .handleErrorNoNotificationsHandler,
 		     .handleErrorCancellation,
 		     .handleErrorPlayerItemNotCurrent,
-		     .handleErrorPlayerItemNotNext:
+		     .handleErrorPlayerItemNotNext,
+		     .playWithoutQueuedItems,
+		     .itemChangedWithoutQueuedItems:
 			break
 		}
 
@@ -633,7 +641,9 @@ extension PlayerLoggable {
 		     .handleErrorNoNotificationsHandler,
 		     .handleErrorCancellation,
 		     .handleErrorPlayerItemNotCurrent,
-		     .handleErrorPlayerItemNotNext:
+		     .handleErrorPlayerItemNotNext,
+		     .playWithoutQueuedItems,
+		     .itemChangedWithoutQueuedItems:
 			.debug
 		}
 	}

--- a/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/AVQueuePlayerWrapper.swift
+++ b/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/AVQueuePlayerWrapper.swift
@@ -2,9 +2,9 @@ import AVFoundation
 import Foundation
 import MediaPlayer
 
-// swiftlint:disable file_length
-
 // MARK: - Constants
+
+// swiftlint:disable file_length
 
 private enum Constants {
 	static let defaultVolume: Float = 1
@@ -62,7 +62,7 @@ final class AVQueuePlayerWrapper: GenericMediaPlayer {
 		queue.maxConcurrentOperationCount = 1
 		queue.qualityOfService = .userInitiated
 
-		assetFactory = AVURLAssetFactory(with: queue)
+		assetFactory = AVURLAssetFactory()
 		player = AVQueuePlayerWrapper.createPlayer()
 
 		preparePlayer()
@@ -130,30 +130,27 @@ final class AVQueuePlayerWrapper: GenericMediaPlayer {
 
 	func unload(asset: Asset) {
 		queue.dispatch {
-			guard let (playerItem, asset) = self.playerItemAssets.first(where: { _, a in a === asset }) else {
+			guard let (playerItem, _) = self.playerItemAssets.first(where: { _, a in a === asset }) else {
 				return
 			}
 
-			if let urlAsset = playerItem.asset as? AVURLAsset,
-			   !urlAsset.isPlayableOffline,
-			   let key = asset.cacheState?.key
-			{
+			if let key = asset.cacheState?.key {
 				self.assetFactory.cancel(with: key)
 			}
 
 			self.unload(playerItem: playerItem)
 
 			if playerItem === self.player.currentItem {
+				// If we are unloading the item that is playing
+				// And there are no more assets loaded we do a reset
 				guard let (nextPlayerItem, _) = self.playerItemAssets.first else {
-					// If we are unloading the item that is playing
-					// And there are no more assets loaded we do a reset
 					self.internalReset()
 					return
 				}
 				self.enqueue(playerItem: nextPlayerItem)
 				self.player.advanceToNextItem()
 			} else {
-				if self.player.items().contains(playerItem) {
+				if !self.player.canInsert(playerItem, after: nil) {
 					self.player.remove(playerItem)
 				}
 				if self.playerItemAssets.isEmpty {
@@ -166,10 +163,7 @@ final class AVQueuePlayerWrapper: GenericMediaPlayer {
 	func play() {
 		queue.dispatch {
 			if self.player.items().isEmpty {
-				guard let (playerItem, _) = self.playerItemAssets.first else {
-					return
-				}
-				self.enqueue(playerItem: playerItem)
+				PlayerWorld.logger?.log(loggable: PlayerLoggable.playWithoutQueuedItems)
 			}
 			self.player.play()
 		}
@@ -375,7 +369,6 @@ private extension AVQueuePlayerWrapper {
 		let playerItem = AVQueuePlayerWrapper.createPlayerItem(urlAsset)
 		register(playerItem: playerItem, for: asset)
 
-		// We only insert it if we don't need to cache it.
 		// Items in the AVPlayer queue are not downloaded in advance
 		// This way the next item in the queue can be downloaded in advance.
 		if cacheState == nil {
@@ -384,6 +377,9 @@ private extension AVQueuePlayerWrapper {
 			switch state.status {
 			case .notCached:
 				assetFactory.cacheAsset(urlAsset, for: state.key)
+				if player.items().isEmpty {
+					enqueue(playerItem: playerItem)
+				}
 			case .cached:
 				enqueue(playerItem: playerItem)
 			}
@@ -594,19 +590,17 @@ private extension AVQueuePlayerWrapper {
 			// AVPlayer has moved to the next item in its queue
 			if let currentPlayerItem = self.player.currentItem {
 				self.delegates.completed(asset: asset)
-
 				if self.player.timeControlStatus == .playing {
 					self.playing(playerItem: currentPlayerItem)
 				}
-
 			} else {
-				// AVPlayer had no other item in the queue (we are still downloading the next one)
+				// AVPlayer had no other item in the queue (we are still downloading the next one?)
+				PlayerWorld.logger?.log(loggable: PlayerLoggable.itemChangedWithoutQueuedItems)
 				if let (nextPlayerItem, _) = self.playerItemAssets.first {
 					self.enqueue(playerItem: nextPlayerItem)
 				} else {
 					self.internalReset()
 				}
-
 				self.delegates.completed(asset: asset)
 			}
 		}
@@ -640,7 +634,7 @@ extension AVQueuePlayerWrapper: AssetFactoryDelegate {
 		queue.dispatch {
 			guard
 				let (oldPlayerItem, asset) = self.playerItemAssets.first(where: { $0.value.cacheState?.key == cacheKey }),
-				!self.player.items().contains(oldPlayerItem)
+				self.player.canInsert(oldPlayerItem, after: nil)
 			else {
 				return
 			}

--- a/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/AVQueuePlayerWrapper.swift
+++ b/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/AVQueuePlayerWrapper.swift
@@ -594,7 +594,7 @@ private extension AVQueuePlayerWrapper {
 					self.playing(playerItem: currentPlayerItem)
 				}
 			} else {
-				// AVPlayer had no other item in the queue (we are still downloading the next one?)
+				// AVPlayer had no other item in the queue (We might still be downloading the next one)`
 				PlayerWorld.logger?.log(loggable: PlayerLoggable.itemChangedWithoutQueuedItems)
 				if let (nextPlayerItem, _) = self.playerItemAssets.first {
 					self.enqueue(playerItem: nextPlayerItem)

--- a/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/AVURLAssetFactory.swift
+++ b/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/AVURLAssetFactory.swift
@@ -12,7 +12,6 @@ protocol AssetFactoryDelegate: AnyObject {
 final class AVURLAssetFactory: NSObject {
 	private static let TTL: Int = 24 * 60 * 60
 
-	private let queue: OperationQueue
 	private let assetCache: AssetCache
 
 	private var downloads: [Download] = [Download]()
@@ -23,14 +22,12 @@ final class AVURLAssetFactory: NSObject {
 	private lazy var session: AVAssetDownloadURLSession = AVAssetDownloadURLSession(
 		configuration: URLSessionConfiguration.background(withIdentifier: "com.tidal.player.hls-cache-\(uuid)"),
 		assetDownloadDelegate: self,
-		delegateQueue: queue
+		delegateQueue: nil
 	)
 
 	init(
-		with queue: OperationQueue,
 		assetCache: AssetCache = AssetCache()
 	) {
-		self.queue = queue
 		self.assetCache = assetCache
 	}
 


### PR DESCRIPTION

## Context
Adjusted the implementation of `AVQueuePlayerWrapper` that uses the improved caching system to solve a crash we have seen on production when we enable the flag to a % of our users.

Unfortunately, we have been unable to reproduce this crash locally.

We have been testing for the past few days a build using this PR branch with ~20 users and ~4k streams without the crash happening and without other issues appearing.

## Description

This PR contains two main changes to the Player <-> cache integration
* The cache uses it's own queue
* We enqueue immediately the first item we load even if it's not cached, instead of waiting until the play is called (this was done to have more time to start caching it)