### PR TITLE
[Player] Fix OfflineItem size calculation

### DIFF
--- a/Sources/Player/Common/Logging/PlayerLoggable.swift
+++ b/Sources/Player/Common/Logging/PlayerLoggable.swift
@@ -80,7 +80,8 @@ enum PlayerLoggable: TidalLoggable {
 
 	// MARK: Offline Engine
 
-	case deleteOfflinedItem(error: Error)
+	case saveOfflinedItemFailed(error: Error)
+	case deleteOfflinedItemFailed(error: Error)
 
 	// MARK: Asset Cache Legacy
 
@@ -294,8 +295,10 @@ extension PlayerLoggable {
 			"GRDBOfflineStorage-withDefaultDatabase"
 
 		// Offline Engine
-		case .deleteOfflinedItem:
-			"OfflineEngine-deleteOfflinedItem"
+		case .saveOfflinedItemFailed:
+			"OfflineEngine-saveOfflinedItemFailed"
+		case .deleteOfflinedItemFailed:
+			"OfflineEngine-deleteOfflinedItemFailed"
 
 		// Asset Cache Legacy
 		case .deleteAssetCacheFailed:
@@ -468,7 +471,8 @@ extension PlayerLoggable {
 		     let .downloadFailed(error),
 		     let .downloadFinalizeFailed(error),
 		     let .withDefaultDatabase(error),
-		     let .deleteOfflinedItem(error),
+		     let .saveOfflinedItemFailed(error),
+		     let .deleteOfflinedItemFailed(error),
 		     let .deleteAssetCacheFailed(error),
 		     let .getAuthBearerTokenCredentialFailed(error),
 		     let .licenseLoaderContentKeyRequestFailed(error),
@@ -577,7 +581,8 @@ extension PlayerLoggable {
 		     .downloadFailed,
 		     .downloadFinalizeFailed,
 		     .withDefaultDatabase,
-		     .deleteOfflinedItem,
+		     .saveOfflinedItemFailed,
+		     .deleteOfflinedItemFailed,
 		     .deleteAssetCacheFailed,
 		     .getAuthBearerTokenToBearerTokenFailed,
 		     .licenseLoaderContentKeyRequestFailed,

--- a/Sources/Player/OfflineEngine/OfflineEngine.swift
+++ b/Sources/Player/OfflineEngine/OfflineEngine.swift
@@ -81,7 +81,7 @@ extension OfflineEngine: DownloadObserver {
 			try offlineStorage.save(offlineEntry)
 			offlinerDelegate?.offliningCompleted(for: mediaProduct)
 		} catch {
-			print("Failed to save item: \(error)")
+			PlayerWorld.logger?.log(loggable: PlayerLoggable.saveOfflinedItemFailed(error: error))
 			offlinerDelegate?.offliningFailed(for: mediaProduct)
 		}
 	}
@@ -111,8 +111,7 @@ private extension OfflineEngine {
 			try offlineStorage.delete(key: mediaProduct.productId)
 			offlinerDelegate?.offlinedDeleted(for: mediaProduct)
 		} catch {
-			PlayerWorld.logger?.log(loggable: PlayerLoggable.deleteOfflinedItem(error: error))
-			print("Failed to remove item: \(error)")
+			PlayerWorld.logger?.log(loggable: PlayerLoggable.deleteOfflinedItemFailed(error: error))
 		}
 	}
 }


### PR DESCRIPTION
I noticed a couple of bugs in the size calculation code while testing the client integration.

This PR fixes them, and refactors the size calculation into the `DownloadTask` , where it makes more sense.

The two things fixed:
* Use the correct size algorithm for the calculation based on the download type (using PlaybackInfo), 
* Use the final URL where we move the progressive file download into, instead of the temporary download path! 🤦‍♂️ 