### PR TITLE
Add `Common` product

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,6 +30,10 @@ let package = Package(
 			name: "Player",
 			targets: ["Player"]
 		),
+		.library(
+			name: "Common",
+			targets: ["Common"]
+		),
 	],
 	dependencies: [
 		.package(url: "https://github.com/groue/GRDB.swift.git", from: "6.27.0"),


### PR DESCRIPTION
To enable using the contents of `Common` individually it needs to be exposed as a product