### PR TITLE
[Player] Refactor OfflineEngine Listener setup and handling

### DIFF
--- a/Sources/Player/Common/Event/NotificationsHandler.swift
+++ b/Sources/Player/Common/Event/NotificationsHandler.swift
@@ -2,10 +2,12 @@ import Foundation
 
 final class NotificationsHandler {
 	private let listener: PlayerListener
+	private let offlineEngineListener: OfflineEngineListener?
 	private let queue: DispatchQueue
 
-	init(listener: PlayerListener, queue: DispatchQueue) {
+	init(listener: PlayerListener, offlineEngineListener: OfflineEngineListener, queue: DispatchQueue) {
 		self.listener = listener
+		self.offlineEngineListener = offlineEngineListener
 		self.queue = queue
 	}
 
@@ -56,6 +58,42 @@ final class NotificationsHandler {
 	func djSessionTransitioned(to transition: DJSessionTransition) {
 		queue.async {
 			self.listener.djSessionTransitioned(to: transition)
+		}
+	}
+
+	func offliningStarted(for mediaProduct: MediaProduct) {
+		queue.async {
+			self.offlineEngineListener?.offliningStarted(for: mediaProduct)
+		}
+	}
+
+	func offliningProgress(for mediaProduct: MediaProduct, is downloadPercentage: Double) {
+		queue.async {
+			self.offlineEngineListener?.offliningProgress(for: mediaProduct, is: downloadPercentage)
+		}
+	}
+
+	func offliningCompleted(for mediaProduct: MediaProduct) {
+		queue.async {
+			self.offlineEngineListener?.offliningCompleted(for: mediaProduct)
+		}
+	}
+
+	func offliningFailed(for mediaProduct: MediaProduct) {
+		queue.async {
+			self.offlineEngineListener?.offliningFailed(for: mediaProduct)
+		}
+	}
+
+	func offlinedDeleted(for mediaProduct: MediaProduct) {
+		queue.async {
+			self.offlineEngineListener?.offlinedDeleted(for: mediaProduct)
+		}
+	}
+
+	func allOfflinedMediaProductsDeleted() {
+		queue.async {
+			self.offlineEngineListener?.allOfflinedMediaProductsDeleted()
 		}
 	}
 }

--- a/Sources/Player/Common/Event/NotificationsHandler.swift
+++ b/Sources/Player/Common/Event/NotificationsHandler.swift
@@ -5,7 +5,7 @@ final class NotificationsHandler {
 	private let offlineEngineListener: OfflineEngineListener?
 	private let queue: DispatchQueue
 
-	init(listener: PlayerListener, offlineEngineListener: OfflineEngineListener, queue: DispatchQueue) {
+	init(listener: PlayerListener, offlineEngineListener: OfflineEngineListener?, queue: DispatchQueue) {
 		self.listener = listener
 		self.offlineEngineListener = offlineEngineListener
 		self.queue = queue

--- a/Sources/Player/Common/Event/NotificationsHandler.swift
+++ b/Sources/Player/Common/Event/NotificationsHandler.swift
@@ -69,7 +69,7 @@ final class NotificationsHandler {
 
 	func offliningProgress(for mediaProduct: MediaProduct, is downloadPercentage: Double) {
 		queue.async {
-			self.offlineEngineListener?.offliningProgress(for: mediaProduct, is: downloadPercentage)
+			self.offlineEngineListener?.offliningProgressed(for: mediaProduct, is: downloadPercentage)
 		}
 	}
 

--- a/Sources/Player/Mocks/OfflineEngine/OfflineEngineListenerMock.swift
+++ b/Sources/Player/Mocks/OfflineEngine/OfflineEngineListenerMock.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public final class OfflineEngineListenerMock: OfflineEngineListener {
+	public func offliningStarted(for mediaProduct: MediaProduct) {}
+
+	public func offliningProgress(for mediaProduct: MediaProduct, is downloadPercentage: Double) {}
+
+	public func offliningCompleted(for mediaProduct: MediaProduct) {}
+
+	public func offliningFailed(for mediaProduct: MediaProduct) {}
+
+	public func offlinedDeleted(for mediaProduct: MediaProduct) {}
+
+	public func allOfflinedMediaProductsDeleted() {}
+}

--- a/Sources/Player/Mocks/OfflineEngine/OfflineEngineListenerMock.swift
+++ b/Sources/Player/Mocks/OfflineEngine/OfflineEngineListenerMock.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class OfflineEngineListenerMock: OfflineEngineListener {
 	public func offliningStarted(for mediaProduct: MediaProduct) {}
 
-	public func offliningProgress(for mediaProduct: MediaProduct, is downloadPercentage: Double) {}
+	public func offliningProgressed(for mediaProduct: MediaProduct, is downloadPercentage: Double) {}
 
 	public func offliningCompleted(for mediaProduct: MediaProduct) {}
 

--- a/Sources/Player/OfflineEngine/OfflineEngineListener.swift
+++ b/Sources/Player/OfflineEngine/OfflineEngineListener.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public protocol OfflinerDelegate: AnyObject {
+public protocol OfflineEngineListener: AnyObject {
 	func offliningStarted(for mediaProduct: MediaProduct)
 	func offliningProgress(for mediaProduct: MediaProduct, is downloadPercentage: Double)
 	func offliningCompleted(for mediaProduct: MediaProduct)

--- a/Sources/Player/OfflineEngine/OfflineEngineListener.swift
+++ b/Sources/Player/OfflineEngine/OfflineEngineListener.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public protocol OfflineEngineListener: AnyObject {
 	func offliningStarted(for mediaProduct: MediaProduct)
-	func offliningProgress(for mediaProduct: MediaProduct, is downloadPercentage: Double)
+	func offliningProgressed(for mediaProduct: MediaProduct, is downloadPercentage: Double)
 	func offliningCompleted(for mediaProduct: MediaProduct)
 	func offliningFailed(for mediaProduct: MediaProduct)
 	func offlinedDeleted(for mediaProduct: MediaProduct)

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -108,7 +108,7 @@ public extension Player {
 	/// logging is actually performed.
 	/// - Returns: Instance of Player if not initialized yet, or nil if initized already.
 	static func bootstrap(
-		listener: PlayerListener,
+		playerListener: PlayerListener,
 		offlineEngineListener: OfflineEngineListener? = nil,
 		listenerQueue: DispatchQueue = .main,
 		featureFlagProvider: FeatureFlagProvider = .standard,
@@ -170,7 +170,7 @@ public extension Player {
 
 		let networkMonitor = NetworkMonitor()
 		let notificationsHandler = NotificationsHandler(
-			listener: listener,
+			listener: playerListener,
 			offlineEngineListener: offlineEngineListener,
 			queue: listenerQueue
 		)

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -109,7 +109,7 @@ public extension Player {
 	/// - Returns: Instance of Player if not initialized yet, or nil if initized already.
 	static func bootstrap(
 		listener: PlayerListener,
-		offlineEngineListener: OfflineEngineListener,
+		offlineEngineListener: OfflineEngineListener? = nil,
 		listenerQueue: DispatchQueue = .main,
 		featureFlagProvider: FeatureFlagProvider = .standard,
 		externalPlayers: [GenericMediaPlayer.Type] = [],

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -109,6 +109,7 @@ public extension Player {
 	/// - Returns: Instance of Player if not initialized yet, or nil if initized already.
 	static func bootstrap(
 		listener: PlayerListener,
+		offlineEngineListener: OfflineEngineListener,
 		listenerQueue: DispatchQueue = .main,
 		featureFlagProvider: FeatureFlagProvider = .standard,
 		externalPlayers: [GenericMediaPlayer.Type] = [],
@@ -168,7 +169,11 @@ public extension Player {
 		)
 
 		let networkMonitor = NetworkMonitor()
-		let notificationsHandler = NotificationsHandler(listener: listener, queue: listenerQueue)
+		let notificationsHandler = NotificationsHandler(
+			listener: listener,
+			offlineEngineListener: offlineEngineListener,
+			queue: listenerQueue
+		)
 
 		// For now, OfflineStorage and OfflineEngine can be optional.
 		// Once the functionality is finalized, Player should not work with a missing OfflineEngine.
@@ -184,7 +189,8 @@ public extension Player {
 					networkMonitor,
 					fairplayLicenseFetcher,
 					featureFlagProvider,
-					credentialsProvider
+					credentialsProvider,
+					notificationsHandler
 				)
 			}
 		}
@@ -380,11 +386,6 @@ public extension Player {
 		return offlineEngine?.getOfflineState(mediaProduct: mediaProduct) ?? .NOT_OFFLINED
 	}
 
-	func setOfflinerDelegate(_ offlinerDelegate: OfflinerDelegate) {
-		initializeOfflineEngineIfNeeded()
-		offlineEngine?.setOfflinerDelegate(offlinerDelegate)
-	}
-
 	func startDjSession(title: String) {
 		queue.dispatch {
 			let now = PlayerWorld.timeProvider.timestamp()
@@ -418,7 +419,8 @@ private extension Player {
 					networkMonitor,
 					fairplayLicenseFetcher,
 					featureFlagProvider,
-					credentialsProvider
+					credentialsProvider,
+					notificationsHandler
 				)
 			}
 		}
@@ -503,7 +505,8 @@ private extension Player {
 		_ networkMonitor: NetworkMonitor,
 		_ fairplayLicenseFetcher: FairPlayLicenseFetcher,
 		_ featureFlagProvider: FeatureFlagProvider,
-		_ credentialsProvider: CredentialsProvider
+		_ credentialsProvider: CredentialsProvider,
+		_ notificationsHandler: NotificationsHandler
 	) -> OfflineEngine {
 		let offlinerPlaybackInfoFetcher = PlaybackInfoFetcher(
 			with: configuration,
@@ -518,8 +521,12 @@ private extension Player {
 			fairPlayLicenseFetcher: fairplayLicenseFetcher,
 			networkMonitor: networkMonitor
 		)
-
-		return OfflineEngine(downloader: downloader, offlineStorage: storage, playerEventSender: playerEventSender)
+		return OfflineEngine(
+			downloader: downloader,
+			offlineStorage: storage,
+			playerEventSender: playerEventSender,
+			notificationsHandler: notificationsHandler
+		)
 	}
 }
 

--- a/TestApps/Player/PlayerTestApp/PlayerViewModel.swift
+++ b/TestApps/Player/PlayerTestApp/PlayerViewModel.swift
@@ -55,7 +55,7 @@ final class PlayerViewModel: ObservableObject {
 
 	private func initPlayer() {
 		player = Player.bootstrap(
-			listener: self,
+			playerListener: self,
 			credentialsProvider: auth,
 			eventSender: eventSender
 		)

--- a/TestApps/Player/PlayerTestApp/PlayerViewModel.swift
+++ b/TestApps/Player/PlayerTestApp/PlayerViewModel.swift
@@ -7,7 +7,7 @@ public typealias PlayerState = State
 
 // MARK: - PlayerViewModel
 
-final class PlayerViewModel: ObservableObject, PlayerListener {
+final class PlayerViewModel: ObservableObject {
 	private let CLIENT_ID = "YOUR_CLIENT_ID"
 	private let CLIENT_SECRET = "YOUR_CLIENT_SECRET"
 	private let CREDENTIALS_KEY = "YOUR_CREDENTIALS_KEY"
@@ -70,7 +70,11 @@ final class PlayerViewModel: ObservableObject, PlayerListener {
 		)
 		player?.play()
 	}
+}
 
+// MARK: PlayerListener
+
+extension PlayerViewModel: PlayerListener {
 	func stateChanged(to state: State) {
 		playerState = state
 	}

--- a/Tests/PlayerTests/EventsTests.swift
+++ b/Tests/PlayerTests/EventsTests.swift
@@ -114,7 +114,7 @@ final class EventsTests: XCTestCase {
 
 		listener = PlayerListenerMock()
 		listenerQueue = DispatchQueue(label: "com.tidal.queue.for.testing")
-		notificationsHandler = NotificationsHandler(listener: listener, queue: listenerQueue)
+		notificationsHandler = .mock(listener: listener, queue: listenerQueue)
 
 		djProducer = DJProducer(
 			httpClient: httpClient,

--- a/Tests/PlayerTests/FeatureFlagProviderTests.swift
+++ b/Tests/PlayerTests/FeatureFlagProviderTests.swift
@@ -20,7 +20,7 @@ final class FeatureFlagProviderTests: XCTestCase {
 		shouldUseOfflineEngine = false
 
 		let playerInstance = Player.bootstrap(
-			listener: PlayerListenerMock(),
+			playerListener: PlayerListenerMock(),
 			offlineEngineListener: OfflineEngineListenerMock(),
 			listenerQueue: DispatchQueue(label: "com.tidal.queue.for.testing"),
 			featureFlagProvider: featureFlagProvider,
@@ -38,7 +38,7 @@ final class FeatureFlagProviderTests: XCTestCase {
 		shouldUseOfflineEngine = true
 
 		let playerInstance = Player.bootstrap(
-			listener: PlayerListenerMock(),
+			playerListener: PlayerListenerMock(),
 			offlineEngineListener: OfflineEngineListenerMock(),
 			listenerQueue: DispatchQueue(label: "com.tidal.queue.for.testing"),
 			featureFlagProvider: featureFlagProvider,
@@ -56,7 +56,7 @@ final class FeatureFlagProviderTests: XCTestCase {
 		shouldUseOfflineEngine = false
 
 		let playerInstance = Player.bootstrap(
-			listener: PlayerListenerMock(),
+			playerListener: PlayerListenerMock(),
 			offlineEngineListener: OfflineEngineListenerMock(),
 			listenerQueue: DispatchQueue(label: "com.tidal.queue.for.testing"),
 			featureFlagProvider: featureFlagProvider,

--- a/Tests/PlayerTests/FeatureFlagProviderTests.swift
+++ b/Tests/PlayerTests/FeatureFlagProviderTests.swift
@@ -21,6 +21,7 @@ final class FeatureFlagProviderTests: XCTestCase {
 
 		let playerInstance = Player.bootstrap(
 			listener: PlayerListenerMock(),
+			offlineEngineListener: OfflineEngineListenerMock(),
 			listenerQueue: DispatchQueue(label: "com.tidal.queue.for.testing"),
 			featureFlagProvider: featureFlagProvider,
 			credentialsProvider: CredentialsProviderMock(),
@@ -38,6 +39,7 @@ final class FeatureFlagProviderTests: XCTestCase {
 
 		let playerInstance = Player.bootstrap(
 			listener: PlayerListenerMock(),
+			offlineEngineListener: OfflineEngineListenerMock(),
 			listenerQueue: DispatchQueue(label: "com.tidal.queue.for.testing"),
 			featureFlagProvider: featureFlagProvider,
 			credentialsProvider: CredentialsProviderMock(),
@@ -55,6 +57,7 @@ final class FeatureFlagProviderTests: XCTestCase {
 
 		let playerInstance = Player.bootstrap(
 			listener: PlayerListenerMock(),
+			offlineEngineListener: OfflineEngineListenerMock(),
 			listenerQueue: DispatchQueue(label: "com.tidal.queue.for.testing"),
 			featureFlagProvider: featureFlagProvider,
 			credentialsProvider: CredentialsProviderMock(),

--- a/Tests/PlayerTests/Mocks/Common/NotificationHandler/NotificationsHandler+Mock.swift
+++ b/Tests/PlayerTests/Mocks/Common/NotificationHandler/NotificationsHandler+Mock.swift
@@ -4,8 +4,13 @@ import Foundation
 extension NotificationsHandler {
 	static func mock(
 		listener: PlayerListener = PlayerListenerMock(),
+		offlineEngineListener: OfflineEngineListener = OfflineEngineListenerMock(),
 		queue: DispatchQueue = DispatchQueue(label: "com.tidal.queue.for.testing")
 	) -> NotificationsHandler {
-		NotificationsHandler(listener: listener, queue: queue)
+		NotificationsHandler(
+			listener: listener,
+			offlineEngineListener: offlineEngineListener,
+			queue: queue
+		)
 	}
 }

--- a/Tests/PlayerTests/Mocks/Player+Mock.swift
+++ b/Tests/PlayerTests/Mocks/Player+Mock.swift
@@ -19,10 +19,7 @@ extension PlayerEngine {
 		storage: OfflineStorage = OfflineStorageMock(),
 		playerLoader: PlayerLoader = PlayerLoaderMock(),
 		featureFlagProvider: FeatureFlagProvider = .mock,
-		notificationsHandler: NotificationsHandler? = NotificationsHandler(
-			listener: PlayerListenerMock(),
-			queue: DispatchQueue(label: "com.tidal.queue.for.testing")
-		)
+		notificationsHandler: NotificationsHandler? = .mock(queue: DispatchQueue(label: "com.tidal.queue.for.testing"))
 	) -> PlayerEngine {
 		PlayerEngine(
 			with: queue,

--- a/Tests/PlayerTests/Player/PlaybackEngine/PlayerEngineTests.swift
+++ b/Tests/PlayerTests/Player/PlaybackEngine/PlayerEngineTests.swift
@@ -75,7 +75,7 @@ final class PlayerEngineTests: XCTestCase {
 		playerEventSender = PlayerEventSenderMock()
 		listener = PlayerListenerMock()
 		listenerQueue = DispatchQueue(label: "com.tidal.queue.for.testing")
-		notificationsHandler = NotificationsHandler(listener: listener, queue: listenerQueue)
+		notificationsHandler = .mock(listener: listener, queue: listenerQueue)
 		credentialsProvider = CredentialsProviderMock()
 		featureFlagProvider = FeatureFlagProvider.mock
 		featureFlagProvider.shouldUseImprovedCaching = {

--- a/Tests/PlayerTests/PlayerStateTests.swift
+++ b/Tests/PlayerTests/PlayerStateTests.swift
@@ -46,7 +46,7 @@ final class PlayerStateTests: XCTestCase {
 
 		listener = PlayerListenerMock()
 		listenerQueue = DispatchQueue(label: "com.tidal.queue.for.testing")
-		notificationsHandler = NotificationsHandler(listener: listener, queue: listenerQueue)
+		notificationsHandler = .mock(listener: listener, queue: listenerQueue)
 
 		credentialsProvider = CredentialsProviderMock()
 		featureFlagProvider = FeatureFlagProvider.mock


### PR DESCRIPTION
Refactored and renamed `OfflinerDelegate` into `OfflineEngineListener`, and added it to the bootstrap process.
Now it also ensures it will use the same queue for the notification events as the `PlayerListener`


One possibility to discuss would be to have different queues for each listener and instead of using `NotificationsHandler` for both, have a different class for each.