### PR TITLE
[Player] Improved License handling in OfflineEngine

### DIFF
--- a/Sources/Player/OfflineEngine/Internal/DownloadTask.swift
+++ b/Sources/Player/OfflineEngine/Internal/DownloadTask.swift
@@ -105,20 +105,16 @@ final class DownloadTask {
 		self.error = error
 		endTimestamp = PlayerWorld.timeProvider.timestamp()
 
+		let fileManager = PlayerWorld.fileManagerClient
+		if let localAssetUrl {
+			try? fileManager.removeItem(at: localAssetUrl)
+		}
+		if let localLicenseUrl {
+			try? fileManager.removeItem(at: localLicenseUrl)
+		}
+
+		PlayerWorld.logger?.log(loggable: PlayerLoggable.downloadFailed(error: error))
 		monitor?.failed(downloadTask: self, with: error)
-
-		guard let localAssetUrl, let localLicenseUrl else {
-			return
-		}
-
-		do {
-			let fileManager = PlayerWorld.fileManagerClient
-			try fileManager.removeItem(at: localAssetUrl)
-			try fileManager.removeItem(at: localLicenseUrl)
-		} catch {
-			PlayerWorld.logger?.log(loggable: PlayerLoggable.downloadFailed(error: error))
-			print("Failed to remove item: \(error)")
-		}
 	}
 }
 
@@ -176,7 +172,7 @@ private extension DownloadTask {
 			return
 		}
 
-		guard licenseDownloader == nil || localLicenseUrl != nil else {
+		guard licenseDownloader == nil || (licenseDownloader != nil && localLicenseUrl != nil) else {
 			return
 		}
 

--- a/Sources/Player/OfflineEngine/Internal/LicenseDownloader.swift
+++ b/Sources/Player/OfflineEngine/Internal/LicenseDownloader.swift
@@ -20,7 +20,10 @@ final class LicenseDownloader: NSObject {
 
 	private func store(_ license: Data, for downloadTask: DownloadTask) throws {
 		let uuid = PlayerWorld.uuidProvider.uuidString()
-		let url = PlayerWorld.fileManagerClient.cachesDirectory().appendingPathComponent("\(uuid).license")
+		let appSupportURL = PlayerWorld.fileManagerClient.applicationSupportDirectory()
+		let directoryURL = appSupportURL.appendingPathComponent("PlayerOfflineLicenses", isDirectory: true)
+		try PlayerWorld.fileManagerClient.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+		let url = directoryURL.appendingPathComponent("\(uuid).license")
 		try license.write(to: url, options: .atomic)
 		downloadTask.setLicenseUrl(url)
 	}

--- a/Sources/Player/OfflineEngine/Internal/Storage/GRDBStorage/GRDBOfflineStorage.swift
+++ b/Sources/Player/OfflineEngine/Internal/Storage/GRDBStorage/GRDBOfflineStorage.swift
@@ -30,6 +30,7 @@ class GRDBOfflineStorage {
 					t.column("albumPeakAmplitude", .double)
 					t.column("trackReplayGain", .double)
 					t.column("trackPeakAmplitude", .double)
+					t.column("licenseSecurityToken", .text)
 					t.column("size", .integer)
 					t.column("mediaBookmark", .blob)
 					t.column("licenseBookmark", .blob)

--- a/Sources/Player/OfflineEngine/Internal/Storage/GRDBStorage/OfflineEntryGRDBEntity.swift
+++ b/Sources/Player/OfflineEngine/Internal/Storage/GRDBStorage/OfflineEntryGRDBEntity.swift
@@ -20,6 +20,7 @@ struct OfflineEntryGRDBEntity: Codable, FetchableRecord, PersistableRecord {
 	let albumPeakAmplitude: Float?
 	let trackReplayGain: Float?
 	let trackPeakAmplitude: Float?
+	let licenseSecurityToken: String?
 	let size: Int
 	let mediaBookmark: Data?
 	let licenseBookmark: Data?
@@ -42,6 +43,7 @@ struct OfflineEntryGRDBEntity: Codable, FetchableRecord, PersistableRecord {
 			albumPeakAmplitude: albumPeakAmplitude,
 			trackReplayGain: trackReplayGain,
 			trackPeakAmplitude: trackPeakAmplitude,
+			licenseSecurityToken: licenseSecurityToken,
 			size: size,
 			mediaURL: mediaURL,
 			licenseURL: licenseURL
@@ -99,6 +101,7 @@ struct OfflineEntryGRDBEntity: Codable, FetchableRecord, PersistableRecord {
 		albumPeakAmplitude = entry.albumPeakAmplitude
 		trackReplayGain = entry.trackReplayGain
 		trackPeakAmplitude = entry.trackPeakAmplitude
+		licenseSecurityToken = entry.licenseSecurityToken
 		size = entry.size
 		mediaBookmark = try? entry.mediaURL?.bookmarkData()
 		licenseBookmark = try? entry.licenseURL?.bookmarkData()

--- a/Sources/Player/OfflineEngine/Internal/Storage/OfflineEntry.swift
+++ b/Sources/Player/OfflineEngine/Internal/Storage/OfflineEntry.swift
@@ -18,12 +18,17 @@ struct OfflineEntry: Codable {
 	let albumPeakAmplitude: Float?
 	let trackReplayGain: Float?
 	let trackPeakAmplitude: Float?
+	let licenseSecurityToken: String?
 	let size: Int
 	var mediaURL: URL?
 	var licenseURL: URL?
 
 	var state: InternalOfflineState {
-		guard let mediaURL, licenseURL != nil else {
+		let needsLicense = needsLicense()
+		guard
+			let mediaURL,
+			!needsLicense || (needsLicense && licenseURL != nil)
+		else {
 			return .OFFLINED_BUT_NO_LICENSE
 		}
 
@@ -59,6 +64,7 @@ struct OfflineEntry: Codable {
 		albumPeakAmplitude: Float?,
 		trackReplayGain: Float?,
 		trackPeakAmplitude: Float?,
+		licenseSecurityToken: String?,
 		size: Int,
 		mediaURL: URL?,
 		licenseURL: URL?
@@ -79,6 +85,7 @@ struct OfflineEntry: Codable {
 		self.albumPeakAmplitude = albumPeakAmplitude
 		self.trackReplayGain = trackReplayGain
 		self.trackPeakAmplitude = trackPeakAmplitude
+		self.licenseSecurityToken = licenseSecurityToken
 		self.size = size
 		self.mediaURL = mediaURL
 		self.licenseURL = licenseURL
@@ -106,6 +113,7 @@ struct OfflineEntry: Codable {
 		albumPeakAmplitude = playbackInfo.albumPeakAmplitude
 		trackReplayGain = playbackInfo.trackReplayGain
 		trackPeakAmplitude = playbackInfo.trackPeakAmplitude
+		licenseSecurityToken = playbackInfo.licenseSecurityToken
 		self.size = size
 		self.mediaURL = mediaURL
 		self.licenseURL = licenseURL
@@ -113,5 +121,9 @@ struct OfflineEntry: Codable {
 
 	func isPlayable() -> Bool {
 		state == .OFFLINED_AND_VALID
+	}
+
+	func needsLicense() -> Bool {
+		licenseSecurityToken != nil
 	}
 }

--- a/Tests/PlayerTests/Mocks/OfflineEngine/Internal/Storage/OfflineEntry+Mock.swift
+++ b/Tests/PlayerTests/Mocks/OfflineEngine/Internal/Storage/OfflineEntry+Mock.swift
@@ -25,6 +25,7 @@ extension OfflineEntry {
 			albumPeakAmplitude: nil,
 			trackReplayGain: nil,
 			trackPeakAmplitude: nil,
+			licenseSecurityToken: nil,
 			size: size,
 			mediaURL: URL,
 			licenseURL: nil
@@ -54,6 +55,7 @@ extension OfflineEntry {
 			albumPeakAmplitude: playbackInfo.albumPeakAmplitude,
 			trackReplayGain: playbackInfo.trackReplayGain,
 			trackPeakAmplitude: playbackInfo.trackPeakAmplitude,
+			licenseSecurityToken: playbackInfo.licenseSecurityToken,
 			size: size,
 			mediaURL: assetURL,
 			licenseURL: licenseURL


### PR DESCRIPTION
There were some edge cases not controlled properly due to the fact that not all products require a license.

In this PR I make sure that we only enforce the existence of a license file if the product needs it, deletion will not fail if a license fail is missing, and I also move the license files to a better path that will not be cleared by the OS.