### PR TITLE
[Player] Rename HLS assets in OfflineEngine

### DIFF
--- a/Sources/Player/OfflineEngine/Internal/MediaDownloader.swift
+++ b/Sources/Player/OfflineEngine/Internal/MediaDownloader.swift
@@ -24,7 +24,7 @@ final class MediaDownloader: NSObject {
 	}
 
 	func download(asset: AVURLAsset, for downloadTask: DownloadTask) {
-		guard let task = createTask(for: asset) else {
+		guard let task = createTask(for: asset, downloadTask) else {
 			return
 		}
 
@@ -47,13 +47,13 @@ final class MediaDownloader: NSObject {
 }
 
 private extension MediaDownloader {
-	func createTask(for asset: AVURLAsset) -> AVAssetDownloadTask? {
-		let uuid = PlayerWorld.uuidProvider.uuidString()
+	func createTask(for asset: AVURLAsset, _ downloadTask: DownloadTask) -> AVAssetDownloadTask? {
+		let type = downloadTask.mediaProduct.productType.rawValue.lowercased()
+		let title = "\(type)-offlined-\(downloadTask.mediaProduct.productId)"
 		return hlsDownloadSession.makeAssetDownloadTask(
 			asset: asset,
-			assetTitle: uuid,
-			assetArtworkData: nil,
-			options: nil
+			assetTitle: title,
+			assetArtworkData: nil
 		)
 	}
 

--- a/Sources/Player/OfflineEngine/Internal/Storage/GRDBStorage/GRDBOfflineStorage.swift
+++ b/Sources/Player/OfflineEngine/Internal/Storage/GRDBStorage/GRDBOfflineStorage.swift
@@ -119,9 +119,9 @@ extension GRDBOfflineStorage: OfflineStorage {
 
 private extension GRDBOfflineStorage {
 	static func databaseURL() throws -> URL {
-		let appSupportURL = PlayerWorldClient.live.fileManagerClient.applicationSupportDirectory()
+		let appSupportURL = PlayerWorld.fileManagerClient.applicationSupportDirectory()
 		let directoryURL = appSupportURL.appendingPathComponent("PlayerOfflineDatabase", isDirectory: true)
-		try PlayerWorldClient.live.fileManagerClient.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+		try PlayerWorld.fileManagerClient.createDirectory(at: directoryURL, withIntermediateDirectories: true)
 		return directoryURL.appendingPathComponent("db.sqlite")
 	}
 


### PR DESCRIPTION
Change the naming of the downloaded HLS AVURLAssets to match the naming used in the cache.
This naming will better reflect what is actually stored in case a user navigates to the Storage settings on their device.

At some later point, we might decide to bridge the user-facing name of the MediaProduct (and the artwork!), which we could use here.

## Screenshots 📷 
![IMG_3092A5C89072-1](https://github.com/user-attachments/assets/095d2567-aed5-468e-8fd6-54c9c8ab7b20)
