### PR TITLE
[Player] Make OfflineEngine non-optional

### DIFF
--- a/Sources/Player/Common/FeatureFlags/FeatureFlagProvider+Standard.swift
+++ b/Sources/Player/Common/FeatureFlags/FeatureFlagProvider+Standard.swift
@@ -7,7 +7,6 @@ public extension FeatureFlagProvider {
 		shouldSendEventsInDeinit: { true },
 		shouldUseImprovedCaching: { false },
 		shouldPauseAndPlayAroundSeek: { false },
-		shouldNotPerformActionAtItemEnd: { false },
-		isOfflineEngineEnabled: { false }
+		shouldNotPerformActionAtItemEnd: { false }
 	)
 }

--- a/Sources/Player/Common/FeatureFlags/FeatureFlagProvider.swift
+++ b/Sources/Player/Common/FeatureFlags/FeatureFlagProvider.swift
@@ -5,7 +5,6 @@ public struct FeatureFlagProvider {
 	public var shouldUseImprovedCaching: () -> Bool
 	public var shouldPauseAndPlayAroundSeek: () -> Bool
 	public var shouldNotPerformActionAtItemEnd: () -> Bool
-	public var isOfflineEngineEnabled: () -> Bool
 
 	public init(
 		shouldUseEventProducer: @escaping () -> Bool,
@@ -13,8 +12,7 @@ public struct FeatureFlagProvider {
 		shouldSendEventsInDeinit: @escaping () -> Bool,
 		shouldUseImprovedCaching: @escaping () -> Bool,
 		shouldPauseAndPlayAroundSeek: @escaping () -> Bool,
-		shouldNotPerformActionAtItemEnd: @escaping () -> Bool,
-		isOfflineEngineEnabled: @escaping () -> Bool
+		shouldNotPerformActionAtItemEnd: @escaping () -> Bool
 	) {
 		self.shouldUseEventProducer = shouldUseEventProducer
 		self.isContentCachingEnabled = isContentCachingEnabled
@@ -22,6 +20,5 @@ public struct FeatureFlagProvider {
 		self.shouldUseImprovedCaching = shouldUseImprovedCaching
 		self.shouldPauseAndPlayAroundSeek = shouldPauseAndPlayAroundSeek
 		self.shouldNotPerformActionAtItemEnd = shouldNotPerformActionAtItemEnd
-		self.isOfflineEngineEnabled = isOfflineEngineEnabled
 	}
 }

--- a/Sources/Player/Mocks/Common/FeatureFlags/FeatureFlagProvider+Mock.swift
+++ b/Sources/Player/Mocks/Common/FeatureFlags/FeatureFlagProvider+Mock.swift
@@ -7,7 +7,6 @@ public extension FeatureFlagProvider {
 		shouldSendEventsInDeinit: { true },
 		shouldUseImprovedCaching: { false },
 		shouldPauseAndPlayAroundSeek: { false },
-		shouldNotPerformActionAtItemEnd: { false },
-		isOfflineEngineEnabled: { false }
+		shouldNotPerformActionAtItemEnd: { false }
 	)
 }

--- a/Tests/PlayerTests/FeatureFlagProviderTests.swift
+++ b/Tests/PlayerTests/FeatureFlagProviderTests.swift
@@ -5,38 +5,13 @@ import XCTest
 
 final class FeatureFlagProviderTests: XCTestCase {
 	private var featureFlagProvider: FeatureFlagProvider!
-	private var shouldUseOfflineEngine: Bool = false
 
 	override func setUp() {
 		Player.shared = nil
-
 		featureFlagProvider = FeatureFlagProvider.mock
-		featureFlagProvider.isOfflineEngineEnabled = {
-			self.shouldUseOfflineEngine
-		}
-	}
-
-	func testOffliningIsNotInitialized() throws {
-		shouldUseOfflineEngine = false
-
-		let playerInstance = Player.bootstrap(
-			playerListener: PlayerListenerMock(),
-			offlineEngineListener: OfflineEngineListenerMock(),
-			listenerQueue: DispatchQueue(label: "com.tidal.queue.for.testing"),
-			featureFlagProvider: featureFlagProvider,
-			credentialsProvider: CredentialsProviderMock(),
-			eventSender: EventSenderMock()
-		)
-
-		let player = try XCTUnwrap(playerInstance)
-		XCTAssertNotNil(player.playerEngine)
-		XCTAssertNil(player.offlineStorage)
-		XCTAssertNil(player.offlineEngine)
 	}
 
 	func testOffliningIsInitialized() throws {
-		shouldUseOfflineEngine = true
-
 		let playerInstance = Player.bootstrap(
 			playerListener: PlayerListenerMock(),
 			offlineEngineListener: OfflineEngineListenerMock(),
@@ -47,28 +22,6 @@ final class FeatureFlagProviderTests: XCTestCase {
 		)
 
 		let player = try XCTUnwrap(playerInstance)
-		XCTAssertNotNil(player.playerEngine)
-		XCTAssertNotNil(player.offlineStorage)
-		XCTAssertNotNil(player.offlineEngine)
-	}
-
-	func testOffliningIsInitializedAfterBootstrap() throws {
-		shouldUseOfflineEngine = false
-
-		let playerInstance = Player.bootstrap(
-			playerListener: PlayerListenerMock(),
-			offlineEngineListener: OfflineEngineListenerMock(),
-			listenerQueue: DispatchQueue(label: "com.tidal.queue.for.testing"),
-			featureFlagProvider: featureFlagProvider,
-			credentialsProvider: CredentialsProviderMock(),
-			eventSender: EventSenderMock()
-		)
-
-		let player = try XCTUnwrap(playerInstance)
-
-		shouldUseOfflineEngine = true
-		_ = player.offline(mediaProduct: .mock())
-
 		XCTAssertNotNil(player.playerEngine)
 		XCTAssertNotNil(player.offlineStorage)
 		XCTAssertNotNil(player.offlineEngine)

--- a/Tests/PlayerTests/Mocks/OfflineEngine/Internal/Downloader+Mock.swift
+++ b/Tests/PlayerTests/Mocks/OfflineEngine/Internal/Downloader+Mock.swift
@@ -1,0 +1,16 @@
+import Foundation
+@testable import Player
+
+extension Downloader {
+	static func mock(
+		playbackInfoFetcher: PlaybackInfoFetcher = .mock(),
+		fairPlayLicenseFetcher: FairPlayLicenseFetcher = .mock(),
+		networkMonitor: NetworkMonitor = NetworkMonitorMock()
+	) -> Downloader {
+		Downloader(
+			playbackInfoFetcher: playbackInfoFetcher,
+			fairPlayLicenseFetcher: fairPlayLicenseFetcher,
+			networkMonitor: networkMonitor
+		)
+	}
+}

--- a/Tests/PlayerTests/Mocks/OfflineEngine/OfflineEngine+Mock.swift
+++ b/Tests/PlayerTests/Mocks/OfflineEngine/OfflineEngine+Mock.swift
@@ -1,0 +1,18 @@
+import Foundation
+@testable import Player
+
+extension OfflineEngine {
+	static func mock(
+		downloader: Downloader = .mock(),
+		storage: OfflineStorage,
+		playerEventSender: PlayerEventSender = PlayerEventSenderMock(),
+		notificationsHandler: NotificationsHandler = .mock()
+	) -> OfflineEngine {
+		OfflineEngine(
+			downloader: downloader,
+			offlineStorage: storage,
+			playerEventSender: playerEventSender,
+			notificationsHandler: notificationsHandler
+		)
+	}
+}

--- a/Tests/PlayerTests/Player/PlayerTests.swift
+++ b/Tests/PlayerTests/Player/PlayerTests.swift
@@ -1,6 +1,6 @@
 import Auth
-@testable import Player
 import GRDB
+@testable import Player
 import XCTest
 
 // MARK: - PlayerTests
@@ -9,7 +9,7 @@ final class PlayerTests: XCTestCase {
 	private var player: Player!
 	private var playerEventSender: PlayerEventSenderMock!
 	private var dbQueue: DatabaseQueue!
-	
+
 	override func setUpWithError() throws {
 		PlayerWorld = PlayerWorldClient.mock(developmentFeatureFlagProvider: DevelopmentFeatureFlagProvider.mock)
 
@@ -50,6 +50,11 @@ final class PlayerTests: XCTestCase {
 		)
 
 		let notificationsHandler = NotificationsHandler.mock()
+		let offlineEngine = OfflineEngine.mock(
+			storage: storage,
+			playerEventSender: playerEventSender,
+			notificationsHandler: notificationsHandler
+		)
 		let playerEngine = PlayerEngine.mock(httpClient: httpClient)
 
 		player = Player(
@@ -64,7 +69,7 @@ final class PlayerTests: XCTestCase {
 			networkMonitor: networkMonitor,
 			notificationsHandler: notificationsHandler,
 			playerEngine: playerEngine,
-			offlineEngine: nil,
+			offlineEngine: offlineEngine,
 			featureFlagProvider: .mock,
 			externalPlayers: [],
 			credentialsProvider: CredentialsProviderMock()


### PR DESCRIPTION
Now that we are getting ready to test the new Offline Engine, we need to have it always initialized because there can be cases where someone downloads stuff with it, but then it gets the FF flag disabled for it, and it needs to still be able to play them.