### PR TITLE
[Player] Update configuration object inside OfflineEngine

### DIFF
--- a/Sources/Player/Common/PlaybackInfo/PlaybackInfoFetcher.swift
+++ b/Sources/Player/Common/PlaybackInfo/PlaybackInfoFetcher.swift
@@ -4,7 +4,7 @@ import Foundation
 // MARK: - PlaybackInfoFetcher
 
 final class PlaybackInfoFetcher {
-	private let configuration: Configuration
+	private var configuration: Configuration
 	private let httpClient: HttpClient
 	private let credentialsProvider: CredentialsProvider
 	private let networkMonitor: NetworkMonitor
@@ -62,6 +62,10 @@ final class PlaybackInfoFetcher {
 
 	func cancellNetworkRequests() {
 		httpClient.cancelAllRequests()
+	}
+
+	func updateConfiguration(_ configuration: Configuration) {
+		self.configuration = configuration
 	}
 }
 

--- a/Sources/Player/OfflineEngine/Internal/Downloader.swift
+++ b/Sources/Player/OfflineEngine/Internal/Downloader.swift
@@ -63,6 +63,10 @@ class Downloader {
 	func setObserver(observer: DownloadObserver) {
 		self.observer = observer
 	}
+
+	func updateConfiguration(_ configuration: Configuration) {
+		playbackInfoFetcher.updateConfiguration(configuration)
+	}
 }
 
 private extension Downloader {

--- a/Sources/Player/OfflineEngine/OfflineEngine.swift
+++ b/Sources/Player/OfflineEngine/OfflineEngine.swift
@@ -61,6 +61,10 @@ public final class OfflineEngine {
 		}
 		return offlineEntry.state.publicState
 	}
+
+	func updateConfiguration(_ configuration: Configuration) {
+		downloader.updateConfiguration(configuration)
+	}
 }
 
 // MARK: DownloadObserver

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -41,6 +41,7 @@ public final class Player {
 		// immediately.
 		didSet {
 			playerEngine.updateConfiguration(configuration)
+			offlineEngine.updateConfiguration(configuration)
 			streamingPrivilegesHandler.updateConfiguration(configuration)
 		}
 	}


### PR DESCRIPTION
We had a silly bug inside `OfflineEngine`

We are using a struct for the configuration type instead of a class, so when we pass it around, it is a copy, not a reference.
When the quality is changed by the client, we are not updating the configuration object in the `OfflineEngine`