### PR TITLE
[Player] Support OfflinePlay event in OfflineEngine items

### DIFF
--- a/Sources/Player/PlaybackEngine/Internal/PlaybackSource.swift
+++ b/Sources/Player/PlaybackEngine/Internal/PlaybackSource.swift
@@ -4,4 +4,13 @@ enum PlaybackSource {
 	case INTERNET
 	case LOCAL_STORAGE
 	case LOCAL_STORAGE_LEGACY
+
+	func isOfflineSource() -> Bool {
+		switch self {
+		case .LOCAL_STORAGE, .LOCAL_STORAGE_LEGACY:
+			true
+		case .INTERNET:
+			false
+		}
+	}
 }

--- a/Sources/Player/PlaybackEngine/Internal/PlayerItem.swift
+++ b/Sources/Player/PlaybackEngine/Internal/PlayerItem.swift
@@ -439,11 +439,12 @@ private extension PlayerItem {
 
 	func emitOfflinePlay() {
 		guard let metrics,
-		      let playbackContext,
-		      let asset,
-		      let productId = Int(playbackContext.productId),
 		      metrics.actualStartTime != nil,
-		      mediaProduct is StoredMediaProduct
+		      let metadata,
+		      metadata.playbackSource.isOfflineSource(),
+		      let playbackContext,
+		      let productId = Int(playbackContext.productId),
+		      let asset
 		else {
 			return
 		}


### PR DESCRIPTION
As the title says, we would also like to send `OfflinePlay` events for items downloaded with the new `OfflineEngine`
