### PR TITLE
[Player] Fix AVQueuePlayerWrapper.canPlay() for PlayableOfflinedMediaProduct 

### DIFF
--- a/Sources/Player/Mocks/PlaybackEngine/PlayerMock.swift
+++ b/Sources/Player/Mocks/PlaybackEngine/PlayerMock.swift
@@ -42,7 +42,12 @@ public final class PlayerMock: GenericMediaPlayer {
 
 	public init(cachePath: URL, featureFlagProvider: FeatureFlagProvider) {}
 
-	public func canPlay(productType: PlayerProductType, codec: PlayerAudioCodec?, mediaType: String?, isOfflined: Bool) -> Bool {
+	public func canPlay(
+		productType: PlayerProductType,
+		codec: PlayerAudioCodec?,
+		mediaType: String?,
+		isOfflined: Bool
+	) -> Bool {
 		true
 	}
 

--- a/Sources/Player/OfflineEngine/Internal/Storage/PlayableOfflinedMediaProduct.swift
+++ b/Sources/Player/OfflineEngine/Internal/Storage/PlayableOfflinedMediaProduct.swift
@@ -11,6 +11,7 @@ struct PlayableOfflinedMediaProduct: Equatable {
 	let audioSampleRate: Int?
 	let audioBitDepth: Int?
 	let videoQuality: VideoQuality?
+	let mediaType: String?
 	let mediaURL: URL
 	let licenseURL: URL?
 	let albumReplayGain: Float?
@@ -36,6 +37,7 @@ struct PlayableOfflinedMediaProduct: Equatable {
 		audioSampleRate = offlineEntry.audioSampleRate
 		audioBitDepth = offlineEntry.audioBitDepth
 		videoQuality = offlineEntry.videoQuality
+		mediaType = offlineEntry.mediaType
 		mediaURL = URL
 		licenseURL = offlineEntry.licenseURL
 		albumReplayGain = offlineEntry.albumReplayGain

--- a/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/AVQueuePlayerWrapper.swift
+++ b/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/AVQueuePlayerWrapper.swift
@@ -81,7 +81,9 @@ final class AVQueuePlayerWrapper: GenericMediaPlayer {
 		guard let codec else {
 			return false
 		}
-		return supportedCodecs.contains(codec) || (codec == .FLAC && !isOfflined)
+		// Because we need to support items downloaded with both the legacy and the new OfflineEngine
+		// We can't just add .FLAC to the 'supportedCodecs' array, and we need to depend on the mediaType
+		return supportedCodecs.contains(codec) || (codec == .FLAC && mediaType != MediaTypes.BTS)
 	}
 
 	func load(

--- a/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/Legacy/AVQueuePlayerWrapperLegacy.swift
+++ b/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/Legacy/AVQueuePlayerWrapperLegacy.swift
@@ -88,7 +88,9 @@ final class AVQueuePlayerWrapperLegacy: GenericMediaPlayer {
 			guard let codec else {
 				return false
 			}
-			return supportedCodecs.contains(codec) || (codec == .FLAC && !isOfflined)
+			// Because we need to support items downloaded with both the legacy and the new OfflineEngine
+			// We can't just add .FLAC to the 'supportedCodecs' array, and we need to depend on the mediaType
+			return supportedCodecs.contains(codec) || (codec == .FLAC && mediaType != MediaTypes.BTS)
 		}
 	}
 

--- a/Sources/Player/PlaybackEngine/Internal/InternalPlayerLoader.swift
+++ b/Sources/Player/PlaybackEngine/Internal/InternalPlayerLoader.swift
@@ -71,7 +71,9 @@ final class InternalPlayerLoader: PlayerLoader {
 		let player = try getPlayer(
 			for: offlinedProduct.audioMode,
 			and: offlinedProduct.audioQuality,
+			with: offlinedProduct.mediaType,
 			audioCodec: offlinedProduct.audioCodec,
+			isOfflined: true,
 			type: offlinedProduct.productType
 		)
 
@@ -100,6 +102,7 @@ final class InternalPlayerLoader: PlayerLoader {
 		let player = try getPlayer(
 			for: storedMediaProduct.audioMode,
 			and: storedMediaProduct.audioQuality,
+			with: MediaTypes.BTS,
 			audioCodec: storedMediaProduct.audioCodec,
 			isOfflined: true,
 			type: storedMediaProduct.productType
@@ -134,6 +137,7 @@ final class InternalPlayerLoader: PlayerLoader {
 				and: playbackInfo.audioQuality,
 				with: playbackInfo.mediaType,
 				audioCodec: playbackInfo.audioCodec,
+				isOfflined: false,
 				type: playbackInfo.productType
 			)
 			return await loadTrack(using: playbackInfo, with: loudnessNormalizer, and: licenseLoader, player: player)


### PR DESCRIPTION
Although the functionality was working correctly, it was by luck. We had a sily mistake where we weren't properly identifying `PlayableOfflinedMediaProduct` plays comming from our OfflineEngine as `offlined`, so the check we were doing inside `AVQueuePlayerWrapper.canPlay()` was incorrect once that was fixed.

This PR solves both issues:
* Correctly identify `PlayableOfflinedMediaProduct` plays as `isOfflined: true`
* Change the check for `FLAC` files to use the `MediaType` of the file to decide if it can be played or not