### PR TITLE
TidalAPI: setup CI/CD (phase 1)

### DIFF
--- a/.github/workflows/generate-tidal-api.yml
+++ b/.github/workflows/generate-tidal-api.yml
@@ -1,0 +1,121 @@
+name: Generate API in the TidalAPI module and create a PR if there are changes
+
+on:
+  workflow_dispatch: # manual triggering of this workflow
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  codegen:
+    runs-on: macos-latest
+    env:
+      API_FOLDER: Sources/TidalAPI/
+      GENERATED_FOLDER_NAME: Generated
+      INPUT_FOLDER_NAME: Config/input
+      SCRIPT_NAME: generate_and_clean.sh
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Step 2: Install OpenAPI Generator via Homebrew
+      - name: Install OpenAPI Generator with Homebrew
+        run: |
+          brew install openapi-generator
+
+      - name: Run Code Generation Script
+        run: |
+          cd $API_FOLDER
+          chmod +x $SCRIPT_NAME
+          ./$SCRIPT_NAME
+
+      - name: Check for changes
+        id: check_for_changes
+        run: |
+          cd $API_FOLDER
+          git add . 
+          changes_in_generated=$(git status -s $GENERATED_FOLDER_NAME | sed 's/"//g')
+          echo "Changes in $GENERATED_FOLDER_NAME:"
+          echo "$changes_in_generated"
+
+          changes_in_input=$(git status -s $INPUT_FOLDER_NAME | sed 's/"//g')
+          echo "Changes in $INPUT_FOLDER_NAME:"
+          echo "$changes_in_input"
+
+          if [ -n "$changes_in_generated" ] || [ -n "$changes_in_input" ]; then
+            changes_detected="true"
+          else
+            changes_detected="false"
+          fi
+          echo "Changes detected: $changes_detected"
+
+          {
+            echo 'CHANGES_IN_GENERATED<<EOF'
+            echo "$changes_in_generated"
+            echo 'EOF'
+          } >> $GITHUB_OUTPUT
+
+          {
+            echo 'CHANGES_IN_INPUT<<EOF'
+            echo "$changes_in_input"
+            echo 'EOF'
+          } >> $GITHUB_OUTPUT
+
+          echo "CHANGES_DETECTED=$changes_detected" >> $GITHUB_OUTPUT
+
+      - name: No Changes Found - Say Goodbye
+        if: ${{ steps.check_for_changes.outputs.CHANGES_DETECTED == 'false' }}
+        run: |
+            echo "No changes found. Good bye"
+      
+      - name: Prepare git and define a branch name
+        id: prepare_git_and_define_branch_name
+        if: ${{ steps.check_for_changes.outputs.CHANGES_DETECTED == 'true' }}
+        run: |
+          git config user.email "svc-github-tidal-music-tools@block.xyz"
+          git config user.name "TIDAL Music Tools"
+          timestamp=$(date +"%Y-%m-%d-%H-%M-%S")
+          branch_name="tidal-music-tools/Update-TidalAPI-${timestamp}"
+          echo "BRANCH_NAME=$branch_name" >> "$GITHUB_OUTPUT"
+
+      - name: Commit changes
+        if: ${{ steps.check_for_changes.outputs.CHANGES_DETECTED == 'true' }}
+        run: |
+          git checkout -b "${{steps.prepare_git_and_define_branch_name.outputs.BRANCH_NAME }}"
+          git commit -m "Update TidalAPI with new generated files"
+  
+      - name: Push changes
+        if: ${{ steps.check_for_changes.outputs.CHANGES_DETECTED == 'true' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+            git push origin "${{steps.prepare_git_and_define_branch_name.outputs.BRANCH_NAME }}"
+
+      - name: Create Pull Request
+        if: ${{ steps.check_for_changes.outputs.CHANGES_DETECTED == 'true' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pr_body=$(cat <<EOF
+
+          This PR was created by GitHub Actions.
+
+          **Changes in Input folder:**
+          ${{ steps.check_for_changes.outputs.CHANGES_IN_INPUT }}
+
+          **Changes in Generated folder:**
+          ${{ steps.check_for_changes.outputs.CHANGES_IN_GENERATED }}          
+          EOF
+          )
+          pr_data=$(jq -n --arg title "TidalAPI: updates after code generation" \
+                            --arg head "${{steps.prepare_git_and_define_branch_name.outputs.BRANCH_NAME }}" \
+                            --arg base "main" \
+                            --arg body "$pr_body" \
+                            '{title: $title, head: $head, base: $base, body: $body}')
+
+          curl -X POST \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d "$pr_data" \
+            https://api.github.com/repos/${{ github.repository }}/pulls


### PR DESCRIPTION
This is the CI/CD workflow for checking if there are API changes. For now will be triggered manually, we will setup a schedule in phase 2.

How it works:
* Checkout code
* Install OpenAPI Generator via Homebrew
* Then we run our [code generation script](https://github.com/tidal-music/tidal-sdk-ios/blob/main/Sources/TidalAPI/generate_and_clean.sh). The script fetches latest JSON input files, places them to the input folder (`Config/input`) and runs the generator. The generator then will re-generate all the APIs and models based on the input files and place the result to the output folder (`Generated`)
* Check for changes in these folders. 
    * Here we use `git status -s`, which provides lines containing a prefix (`A`, `M` or `D`) and a file name. 
    * We also remove double quotes (`sed 's/"//g'`) because a deleted file has them in its line, in contrast with `M` and `A`. This can cause issues later.
    * We set variables `changes_in_generated` and `changes_in_input`
    * We are checking if these variables are not empty by using `[ -n "$changes_in_generated" ]`. We also set `changes_detected` variable here.
    * Then we send these variables to the output of this step by using `>> $GITHUB_OUTPUT`.  [Multiline string notation](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#multiline-strings) is used for `CHANGES_IN_GENERATED` and `CHANGES_IN_INPUT` output variables
* If changes not found - we say good bye (`if:  ${{ steps.check_for_changes.outputs.CHANGES_DETECTED == 'false' }}`)
* All next steps have this condition `if: ${{ steps.check_for_changes.outputs.CHANGES_DETECTED == 'true' }}`, therefore they will be executed only if there are changes.
* Prepare git and define a branch name
    *  Configure git with our bot info
    * Create a branch name including current date, to avoid collisions. Set `BRANCH_NAME` variable in the output of this step.
* Create new branch and commit
* Push
* Create pull request:
    * Use `$GITHUB_TOKEN` provided by GitHub (because our Actions are allowed to create pull requests)
    * Create `pr_body`, include changes from input and output folders there
    * Prepare JSON data for the pull request
    * Execute `curl` to create the pull request. `${{ github.repository }}` - is a current repository 🙂 

In [this commit](https://github.com/tidal-music/tidal-sdk-ios/pull/132/commits/ba75f6b851bd5900220c9b3198e0196100020f56) I prepared the workflow for production. It is not triggered on `push` anymore and uses `main` branch (to compare and to create pull request). 

You can see the result of its work against my test branch for example, in [this PR](https://github.com/tidal-music/tidal-sdk-ios/pull/144).

If you want to test it yourself, set HEAD to a previous commit, push something and then observe execution of this workflow in Actions.

To check a manual execution and a real work against `main`, we need to merge this PR at first (and then wait for API to be changed 😅) Let's just hope it will work! 🙂 