### PR TITLE
Add player item monitor for when an item reaches the end when action at end is none

### DIFF
--- a/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/AVPlayerItemMonitor.swift
+++ b/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/AVPlayerItemMonitor.swift
@@ -8,6 +8,7 @@ final class AVPlayerItemMonitor {
 	private let completelyDownloadedMonitor: CompletelyDownloadedMonitor
 	private let readyToPlayMonitor: ReadyToPlayMonitor
 	private let inStreamMetadataMonitor: DJSessionTransitionMonitor
+	private let playerItemDidPlayToEndTimeMonitor: ItemPlayedToEndMonitor
 
 	init(
 		_ playerItem: AVPlayerItem,
@@ -15,6 +16,7 @@ final class AVPlayerItemMonitor {
 		onStall: @escaping (AVPlayerItem) -> Void,
 		onCompletelyDownloaded: @escaping (AVPlayerItem) -> Void,
 		onReadyToPlayToPlay: @escaping (AVPlayerItem) -> Void,
+		onItemPlayedToEnd: @escaping (AVPlayerItem) -> Void,
 		onDjSessionTransition: @escaping (AVPlayerItem, DJSessionTransition) -> Void
 	) {
 		failureMonitor = FailureMonitor(playerItem, onFailure)
@@ -22,6 +24,7 @@ final class AVPlayerItemMonitor {
 		stallMonitor = StallMonitor(playerItem, onStall)
 		completelyDownloadedMonitor = CompletelyDownloadedMonitor(playerItem, onCompletelyDownloaded)
 		readyToPlayMonitor = ReadyToPlayMonitor(playerItem, onReadyToPlayToPlay)
+		playerItemDidPlayToEndTimeMonitor = ItemPlayedToEndMonitor(playerItem: playerItem, onPlayedToEnd: onItemPlayedToEnd)
 		inStreamMetadataMonitor = DJSessionTransitionMonitor(
 			with: playerItem,
 			and: DispatchQueue.global(qos: .default),

--- a/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/AVQueuePlayerWrapper.swift
+++ b/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/AVQueuePlayerWrapper.swift
@@ -401,6 +401,7 @@ private extension AVQueuePlayerWrapper {
 			onStall: stalled,
 			onCompletelyDownloaded: downloaded,
 			onReadyToPlayToPlay: loaded,
+			onItemPlayedToEnd: playedToEnd,
 			onDjSessionTransition: receivedDjSessionTransition
 		)
 	}
@@ -629,6 +630,12 @@ private extension AVQueuePlayerWrapper {
 			}
 
 			self.delegates.djSessionTransition(asset: asset, transition: transition)
+		}
+	}
+	
+	func playedToEnd(playerItem: AVPlayerItem) {
+		if featureFlagProvider.shouldNotPerformActionAtItemEnd() {
+			self.player.remove(playerItem)
 		}
 	}
 }

--- a/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/Legacy/AVQueuePlayerWrapperLegacy.swift
+++ b/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/Legacy/AVQueuePlayerWrapperLegacy.swift
@@ -372,6 +372,7 @@ private extension AVQueuePlayerWrapperLegacy {
 			onStall: stalled,
 			onCompletelyDownloaded: downloaded,
 			onReadyToPlayToPlay: loaded,
+			onItemPlayedToEnd: playedToEnd, 
 			onDjSessionTransition: receivedDjSessionTransition
 		)
 	}
@@ -530,6 +531,8 @@ private extension AVQueuePlayerWrapperLegacy {
 			let asset = self.playerItemAssets.removeValue(forKey: oldPlayerItem)
 			self.delegates.completed(asset: asset)
 
+			self.player.remove(oldPlayerItem)
+
 			guard let newPlayerItem = self.player.currentItem else {
 				self.reset()
 				return
@@ -558,6 +561,12 @@ private extension AVQueuePlayerWrapperLegacy {
 			}
 
 			self.delegates.djSessionTransition(asset: asset, transition: transition)
+		}
+	}
+
+	func playedToEnd(playerItem: AVPlayerItem) {
+		if featureFlagProvider.shouldNotPerformActionAtItemEnd() {
+			self.player.remove(playerItem)
 		}
 	}
 }

--- a/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/Observers/ItemPlayedToEndMonitor.swift
+++ b/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/Observers/ItemPlayedToEndMonitor.swift
@@ -1,0 +1,35 @@
+import AVFoundation
+import Foundation
+
+final class ItemPlayedToEndMonitor {
+	private let playerItem: AVPlayerItem
+	private let onPlayedToEnd: (AVPlayerItem) -> Void
+
+	init(playerItem: AVPlayerItem, onPlayedToEnd: @escaping (AVPlayerItem) -> Void) {
+		self.playerItem = playerItem
+		self.onPlayedToEnd = onPlayedToEnd
+
+		NotificationCenter.default.addObserver(
+			self,
+			selector: #selector(playerItemDidPlayToEndTime(notification:)),
+			name: NSNotification.Name.AVPlayerItemDidPlayToEndTime,
+			object: playerItem
+		)
+	}
+
+	deinit {
+		NotificationCenter.default.removeObserver(
+			self,
+			name: NSNotification.Name.AVPlayerItemDidPlayToEndTime,
+			object: playerItem
+		)
+	}
+
+	@objc
+	private func playerItemDidPlayToEndTime(notification: Notification) {
+		if let playerItem = notification.object as? AVPlayerItem {
+			print("--> PlayerItemDidPlayToEndTimeMonitor.playerItemDidPlayToEndTime(notification: \(notification))")
+			onPlayedToEnd(playerItem)
+		}
+	}
+}


### PR DESCRIPTION
Continuation of logic for when the item reaches the end.
First part here: https://github.com/tidal-music/tidal-sdk-ios/pull/110

Here, I've added a monitor for when the player item reached the end. At that moment, since we don't automatically perform any action automatically, I remove it from the player when the FF is enabled.

I continue testing to see if there's any scenario which I might have missed.

---

This pull request introduces a new feature to handle the event when an `AVPlayerItem` finishes playing. It adds a new monitor class and integrates it into the existing player wrapper classes.

### New Feature: Item Played to End Monitoring

* **New Monitor Class**:
  * [`Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/Observers/ItemPlayedToEndMonitor.swift`](diffhunk://#diff-66dd1acaa94ad9d8f2e1e105b63057e7e306dcb88df07d44e47a84f294b3e813R1-R35): Introduced `ItemPlayedToEndMonitor` to observe when an `AVPlayerItem` finishes playing and trigger a callback.

* **Integration into `AVPlayerItemMonitor`**:
  * [`Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/AVPlayerItemMonitor.swift`](diffhunk://#diff-2685a78fb53c72072cf13c7cb75694b64150414a78498eaac68c4fc20c736327R11-R27): Added `playerItemDidPlayToEndTimeMonitor` to monitor when an item has played to the end.

### Updates to Player Wrappers

* **`AVQueuePlayerWrapper`**:
  * [`Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/AVQueuePlayerWrapper.swift`](diffhunk://#diff-b75f24d9a1db1bbe79fed5b71b9fd741a62df41c29d49643af0db04b36fe6985R404): Updated to handle the `onItemPlayedToEnd` callback and remove the player item if a feature flag is set. [[1]](diffhunk://#diff-b75f24d9a1db1bbe79fed5b71b9fd741a62df41c29d49643af0db04b36fe6985R404) [[2]](diffhunk://#diff-b75f24d9a1db1bbe79fed5b71b9fd741a62df41c29d49643af0db04b36fe6985R635-R640)

* **`AVQueuePlayerWrapperLegacy`**:
  * [`Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/Legacy/AVQueuePlayerWrapperLegacy.swift`](diffhunk://#diff-f2fb496a12a5d9bea6f0efb2ea3766e9213555c80f56ad9f7c7dc4cc7d255917R375): Similarly updated to handle the `onItemPlayedToEnd` callback and remove the player item if a feature flag is set. [[1]](diffhunk://#diff-f2fb496a12a5d9bea6f0efb2ea3766e9213555c80f56ad9f7c7dc4cc7d255917R375) [[2]](diffhunk://#diff-f2fb496a12a5d9bea6f0efb2ea3766e9213555c80f56ad9f7c7dc4cc7d255917R534-R535) [[3]](diffhunk://#diff-f2fb496a12a5d9bea6f0efb2ea3766e9213555c80f56ad9f7c7dc4cc7d255917R566-R571)


