### PR TITLE
[Player] Improve external player injection

### DIFF
--- a/Tests/PlayerTests/Player/PlayerTests.swift
+++ b/Tests/PlayerTests/Player/PlayerTests.swift
@@ -71,7 +71,7 @@ final class PlayerTests: XCTestCase {
 			playerEngine: playerEngine,
 			offlineEngine: offlineEngine,
 			featureFlagProvider: .mock,
-			externalPlayers: [],
+			externalPlayersSupplier: nil,
 			credentialsProvider: CredentialsProviderMock()
 		)
 	}


### PR DESCRIPTION
Their PR changes how external players are provided so they can be changed at runtime.

Currently, we were passing an array at `bootstrap` that can't be updated, and this caused issues with our improved caching feature flag.