### PR TITLE
TidalAPI - CI/CD follow up (better PR title and commit message)

### DIFF
--- a/.github/workflows/generate-tidal-api.yml
+++ b/.github/workflows/generate-tidal-api.yml
@@ -104,7 +104,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          pr_title="Automatic Tidal API module update - ${{ steps.check_for_changes.outputs.changed_file_count }} files changed"
+          pr_title="Automatic Tidal API module update - ${{ steps.check_for_changes.outputs.CHANGED_FILE_COUNT }} files changed"
           pr_body=$(cat <<EOF
 
           This PR was created by GitHub Actions.

--- a/.github/workflows/generate-tidal-api.yml
+++ b/.github/workflows/generate-tidal-api.yml
@@ -40,13 +40,19 @@ jobs:
           echo "$changes_in_generated"
 
           changes_in_input=$(git status -s $INPUT_FOLDER_NAME | sed 's/"//g')
+          
           echo "Changes in $INPUT_FOLDER_NAME:"
           echo "$changes_in_input"
 
           if [ -n "$changes_in_generated" ] || [ -n "$changes_in_input" ]; then
             changes_detected="true"
+            changes_in_input_file_count=$(echo "$changes_in_input" | wc -l)
+            changed_in_generated_file_count=$(echo "$changes_in_generated" | wc -l)
+            changed_file_count=$((changes_in_input_file_count+changed_in_generated_file_count))
+
           else
             changes_detected="false"
+            changed_file_count=0
           fi
           echo "Changes detected: $changes_detected"
 
@@ -63,6 +69,7 @@ jobs:
           } >> $GITHUB_OUTPUT
 
           echo "CHANGES_DETECTED=$changes_detected" >> $GITHUB_OUTPUT
+          echo "CHANGED_FILE_COUNT=$changed_file_count" >> $GITHUB_OUTPUT
 
       - name: No Changes Found - Say Goodbye
         if: ${{ steps.check_for_changes.outputs.CHANGES_DETECTED == 'false' }}
@@ -83,7 +90,7 @@ jobs:
         if: ${{ steps.check_for_changes.outputs.CHANGES_DETECTED == 'true' }}
         run: |
           git checkout -b "${{steps.prepare_git_and_define_branch_name.outputs.BRANCH_NAME }}"
-          git commit -m "Update TidalAPI with new generated files"
+          git commit -m "Changed ${{ steps.check_for_changes.outputs.CHANGED_FILE_COUNT }} files via GitHub Actions"
   
       - name: Push changes
         if: ${{ steps.check_for_changes.outputs.CHANGES_DETECTED == 'true' }}
@@ -97,6 +104,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          pr_title="Automatic Tidal API module update - ${{ steps.check_for_changes.outputs.changed_file_count }} files changed"
           pr_body=$(cat <<EOF
 
           This PR was created by GitHub Actions.
@@ -108,7 +116,8 @@ jobs:
           ${{ steps.check_for_changes.outputs.CHANGES_IN_GENERATED }}          
           EOF
           )
-          pr_data=$(jq -n --arg title "TidalAPI: updates after code generation" \
+
+          pr_data=$(jq -n --arg title "$pr_title" \
                             --arg head "${{steps.prepare_git_and_define_branch_name.outputs.BRANCH_NAME }}" \
                             --arg base "main" \
                             --arg body "$pr_body" \


### PR DESCRIPTION
Adjusted title and commit message of a PR created by GitHub Actions: included there calculated changed file count (changes in the Input folder + changes in the Generated folder)

This is how the Pull Request looks now: https://github.com/tidal-music/tidal-sdk-ios/pull/154 (it is opened against my test branch)