### PR TITLE
[Player] Fix logic for OfflineEntry state check 

### DIFF
--- a/Sources/Player/Common/World/DevelopmentFeatureFlagProvider/DevelopmentFeatureFlagProvider+Live.swift
+++ b/Sources/Player/Common/World/DevelopmentFeatureFlagProvider/DevelopmentFeatureFlagProvider+Live.swift
@@ -1,6 +1,6 @@
 extension DevelopmentFeatureFlagProvider {
 	static let live = DevelopmentFeatureFlagProvider(
 		shouldReadAndVerifyPlaybackMetadata: false,
-		shouldCheckExpiryAndRevalidateOfflineItems: false
+		shouldCheckAndRevalidateOfflineItems: false
 	)
 }

--- a/Sources/Player/Common/World/DevelopmentFeatureFlagProvider/DevelopmentFeatureFlagProvider+Live.swift
+++ b/Sources/Player/Common/World/DevelopmentFeatureFlagProvider/DevelopmentFeatureFlagProvider+Live.swift
@@ -1,5 +1,6 @@
 extension DevelopmentFeatureFlagProvider {
 	static let live = DevelopmentFeatureFlagProvider(
-		shouldReadAndVerifyPlaybackMetadata: false
+		shouldReadAndVerifyPlaybackMetadata: false,
+		shouldCheckExpiryAndRevalidateOfflineItems: false
 	)
 }

--- a/Sources/Player/Common/World/DevelopmentFeatureFlagProvider/DevelopmentFeatureFlagProvider.swift
+++ b/Sources/Player/Common/World/DevelopmentFeatureFlagProvider/DevelopmentFeatureFlagProvider.swift
@@ -3,4 +3,5 @@ import Foundation
 /// Provider of feature flags used during development of new features.
 struct DevelopmentFeatureFlagProvider {
 	var shouldReadAndVerifyPlaybackMetadata: Bool
+	var shouldCheckExpiryAndRevalidateOfflineItems: Bool
 }

--- a/Sources/Player/Common/World/DevelopmentFeatureFlagProvider/DevelopmentFeatureFlagProvider.swift
+++ b/Sources/Player/Common/World/DevelopmentFeatureFlagProvider/DevelopmentFeatureFlagProvider.swift
@@ -3,5 +3,5 @@ import Foundation
 /// Provider of feature flags used during development of new features.
 struct DevelopmentFeatureFlagProvider {
 	var shouldReadAndVerifyPlaybackMetadata: Bool
-	var shouldCheckExpiryAndRevalidateOfflineItems: Bool
+	var shouldCheckAndRevalidateOfflineItems: Bool
 }

--- a/Sources/Player/OfflineEngine/Internal/Storage/OfflineEntry.swift
+++ b/Sources/Player/OfflineEngine/Internal/Storage/OfflineEntry.swift
@@ -33,12 +33,14 @@ struct OfflineEntry: Codable {
 			return .OFFLINED_BUT_NO_LICENSE
 		}
 
-		let now = PlayerWorld.timeProvider.timestamp()
-		if let expiry, now > expiry * 1000 {
-			return .OFFLINED_BUT_EXPIRED
+		if PlayerWorld.developmentFeatureFlagProvider.shouldCheckExpiryAndRevalidateOfflineItems {
+			let now = PlayerWorld.timeProvider.timestamp()
+			if let expiry, now > expiry * 1000 {
+				return .OFFLINED_BUT_EXPIRED
+			}
 		}
 
-		if mediaType == MediaTypes.HLS {
+		if mediaType == MediaTypes.HLS || mediaType == MediaTypes.EMU {
 			let asset = AVURLAsset(url: mediaURL)
 			guard let cache = asset.assetCache, cache.isPlayableOffline else {
 				return .OFFLINED_BUT_NOT_VALID

--- a/Sources/Player/OfflineEngine/Internal/Storage/OfflineEntry.swift
+++ b/Sources/Player/OfflineEngine/Internal/Storage/OfflineEntry.swift
@@ -33,7 +33,7 @@ struct OfflineEntry: Codable {
 			return .OFFLINED_BUT_NO_LICENSE
 		}
 
-		if PlayerWorld.developmentFeatureFlagProvider.shouldCheckExpiryAndRevalidateOfflineItems {
+		if PlayerWorld.developmentFeatureFlagProvider.shouldCheckAndRevalidateOfflineItems {
 			let now = PlayerWorld.timeProvider.timestamp()
 			if let expiry, now > expiry * 1000 {
 				return .OFFLINED_BUT_EXPIRED

--- a/Tests/PlayerTests/Mocks/Common/Types/PlaybackInfo+Mock.swift
+++ b/Tests/PlayerTests/Mocks/Common/Types/PlaybackInfo+Mock.swift
@@ -69,13 +69,13 @@ extension PlaybackInfo {
 			contentHash: trackPlaybackInfo.manifestHash,
 			mediaType: trackPlaybackInfo.manifestMimeType,
 			url: URL(string: "https://www.tidal.com")!, // from the manifest
-			licenseSecurityToken: nil,
+			licenseSecurityToken: trackPlaybackInfo.licenseSecurityToken,
 			albumReplayGain: trackPlaybackInfo.albumReplayGain,
 			albumPeakAmplitude: trackPlaybackInfo.albumPeakAmplitude,
 			trackReplayGain: trackPlaybackInfo.trackReplayGain,
 			trackPeakAmplitude: trackPlaybackInfo.trackPeakAmplitude,
-			offlineRevalidateAt: nil,
-			offlineValidUntil: nil
+			offlineRevalidateAt: trackPlaybackInfo.offlineRevalidateAt,
+			offlineValidUntil: trackPlaybackInfo.offlineValidUntil
 		)
 	}
 }

--- a/Tests/PlayerTests/Mocks/Common/World/DevelopmentFeatureFlagProvider+Mock.swift
+++ b/Tests/PlayerTests/Mocks/Common/World/DevelopmentFeatureFlagProvider+Mock.swift
@@ -2,6 +2,7 @@
 
 extension DevelopmentFeatureFlagProvider {
 	static let mock: Self = DevelopmentFeatureFlagProvider(
-		shouldReadAndVerifyPlaybackMetadata: false
+		shouldReadAndVerifyPlaybackMetadata: false,
+		shouldCheckExpiryAndRevalidateOfflineItems: false
 	)
 }

--- a/Tests/PlayerTests/Mocks/Common/World/DevelopmentFeatureFlagProvider+Mock.swift
+++ b/Tests/PlayerTests/Mocks/Common/World/DevelopmentFeatureFlagProvider+Mock.swift
@@ -3,6 +3,6 @@
 extension DevelopmentFeatureFlagProvider {
 	static let mock: Self = DevelopmentFeatureFlagProvider(
 		shouldReadAndVerifyPlaybackMetadata: false,
-		shouldCheckExpiryAndRevalidateOfflineItems: false
+		shouldCheckAndRevalidateOfflineItems: false
 	)
 }

--- a/Tests/PlayerTests/Player/OfflineEngine/Internal/Storage/OfflineEntryTests.swift
+++ b/Tests/PlayerTests/Player/OfflineEngine/Internal/Storage/OfflineEntryTests.swift
@@ -1,0 +1,75 @@
+@testable import Player
+import XCTest
+
+// MARK: - OfflineEntryTests
+
+final class OfflineEntryTests: XCTestCase {
+	private var timeProvider: TimeProvider!
+	private var currentTimestamp: UInt64 = 1
+
+	override func setUpWithError() throws {
+		timeProvider = .mock(timestamp: {
+			self.currentTimestamp
+		})
+		PlayerWorld = PlayerWorldClient.mock(timeProvider: timeProvider)
+	}
+
+	// MARK: - state
+
+	func test_state_offlined_not_valid() async throws {
+		// GIVEN
+		let trackPlaybackInfo = TrackPlaybackInfo.mock(
+			licenseSecurityToken: "sdfasdfasdf",
+			albumReplayGain: 4,
+			albumPeakAmplitude: 1
+		)
+		let playbackInfo = PlaybackInfo.mock(mediaProduct: .mock(), trackPlaybackInfo: trackPlaybackInfo)
+		let offlineEntry = OfflineEntry.mock(
+			from: playbackInfo,
+			assetURL: URL(string: "www.tidal.com")!,
+			licenseURL: URL(string: "www.tidal.com/license")!
+		)
+
+		XCTAssertEqual(offlineEntry.state, .OFFLINED_BUT_NOT_VALID)
+	}
+
+	func test_state_no_license() async throws {
+		// GIVEN
+		let trackPlaybackInfo = TrackPlaybackInfo.mock(
+			licenseSecurityToken: "sdfasdfasdf",
+			albumReplayGain: 4,
+			albumPeakAmplitude: 1
+		)
+		let playbackInfo = PlaybackInfo.mock(mediaProduct: .mock(), trackPlaybackInfo: trackPlaybackInfo)
+		let offlineEntry = OfflineEntry.mock(
+			from: playbackInfo,
+			assetURL: URL(string: "www.tidal.com")!,
+			licenseURL: nil
+		)
+
+		XCTAssertEqual(offlineEntry.state, .OFFLINED_BUT_NO_LICENSE)
+	}
+
+	func test_state_expired() async throws {
+		// GIVEN
+		currentTimestamp = 2 * 1000
+		PlayerWorld.developmentFeatureFlagProvider.shouldCheckExpiryAndRevalidateOfflineItems = true
+
+		let trackPlaybackInfo = TrackPlaybackInfo.mock(
+			licenseSecurityToken: "sdfasdfasdf",
+			albumReplayGain: 4,
+			albumPeakAmplitude: 1,
+			offlineValidUntil: 1
+		)
+		let playbackInfo = PlaybackInfo.mock(
+			mediaProduct: .mock(),
+			trackPlaybackInfo: trackPlaybackInfo
+		)
+		let offlineEntry = OfflineEntry.mock(
+			from: playbackInfo,
+			assetURL: URL(string: "www.tidal.com")!,
+			licenseURL: URL(string: "www.tidal.com/license")!
+		)
+		XCTAssertEqual(offlineEntry.state, .OFFLINED_BUT_EXPIRED)
+	}
+}

--- a/Tests/PlayerTests/Player/OfflineEngine/Internal/Storage/OfflineEntryTests.swift
+++ b/Tests/PlayerTests/Player/OfflineEngine/Internal/Storage/OfflineEntryTests.swift
@@ -16,7 +16,7 @@ final class OfflineEntryTests: XCTestCase {
 
 	// MARK: - state
 
-	func test_state_offlined_not_valid() async throws {
+	func test_stateIsOfflinedButNotValid_whenNoPlayableAVPlayer() async throws {
 		// GIVEN
 		let trackPlaybackInfo = TrackPlaybackInfo.mock(
 			licenseSecurityToken: "sdfasdfasdf",
@@ -30,10 +30,11 @@ final class OfflineEntryTests: XCTestCase {
 			licenseURL: URL(string: "www.tidal.com/license")!
 		)
 
+		// THEN
 		XCTAssertEqual(offlineEntry.state, .OFFLINED_BUT_NOT_VALID)
 	}
 
-	func test_state_no_license() async throws {
+	func test_stateIsOfflinedButNotLicense_whenNoLicenseURL() async throws {
 		// GIVEN
 		let trackPlaybackInfo = TrackPlaybackInfo.mock(
 			licenseSecurityToken: "sdfasdfasdf",
@@ -47,13 +48,14 @@ final class OfflineEntryTests: XCTestCase {
 			licenseURL: nil
 		)
 
+		// THEN
 		XCTAssertEqual(offlineEntry.state, .OFFLINED_BUT_NO_LICENSE)
 	}
 
-	func test_state_expired() async throws {
+	func test_stateIsOfflinedButExpired_whenOfflineValidUntilHasPassed() async throws {
 		// GIVEN
 		currentTimestamp = 2 * 1000
-		PlayerWorld.developmentFeatureFlagProvider.shouldCheckExpiryAndRevalidateOfflineItems = true
+		PlayerWorld.developmentFeatureFlagProvider.shouldCheckAndRevalidateOfflineItems = true
 
 		let trackPlaybackInfo = TrackPlaybackInfo.mock(
 			licenseSecurityToken: "sdfasdfasdf",
@@ -70,6 +72,8 @@ final class OfflineEntryTests: XCTestCase {
 			assetURL: URL(string: "www.tidal.com")!,
 			licenseURL: URL(string: "www.tidal.com/license")!
 		)
+
+		// THEN
 		XCTAssertEqual(offlineEntry.state, .OFFLINED_BUT_EXPIRED)
 	}
 }

--- a/Tests/PlayerTests/Player/PlaybackEngine/Internal/InternalPlayerLoaderTests.swift
+++ b/Tests/PlayerTests/Player/PlaybackEngine/Internal/InternalPlayerLoaderTests.swift
@@ -78,7 +78,12 @@ final class InternalPlayerLoaderTests: XCTestCase {
 
 	func test_load_PlayableStorageItem() async throws {
 		// GIVEN
-		let trackPlaybackInfo = TrackPlaybackInfo.mock(albumReplayGain: 4, albumPeakAmplitude: 1)
+		let trackPlaybackInfo = TrackPlaybackInfo.mock(
+			licenseSecurityToken: "sdf2ewerqwe",
+			manifestMimeType: MediaTypes.BTS,
+			albumReplayGain: 4,
+			albumPeakAmplitude: 1
+		)
 		let playbackInfo = PlaybackInfo.mock(mediaProduct: .mock(), trackPlaybackInfo: trackPlaybackInfo)
 		let offlinedMediaProduct = PlayableOfflinedMediaProduct(from: OfflineEntry.mock(
 			from: playbackInfo,

--- a/Tests/PlayerTests/Player/PlaybackEngine/Internal/Utils/LoudnessNormalizerTests.swift
+++ b/Tests/PlayerTests/Player/PlaybackEngine/Internal/Utils/LoudnessNormalizerTests.swift
@@ -7,6 +7,7 @@ private enum Constants {
 	static let albumReplayGain: Float = 1
 	static let albumPeakAmplitude: Float = 3
 	static let playbackInfo = PlaybackInfo.mock(
+		mediaType: MediaTypes.BTS,
 		albumReplayGain: albumReplayGain,
 		albumPeakAmplitude: albumPeakAmplitude,
 		trackReplayGain: 2,


### PR DESCRIPTION
Moved the expiry check behind a development flag so we can work on a full revalidation implementation and improved UTs