### PR TITLE
Logging: Unify common metadata keys

### DIFF
--- a/Sources/Auth/Model/AuthLoggable.swift
+++ b/Sources/Auth/Model/AuthLoggable.swift
@@ -26,7 +26,7 @@ extension AuthLoggable {
 	static var enableLogging: Bool = false
 	private static let metadataErrorKey = "error"
 	private static let metadataReasonKey = "reason"
-	private static let metadataErrorCodeKey = "code"
+	private static let metadataCodeKey = "code"
 	private static let metadataPreviousSubstatusKey = "previous_substatus"
 
 	var loggingMessage: Logger.Message {
@@ -82,7 +82,7 @@ extension AuthLoggable {
 			return [:]
 		}
 		
-		metadata[Self.metadataErrorCodeKey] = .string(errorCode)
+		metadata[Self.metadataCodeKey] = .string(eventCode)
 
 		return metadata
 	}
@@ -100,7 +100,7 @@ extension AuthLoggable {
 		"Auth"
 	}
 	
-	private var errorCode: String {
+	private var eventCode: String {
 		let intCode = switch self {
 		case .initializeDeviceLoginNetworkError:
 			1

--- a/Sources/Auth/Model/AuthLoggable.swift
+++ b/Sources/Auth/Model/AuthLoggable.swift
@@ -24,9 +24,6 @@ enum AuthLoggable: TidalLoggable {
 
 extension AuthLoggable {
 	static var enableLogging: Bool = false
-	private static let metadataErrorKey = "error"
-	private static let metadataReasonKey = "reason"
-	private static let metadataCodeKey = "code"
 	private static let metadataPreviousSubstatusKey = "previous_substatus"
 
 	var loggingMessage: Logger.Message {
@@ -66,15 +63,15 @@ extension AuthLoggable {
 			 let .finalizeLoginNetworkError(error),
 			 let .finalizeDeviceLoginNetworkError(error),
 			 let .getCredentialsUpgradeTokenNetworkError(error):
-			metadata[Self.metadataErrorKey] = .string(.init(describing: error))
+			metadata[Logger.Metadata.errorKey] = .string(.init(describing: error))
 		case let .getCredentialsRefreshTokenNetworkError(error, previousSubstatus),
 			 let .getCredentialsRefreshTokenWithClientCredentialsNetworkError(error, previousSubstatus):
-			metadata[Self.metadataErrorKey] = .string(.init(describing: error))
+			metadata[Logger.Metadata.errorKey] = .string(.init(describing: error))
 			metadata[Self.metadataPreviousSubstatusKey] = "\(previousSubstatus ?? "nil")"
 		case let .authLogout(reason, error, previousSubstatus):
-			metadata[Self.metadataReasonKey] = "\(reason)"
+			metadata[Logger.Metadata.reasonKey] = "\(reason)"
 			if let error = error {
-				metadata[Self.metadataErrorKey] = .string(.init(describing: error))
+				metadata[Logger.Metadata.errorKey] = .string(.init(describing: error))
 			}
 			metadata[Self.metadataPreviousSubstatusKey] = "\(previousSubstatus ?? "nil")"
 			return metadata
@@ -82,7 +79,7 @@ extension AuthLoggable {
 			return [:]
 		}
 		
-		metadata[Self.metadataCodeKey] = .string(eventCode)
+		metadata[Logger.Metadata.codeKey] = .string(eventCode)
 
 		return metadata
 	}

--- a/Sources/Common/Logger/LoggerMetadata+Extension.swift
+++ b/Sources/Common/Logger/LoggerMetadata+Extension.swift
@@ -5,4 +5,9 @@ public extension Logger.Metadata {
 	init(stringDict: [String: String]) {
 		self = stringDict.mapValues { .string($0) }
 	}
+	
+	// Common keys that can be used in metadata for the sake of consistency
+	static let errorKey = "error"
+	static let codeKey = "code"
+	static let reasonKey = "reason"
 }

--- a/Sources/Player/Common/Logging/PlayerLoggable.swift
+++ b/Sources/Player/Common/Logging/PlayerLoggable.swift
@@ -5,7 +5,6 @@ import Logging
 // MARK: - Constants
 
 private enum Constants {
-	static let metadataErrorKey = "error"
 	static let metadataAudioCodecKey = "audioCodec"
 	static let metadataAudioModeKey = "audioMode"
 	static let metadataErrorSubstatusKey = "errorSubstatus"
@@ -504,9 +503,9 @@ extension PlayerLoggable {
 		     let .djSessionSendCommandFailed(error),
 		     let .loadUCFailed(error),
 		     let .loadPlayerItemFailed(error):
-			metadata[Constants.metadataErrorKey] = "\(String(describing: error))"
+			metadata[Logger.Metadata.errorKey] = "\(String(describing: error))"
 		case let .backoffHandleResponseFailed(error, retryStrategy):
-			metadata[Constants.metadataErrorKey] = "\(String(describing: error))"
+			metadata[Logger.Metadata.errorKey] = "\(String(describing: error))"
 			metadata[Constants.metadataRetryStrategyKey] = "\(String(describing: retryStrategy))"
 		case let .audioCodecInitWithUnknown(codec):
 			metadata[Constants.metadataAudioCodecKey] = "\(String(describing: codec))"


### PR DESCRIPTION
For the sake of consistency, I decided to extract most common metadata keys to its extension. These keys can also be used on clients