### PR TITLE
AuthLoggable - fix AuthLoggable metadata

### DIFF
--- a/Sources/Auth/Model/AuthLoggable.swift
+++ b/Sources/Auth/Model/AuthLoggable.swift
@@ -78,9 +78,8 @@ extension AuthLoggable {
 				metadata[Logger.Metadata.errorKey] = .string(.init(describing: error))
 			}
 			metadata[Self.metadataPreviousSubstatusKey] = "\(previousSubstatus ?? "nil")"
-			return metadata
 		default:
-			return [:]
+			break
 		}
 		
 		metadata[Logger.Metadata.codeKey] = .string(eventCode)


### PR DESCRIPTION
For some cases code was not set, because we returned from the function before 😅 

It's a pity that I discovered it right after releasing a new version... 