### PR TITLE
Remove linting

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -46,15 +46,6 @@
       }
     },
     {
-      "identity" : "swiftlintplugin",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/lukepistrol/SwiftLintPlugin",
-      "state" : {
-        "revision" : "5a65f4074975f811da666dfe31a19850950b1ea4",
-        "version" : "0.56.2"
-      }
-    },
-    {
       "identity" : "swxmlhash",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/drmohundro/SWXMLHash.git",

--- a/Package.swift
+++ b/Package.swift
@@ -9,6 +9,7 @@ import PackageDescription
 let environmentVariables = ProcessInfo.processInfo.environment
 let shouldIncludeDocCPlugin = environmentVariables["INCLUDE_DOCC_PLUGIN"] == "true"
 
+// swiftLint makes no sense in a library!
 let package = Package(
 	name: "tidal-sdk-ios",
 	platforms: [

--- a/Package.swift
+++ b/Package.swift
@@ -44,7 +44,6 @@ let package = Package(
 		.package(url: "https://github.com/drmohundro/SWXMLHash.git", from: "7.0.2"),
 		.package(url: "https://github.com/kishikawakatsumi/KeychainAccess.git", from: "4.2.2"),
 		.package(url: "https://github.com/MobileNativeFoundation/Kronos.git", exact: "4.2.2"),
-		.package(url: "https://github.com/lukepistrol/SwiftLintPlugin", from: "0.54.0"),
 		.package(url: "https://github.com/apple/swift-log.git", from: "1.6.1"),
 		.package(url: "https://github.com/Flight-School/AnyCodable", from: "0.6.0"),
 	] + (shouldIncludeDocCPlugin ? [.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0")] : []),
@@ -52,7 +51,6 @@ let package = Package(
 		.target(
 			name: "Template",
 			plugins: [
-				.plugin(name: "SwiftLint", package: "SwiftLintPlugin"),
 			]
 		),
 		.testTarget(
@@ -68,7 +66,6 @@ let package = Package(
 				.auth
 			],
 			plugins: [
-				.plugin(name: "SwiftLint", package: "SwiftLintPlugin"),
 			]
 		),
 		.target(
@@ -78,7 +75,6 @@ let package = Package(
 				.AnyCodable,
 			],
 			plugins: [
-				.plugin(name: "SwiftLint", package: "SwiftLintPlugin"),
 			]
 		),
 		.testTarget(
@@ -96,7 +92,6 @@ let package = Package(
 				.auth,
 			],
 			plugins: [
-				.plugin(name: "SwiftLint", package: "SwiftLintPlugin"),
 			]
 		),
 		.testTarget(
@@ -115,7 +110,6 @@ let package = Package(
 				.Logging,
 			],
 			plugins: [
-				.plugin(name: "SwiftLint", package: "SwiftLintPlugin"),
 			]
 		),
 		.testTarget(
@@ -137,7 +131,6 @@ let package = Package(
 				.process("README.md"),
 			],
 			plugins: [
-				.plugin(name: "SwiftLint", package: "SwiftLintPlugin"),
 			]
 		),
 		.testTarget(
@@ -151,7 +144,6 @@ let package = Package(
 				.process("Resources"),
 			],
 			plugins: [
-				.plugin(name: "SwiftLint", package: "SwiftLintPlugin"),
 			]
 		),
 	]


### PR DESCRIPTION
Linting has no place in a library since its users will never edit the code. Linting is something a company does internally.
It also prevents the library to be used by others. You can test this by setting up a new user, creating a new project and just adding the library - basic compile will not work.