### PR TITLE
[Player] Fix initialization errors due to file Protection in OfflineStorage DB

### DIFF
--- a/Sources/Player/Common/Logging/PlayerLoggable.swift
+++ b/Sources/Player/Common/Logging/PlayerLoggable.swift
@@ -201,6 +201,10 @@ enum PlayerLoggable: TidalLoggable {
 	// MARK: Metrics
 
 	case metricsNoIdealStartTime
+
+	// MARK: Player
+
+	case alreadyInitialized
 }
 
 // swiftlint:enable identifier_name
@@ -455,6 +459,9 @@ extension PlayerLoggable {
 		// Metrics
 		case .metricsNoIdealStartTime:
 			"Metrics-noIdealStartTime"
+		// Player
+		case .alreadyInitialized:
+			"Player-alreadyInitialized"
 		}
 	}
 
@@ -541,8 +548,8 @@ extension PlayerLoggable {
 		     .interruptionMonitorHandleNotificationUnknownType,
 		     .changeMonitorHandleNotificationWithoutRequiredData,
 		     .changeMonitorUpdateVolumeWithoutRequiredData,
-			 .handleMediaServicesWereReset,
-			 .handleMediaServicesWereLost,
+		     .handleMediaServicesWereReset,
+		     .handleMediaServicesWereLost,
 		     .eventSenderInitEventsDirectoryFailed,
 		     .eventSenderInitOfflinePlaysDirectoryFailed,
 		     .eventSenderInitializeDirectoryNoURLPath,
@@ -562,7 +569,8 @@ extension PlayerLoggable {
 		     .handleErrorPlayerItemNotCurrent,
 		     .handleErrorPlayerItemNotNext,
 		     .playWithoutQueuedItems,
-		     .itemChangedWithoutQueuedItems:
+		     .itemChangedWithoutQueuedItems,
+		     .alreadyInitialized:
 			break
 		}
 
@@ -616,7 +624,8 @@ extension PlayerLoggable {
 		     .djSessionStartFailed,
 		     .djSessionSendCommandFailed,
 		     .loadUCFailed,
-		     .loadPlayerItemFailed:
+		     .loadPlayerItemFailed,
+		     .alreadyInitialized:
 			.error
 		case .streamingNotifyGetCredentialFailed,
 		     .streamingConnectOfflineMode,
@@ -641,8 +650,8 @@ extension PlayerLoggable {
 		     .changeMonitorHandleNotificationWithoutRequiredData,
 		     .changeMonitorHandleNotificationDefaultReason,
 		     .changeMonitorUpdateVolumeWithoutRequiredData,
-			 .handleMediaServicesWereLost,
-			 .handleMediaServicesWereReset,
+		     .handleMediaServicesWereLost,
+		     .handleMediaServicesWereReset,
 		     .eventSenderInitEventsDirectoryFailed,
 		     .eventSenderInitOfflinePlaysDirectoryFailed,
 		     .eventSenderInitializeDirectoryNoURLPath,

--- a/Sources/Player/Common/Logging/PlayerLoggable.swift
+++ b/Sources/Player/Common/Logging/PlayerLoggable.swift
@@ -76,6 +76,7 @@ enum PlayerLoggable: TidalLoggable {
 	// MARK: Offline Storage
 
 	case withDefaultDatabase(error: Error)
+	case updateDBFileAttributes(error: Error)
 
 	// MARK: Offline Engine
 
@@ -301,6 +302,8 @@ extension PlayerLoggable {
 		// GRDBOfflineStorage
 		case .withDefaultDatabase:
 			"GRDBOfflineStorage-withDefaultDatabase"
+		case .updateDBFileAttributes:
+			"GRDBOfflineStorage-updateDBFileAttributes"
 
 		// Offline Engine
 		case .saveOfflinedItemFailed:
@@ -459,6 +462,7 @@ extension PlayerLoggable {
 		// Metrics
 		case .metricsNoIdealStartTime:
 			"Metrics-noIdealStartTime"
+
 		// Player
 		case .alreadyInitialized:
 			"Player-alreadyInitialized"
@@ -488,6 +492,7 @@ extension PlayerLoggable {
 		     let .downloadFailed(error),
 		     let .downloadFinalizeFailed(error),
 		     let .withDefaultDatabase(error),
+		     let .updateDBFileAttributes(error),
 		     let .saveOfflinedItemFailed(error),
 		     let .deleteOfflinedItemFailed(error),
 		     let .deleteAssetCacheFailed(error),
@@ -602,6 +607,7 @@ extension PlayerLoggable {
 		     .downloadFailed,
 		     .downloadFinalizeFailed,
 		     .withDefaultDatabase,
+		     .updateDBFileAttributes,
 		     .saveOfflinedItemFailed,
 		     .deleteOfflinedItemFailed,
 		     .deleteAssetCacheFailed,

--- a/Sources/Player/Common/Utils/FileManager/FileManagerClient+Live.swift
+++ b/Sources/Player/Common/Utils/FileManager/FileManagerClient+Live.swift
@@ -41,6 +41,12 @@ extension FileManagerClient {
 		},
 		enumerator: { url, keys, options, handler in
 			FileManager.default.enumerator(at: url, includingPropertiesForKeys: keys, options: options, errorHandler: handler)
+		},
+		attributesOfItem: { path in
+			try FileManager.default.attributesOfItem(atPath: path)
+		},
+		setAttributes: { attributes, path in
+			try FileManager.default.setAttributes(attributes, ofItemAtPath: path)
 		}
 	)
 }

--- a/Sources/Player/Common/Utils/FileManager/FileManagerClient.swift
+++ b/Sources/Player/Common/Utils/FileManager/FileManagerClient.swift
@@ -26,6 +26,8 @@ struct FileManagerClient {
 		_ options: FileManager.DirectoryEnumerationOptions,
 		_ handler: ((URL, any Error) -> Bool)?
 	) -> FileManager.DirectoryEnumerator?
+	var attributesOfItem: (_ path: String) throws -> [FileAttributeKey: Any]
+	var setAttributes: (_ attributes: [FileAttributeKey: Any], _ path: String) throws -> Void
 }
 
 extension FileManagerClient {

--- a/Sources/Player/OfflineEngine/Internal/Storage/GRDBStorage/GRDBOfflineStorage.swift
+++ b/Sources/Player/OfflineEngine/Internal/Storage/GRDBStorage/GRDBOfflineStorage.swift
@@ -118,13 +118,16 @@ private extension GRDBOfflineStorage {
 		let appSupportURL = PlayerWorld.fileManagerClient.applicationSupportDirectory()
 		let directoryURL = appSupportURL.appendingPathComponent("PlayerOfflineDatabase", isDirectory: true)
 		if PlayerWorld.fileManagerClient.fileExists(atPath: directoryURL.path, isDirectory: nil) {
-			var attributes = try? PlayerWorld.fileManagerClient.attributesOfItem(directoryURL.path)
-			if attributes != nil,
-			   let protectionKey = attributes?[FileAttributeKey.protectionKey] as? FileProtectionType,
-			   protectionKey != FileProtectionType.none
-			{
-				attributes?[FileAttributeKey.protectionKey] = FileProtectionType.none
-				try? PlayerWorld.fileManagerClient.setAttributes(attributes!, directoryURL.path)
+			do {
+				var attributes = try PlayerWorld.fileManagerClient.attributesOfItem(directoryURL.path)
+				if let protectionKey = attributes[FileAttributeKey.protectionKey] as? FileProtectionType,
+				   protectionKey != FileProtectionType.none
+				{
+					attributes[FileAttributeKey.protectionKey] = FileProtectionType.none
+					try PlayerWorld.fileManagerClient.setAttributes(attributes, directoryURL.path)
+				}
+			} catch {
+				PlayerWorld.logger?.log(loggable: PlayerLoggable.updateDBFileAttributes(error: error))
 			}
 		} else {
 			try PlayerWorld.fileManagerClient.createDirectory(

--- a/Tests/PlayerTests/Mocks/Common/Utils/FileManager/FileManagerClient+Mock.swift
+++ b/Tests/PlayerTests/Mocks/Common/Utils/FileManager/FileManagerClient+Mock.swift
@@ -42,6 +42,12 @@ extension FileManagerClient {
 		},
 		enumerator: { url, keys, options, handler in
 			FileManager.default.enumerator(at: url, includingPropertiesForKeys: keys, options: options, errorHandler: handler)
+		},
+		attributesOfItem: { path in
+			try FileManager.default.attributesOfItem(atPath: path)
+		},
+		setAttributes: { attributes, path in
+			try FileManager.default.setAttributes(attributes, ofItemAtPath: path)
 		}
 	)
 }


### PR DESCRIPTION
## Context
We noticed some crashes in our TIDAL client happening under some circumstances, which were caused due to an uninitialized Player instance.

After some investigation, the reason why the Player was not being initialised properly was due to an error opening the `OfflineStorage` database.

We are already logging when this happens, unfortunately, this was happening before we had initialized the `PlayerLogger` 😅 

If we had the logs in place, we probably would see that the issue is due to the db file having `fileProtection = .completeFileProtectionUntilFirstUserAuthentication`. When the app gets prewarmed after a reboot, but before the user has unlocked his device for the first time, this files are not accesible, and `Player.bootstrap()` will fail, causing a crash in our client because it expects it to never be `nil`

## Fix

This PR changes three main things
- Init the PlayerLogger first thing in the bootstrap process, 
- Clarifying the error handling for `OfflineStorage`
- Setting the file protection to `.none` for the `OfflineStorage` database

