### PR TITLE
[Player] Unified caching (3/X): Better URL handling in GRDB

### DIFF
--- a/Sources/Player/OfflineEngine/Internal/Storage/GRDBStorage/GRDBOfflineStorage.swift
+++ b/Sources/Player/OfflineEngine/Internal/Storage/GRDBStorage/GRDBOfflineStorage.swift
@@ -67,7 +67,16 @@ extension GRDBOfflineStorage: OfflineStorage {
 		let entity = try dbQueue.read { db in
 			try OfflineEntryGRDBEntity.filter(OfflineEntryGRDBEntity.Columns.productId == key).fetchOne(db)
 		}
-		return entity?.offlineEntry
+
+		guard let entity else {
+			return nil
+		}
+
+		if entity.bookmarkDataNeedsUpdating() {
+			try update(entity.offlineEntry)
+		}
+
+		return entity.offlineEntry
 	}
 
 	// MARK: - Delete OfflineEntry by MediaProduct

--- a/Sources/Player/OfflineEngine/Internal/Storage/GRDBStorage/OfflineEntryGRDBEntity.swift
+++ b/Sources/Player/OfflineEngine/Internal/Storage/GRDBStorage/OfflineEntryGRDBEntity.swift
@@ -56,8 +56,7 @@ struct OfflineEntryGRDBEntity: Codable, FetchableRecord, PersistableRecord {
 		var isStale = false
 		guard
 			let mediaBookmark,
-			let url = try? URL(resolvingBookmarkData: mediaBookmark, bookmarkDataIsStale: &isStale),
-			!isStale
+			let url = try? URL(resolvingBookmarkData: mediaBookmark, bookmarkDataIsStale: &isStale)
 		else {
 			return nil
 		}
@@ -68,12 +67,10 @@ struct OfflineEntryGRDBEntity: Codable, FetchableRecord, PersistableRecord {
 		var isStale = false
 		guard
 			let licenseBookmark,
-			let url = try? URL(resolvingBookmarkData: licenseBookmark, bookmarkDataIsStale: &isStale),
-			!isStale
+			let url = try? URL(resolvingBookmarkData: licenseBookmark, bookmarkDataIsStale: &isStale)
 		else {
 			return nil
 		}
-
 		return url
 	}
 
@@ -108,5 +105,23 @@ struct OfflineEntryGRDBEntity: Codable, FetchableRecord, PersistableRecord {
 		size = entry.size
 		mediaBookmark = try? entry.mediaURL?.bookmarkData()
 		licenseBookmark = try? entry.licenseURL?.bookmarkData()
+	}
+
+	func bookmarkDataNeedsUpdating() -> Bool {
+		do {
+			var mediaBookmarkIsStale = false
+			var licenseBookmarkIsStale = false
+
+			if let mediaBookmark {
+				_ = try URL(resolvingBookmarkData: mediaBookmark, bookmarkDataIsStale: &mediaBookmarkIsStale)
+			}
+			if let licenseBookmark {
+				_ = try URL(resolvingBookmarkData: licenseBookmark, bookmarkDataIsStale: &licenseBookmarkIsStale)
+			}
+
+			return mediaBookmarkIsStale || licenseBookmarkIsStale
+		} catch {
+			return false
+		}
 	}
 }

--- a/Sources/Player/PlaybackEngine/Internal/Cache/CacheEntry.swift
+++ b/Sources/Player/PlaybackEngine/Internal/Cache/CacheEntry.swift
@@ -5,11 +5,11 @@ import Foundation
 struct CacheEntry: Codable {
 	var key: String
 	var type: CacheEntryType
-	var url: URL
+	var url: URL?
 	var lastAccessedAt: Date
 	var size: Int
 
-	init(key: String, type: CacheEntryType, url: URL, lastAccessedAt: Date = Date.now, size: Int) {
+	init(key: String, type: CacheEntryType, url: URL?, lastAccessedAt: Date = Date.now, size: Int) {
 		self.key = key
 		self.type = type
 		self.url = url


### PR DESCRIPTION
## Context

While updating Player to use the new unified cache layer, I noticed a couple of issues with the current approach about storing and reading URLs from GRDB entities.

It is important to understand that URL are relative to the app sandbox fodler, and this can change after an OS update, a phone backup restore, etc

Due to this, we can't rely on the raw URL stored, and we need to use the `bookmarkData()` method available for this. 

## Description

### Update Cache entity

First, I changed the GRDB `CacheEntryEntity` to store the bookmark data instead of the URL, just like we do with the GRDB `OfflineEntryEntity`. We don't need a proper migration because the code has never run in production yet.

### Update bookmark data if stale

We were not detecting when the bookmark data was stale and updating the stored entity accordingly. This could cause issues in the future, so I made the necessary changes to fix it.