### PR TITLE
[Player] Unified caching (4/X): Modify `GenericMediaPlayer` interface

### DIFF
--- a/Sources/Player/Mocks/PlaybackEngine/PlayerMock.swift
+++ b/Sources/Player/Mocks/PlaybackEngine/PlayerMock.swift
@@ -40,7 +40,7 @@ public final class PlayerMock: GenericMediaPlayer {
 
 	public init() {}
 
-	public init(cachePath: URL, featureFlagProvider: FeatureFlagProvider) {}
+	public init(cachePath: URL, cacheStorage: CacheStorage?, featureFlagProvider: FeatureFlagProvider) {}
 
 	public func canPlay(
 		productType: PlayerProductType,

--- a/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/AVQueuePlayerWrapper.swift
+++ b/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/AVQueuePlayerWrapper.swift
@@ -16,7 +16,9 @@ final class AVQueuePlayerWrapper: GenericMediaPlayer {
 	private let featureFlagProvider: FeatureFlagProvider
 
 	private let queue: OperationQueue
+
 	private let assetFactory: AVURLAssetFactory
+	private let cacheStorage: CacheStorage?
 
 	@Atomic private var player: AVQueuePlayer
 	private var playerMonitor: AVPlayerMonitor?
@@ -55,14 +57,15 @@ final class AVQueuePlayerWrapper: GenericMediaPlayer {
 
 	// MARK: Initialization
 
-	init(cachePath: URL, featureFlagProvider: FeatureFlagProvider) {
+	init(cachePath: URL, cacheStorage: CacheStorage?, featureFlagProvider: FeatureFlagProvider) {
+		self.cacheStorage = cacheStorage
 		self.featureFlagProvider = featureFlagProvider
 
 		queue = OperationQueue()
 		queue.maxConcurrentOperationCount = 1
 		queue.qualityOfService = .userInitiated
 
-		assetFactory = AVURLAssetFactory()
+		assetFactory = AVURLAssetFactory(cacheStorage: cacheStorage)
 		player = AVQueuePlayerWrapper.createPlayer(featureFlagProvider: featureFlagProvider)
 
 		preparePlayer()

--- a/Sources/Player/PlaybackEngine/Internal/Cache/CacheEntry.swift
+++ b/Sources/Player/PlaybackEngine/Internal/Cache/CacheEntry.swift
@@ -2,7 +2,7 @@ import Foundation
 
 // MARK: - CacheEntry
 
-struct CacheEntry: Codable {
+public struct CacheEntry: Codable {
 	var key: String
 	var type: CacheEntryType
 	var url: URL?

--- a/Sources/Player/PlaybackEngine/Internal/Cache/CacheStorage.swift
+++ b/Sources/Player/PlaybackEngine/Internal/Cache/CacheStorage.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-protocol CacheStorage {
+public protocol CacheStorage {
 	// MARK: - Save CacheEntry
 
 	func save(_ entry: CacheEntry) throws
@@ -12,6 +12,10 @@ protocol CacheStorage {
 	// MARK: - Delete CacheEntry by Key
 
 	func delete(key: String) throws
+
+	// MARK: - Delete All CacheEntries
+
+	func deleteAll() throws
 
 	// MARK: - Update CacheEntry
 

--- a/Sources/Player/PlaybackEngine/Internal/Cache/GRDBCache/GRDBCacheStorage.swift
+++ b/Sources/Player/PlaybackEngine/Internal/Cache/GRDBCache/GRDBCacheStorage.swift
@@ -95,6 +95,10 @@ extension GRDBCacheStorage: CacheStorage {
 			try CacheEntryGRDBEntity.deleteAll(db)
 		}
 
+		guard !contentURLs.isEmpty else {
+			return
+		}
+
 		SafeTask { [contentURLs] in
 			for url in contentURLs {
 				try? PlayerWorld.fileManagerClient.removeFile(url)

--- a/Sources/Player/PlaybackEngine/Internal/Cache/GRDBCache/GRDBCacheStorage.swift
+++ b/Sources/Player/PlaybackEngine/Internal/Cache/GRDBCache/GRDBCacheStorage.swift
@@ -86,6 +86,22 @@ extension GRDBCacheStorage: CacheStorage {
 		}
 	}
 
+	// MARK: - Delete All CacheEntries
+
+	func deleteAll() throws {
+		let contentURLs = try getAll().compactMap { $0.url }
+
+		_ = try dbQueue.write { db in
+			try CacheEntryGRDBEntity.deleteAll(db)
+		}
+
+		SafeTask { [contentURLs] in
+			for url in contentURLs {
+				try? PlayerWorld.fileManagerClient.removeFile(url)
+			}
+		}
+	}
+
 	// MARK: - Update CacheEntry
 
 	func update(_ entry: CacheEntry) throws {

--- a/Sources/Player/PlaybackEngine/Internal/InternalPlayerLoader.swift
+++ b/Sources/Player/PlaybackEngine/Internal/InternalPlayerLoader.swift
@@ -44,6 +44,7 @@ final class InternalPlayerLoader: PlayerLoader {
 		let cachePath = PlayerWorld.fileManagerClient.cachesDirectory()
 		self.mainPlayer = mainPlayer.init(
 			cachePath: cachePath,
+			cacheStorage: cacheStorage,
 			featureFlagProvider: featureFlagProvider
 		)
 
@@ -53,6 +54,7 @@ final class InternalPlayerLoader: PlayerLoader {
 			registerPlayer(
 				externalPlayerType.init(
 					cachePath: cachePath,
+					cacheStorage: cacheStorage,
 					featureFlagProvider: featureFlagProvider
 				)
 			)

--- a/Sources/Player/PlaybackEngine/Internal/MediaPlayers/GenericMediaPlayer.swift
+++ b/Sources/Player/PlaybackEngine/Internal/MediaPlayers/GenericMediaPlayer.swift
@@ -6,7 +6,7 @@ public protocol GenericMediaPlayer: AnyObject {
 	var shouldSwitchStateOnSkipToNext: Bool { get }
 	// swiftlint:enable identifier_name
 
-	init(cachePath: URL, featureFlagProvider: FeatureFlagProvider)
+	init(cachePath: URL, cacheStorage: CacheStorage?, featureFlagProvider: FeatureFlagProvider)
 
 	func canPlay(
 		productType: ProductType,

--- a/Tests/PlayerTests/Mocks/PlaybackEngine/Internal/Cache/CacheStorageMock.swift
+++ b/Tests/PlayerTests/Mocks/PlaybackEngine/Internal/Cache/CacheStorageMock.swift
@@ -10,6 +10,8 @@ final class CacheStorageMock: CacheStorage {
 
 	func delete(key: String) throws {}
 
+	func deleteAll() throws {}
+
 	func update(_ entry: CacheEntry) throws {}
 
 	func getAll() throws -> [CacheEntry] {


### PR DESCRIPTION
This PR focuses on adapting our `GenericMediaPlayer` interface to support the new unified caching that all player implementations will share.

It also adds the `deleteAll()` method to the `CacheStorage` protocol

And prepares the `AVURLAssetFactory` to be migrated to use the new `CacheStorage` as the backing layer in the next PR.