### PR TITLE
Remove swiftlint plugin

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -46,15 +46,6 @@
       }
     },
     {
-      "identity" : "swiftlintplugin",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/lukepistrol/SwiftLintPlugin",
-      "state" : {
-        "revision" : "5a65f4074975f811da666dfe31a19850950b1ea4",
-        "version" : "0.56.2"
-      }
-    },
-    {
       "identity" : "swxmlhash",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/drmohundro/SWXMLHash.git",

--- a/Package.swift
+++ b/Package.swift
@@ -44,16 +44,12 @@ let package = Package(
 		.package(url: "https://github.com/drmohundro/SWXMLHash.git", from: "7.0.2"),
 		.package(url: "https://github.com/kishikawakatsumi/KeychainAccess.git", from: "4.2.2"),
 		.package(url: "https://github.com/MobileNativeFoundation/Kronos.git", exact: "4.2.2"),
-		.package(url: "https://github.com/lukepistrol/SwiftLintPlugin", from: "0.54.0"),
 		.package(url: "https://github.com/apple/swift-log.git", from: "1.6.1"),
 		.package(url: "https://github.com/Flight-School/AnyCodable", from: "0.6.0"),
 	] + (shouldIncludeDocCPlugin ? [.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0")] : []),
 	targets: [
 		.target(
-			name: "Template",
-			plugins: [
-				.plugin(name: "SwiftLint", package: "SwiftLintPlugin"),
-			]
+			name: "Template"
 		),
 		.testTarget(
 			name: "TemplateTests",
@@ -67,9 +63,6 @@ let package = Package(
 				.AnyCodable,
 				.auth,
 				.common,
-			],
-			plugins: [
-				.plugin(name: "SwiftLint", package: "SwiftLintPlugin"),
 			]
 		),
 		.target(
@@ -77,9 +70,6 @@ let package = Package(
 			dependencies: [
 				.Logging,
 				.AnyCodable,
-			],
-			plugins: [
-				.plugin(name: "SwiftLint", package: "SwiftLintPlugin"),
 			]
 		),
 		.testTarget(
@@ -95,9 +85,6 @@ let package = Package(
 				.GRDB,
 				.SWXMLHash,
 				.auth,
-			],
-			plugins: [
-				.plugin(name: "SwiftLint", package: "SwiftLintPlugin"),
 			]
 		),
 		.testTarget(
@@ -114,9 +101,6 @@ let package = Package(
 				.common,
 				.KeychainAccess,
 				.Logging,
-			],
-			plugins: [
-				.plugin(name: "SwiftLint", package: "SwiftLintPlugin"),
 			]
 		),
 		.testTarget(
@@ -136,9 +120,6 @@ let package = Package(
 			],
 			resources: [
 				.process("README.md"),
-			],
-			plugins: [
-				.plugin(name: "SwiftLint", package: "SwiftLintPlugin"),
 			]
 		),
 		.testTarget(
@@ -150,9 +131,6 @@ let package = Package(
 			],
 			resources: [
 				.process("Resources"),
-			],
-			plugins: [
-				.plugin(name: "SwiftLint", package: "SwiftLintPlugin"),
 			]
 		),
 	]


### PR DESCRIPTION
We are moving the lint to pre-commit. In this PR, I simply remove the SwiftLint plug-in.