### PR TITLE
Remove isUserLoggedIn check in TidalApi

### DIFF
--- a/Sources/TidalAPI/Utils/RequestHelper.swift
+++ b/Sources/TidalAPI/Utils/RequestHelper.swift
@@ -15,10 +15,7 @@ enum RequestHelper {
 		let credentials = try await credentialsProvider.getCredentials()
 		let requestBuilder = try await requestBuilder()
 		let requestURL = requestBuilder.URLString
-		guard
-			let token = credentials.token,
-			OpenAPIClientAPI.credentialsProvider?.isUserLoggedIn == true
-		else {
+		guard let token = credentials.token else {
 			throw TidalAPIError(
 				message: "NO_TOKEN",
 				url: requestURL


### PR DESCRIPTION
Currently the `RequestHelper` checks for a few conditions before making requests. One of the check is whether the user is logged in. It throws an error if that's not the case. This limits the TidalAPI to be only used when the user is authenticated. 

This prevents its usage with Client Credentials auth flow where the client is authenticated and capable to make API requests that don't require user authentication. This PR removes the check of `isUserLoggedIn == true`.

