### PR TITLE
[Fix] Identifiable conformance of some generated code

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -96,3 +96,4 @@
 # Excluded files and directories 
 --exclude bin
 --exclude **/.build
+--exclude **/Generated/**

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -9,6 +9,7 @@ disabled_rules:
   - trailing_comma  # Swiftformat takes care of this
   - trailing_whitespace  # Swiftformat takes care of this
   - type_body_length
+  - type_name
 
 # Customizations
 function_body_length: 300

--- a/Sources/TidalAPI/Generated/OpenAPIClient/Classes/OpenAPIs/Models/AlbumsMultiDataDocumentIncludedInner.swift
+++ b/Sources/TidalAPI/Generated/OpenAPIClient/Classes/OpenAPIs/Models/AlbumsMultiDataDocumentIncludedInner.swift
@@ -51,6 +51,20 @@ public enum AlbumsMultiDataDocumentIncludedInner: Codable, JSONEncodable, Hashab
     }
 }
 
-
 @available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
-extension AlbumsMultiDataDocumentIncludedInner: Identifiable {}
+extension AlbumsMultiDataDocumentIncludedInner: Identifiable {
+	public var id: some Hashable {
+		switch self {
+		case let .typeAlbumsResource(value):
+			value.id
+		case let .typeArtistsResource(value):
+			value.id
+		case let .typeProvidersResource(value):
+			value.id
+		case let .typeTracksResource(value):
+			value.id
+		case let .typeVideosResource(value):
+			value.id
+		}
+	}
+}

--- a/Sources/TidalAPI/Generated/OpenAPIClient/Classes/OpenAPIs/Models/AlbumsMultiDataRelationshipDocumentIncludedInner.swift
+++ b/Sources/TidalAPI/Generated/OpenAPIClient/Classes/OpenAPIs/Models/AlbumsMultiDataRelationshipDocumentIncludedInner.swift
@@ -51,6 +51,20 @@ public enum AlbumsMultiDataRelationshipDocumentIncludedInner: Codable, JSONEncod
     }
 }
 
-
 @available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
-extension AlbumsMultiDataRelationshipDocumentIncludedInner: Identifiable {}
+extension AlbumsMultiDataRelationshipDocumentIncludedInner: Identifiable {
+	public var id: some Hashable {
+		switch self {
+		case let .typeAlbumsResource(value):
+			value.id
+		case let .typeArtistsResource(value):
+			value.id
+		case let .typeProvidersResource(value):
+			value.id
+		case let .typeTracksResource(value):
+			value.id
+		case let .typeVideosResource(value):
+			value.id
+		}
+	}
+}

--- a/Sources/TidalAPI/Generated/OpenAPIClient/Classes/OpenAPIs/Models/ArtistsMultiDataDocumentIncludedInner.swift
+++ b/Sources/TidalAPI/Generated/OpenAPIClient/Classes/OpenAPIs/Models/ArtistsMultiDataDocumentIncludedInner.swift
@@ -61,6 +61,24 @@ public enum ArtistsMultiDataDocumentIncludedInner: Codable, JSONEncodable, Hasha
     }
 }
 
-
 @available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
-extension ArtistsMultiDataDocumentIncludedInner: Identifiable {}
+extension ArtistsMultiDataDocumentIncludedInner: Identifiable {
+	public var id: some Hashable {
+		switch self {
+		case let .typeAlbumsResource(value):
+			value.id
+		case let .typeArtistRolesResource(value):
+			value.id
+		case let .typeArtistsResource(value):
+			value.id
+		case let .typePlaylistsResource(value):
+			value.id
+		case let .typeProvidersResource(value):
+			value.id
+		case let .typeTracksResource(value):
+			value.id
+		case let .typeVideosResource(value):
+			value.id
+		}
+	}
+}

--- a/Sources/TidalAPI/Generated/OpenAPIClient/Classes/OpenAPIs/Models/ArtistsMultiDataRelationshipDocumentIncludedInner.swift
+++ b/Sources/TidalAPI/Generated/OpenAPIClient/Classes/OpenAPIs/Models/ArtistsMultiDataRelationshipDocumentIncludedInner.swift
@@ -61,6 +61,24 @@ public enum ArtistsMultiDataRelationshipDocumentIncludedInner: Codable, JSONEnco
     }
 }
 
-
 @available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
-extension ArtistsMultiDataRelationshipDocumentIncludedInner: Identifiable {}
+extension ArtistsMultiDataRelationshipDocumentIncludedInner: Identifiable {
+	public var id: some Hashable {
+		switch self {
+		case let .typeAlbumsResource(value):
+			value.id
+		case let .typeArtistRolesResource(value):
+			value.id
+		case let .typeArtistsResource(value):
+			value.id
+		case let .typePlaylistsResource(value):
+			value.id
+		case let .typeProvidersResource(value):
+			value.id
+		case let .typeTracksResource(value):
+			value.id
+		case let .typeVideosResource(value):
+			value.id
+		}
+	}
+}

--- a/Sources/TidalAPI/Generated/OpenAPIClient/Classes/OpenAPIs/Models/PlaylistsMultiDataDocumentIncludedInner.swift
+++ b/Sources/TidalAPI/Generated/OpenAPIClient/Classes/OpenAPIs/Models/PlaylistsMultiDataDocumentIncludedInner.swift
@@ -46,6 +46,18 @@ public enum PlaylistsMultiDataDocumentIncludedInner: Codable, JSONEncodable, Has
     }
 }
 
-
 @available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
-extension PlaylistsMultiDataDocumentIncludedInner: Identifiable {}
+extension PlaylistsMultiDataDocumentIncludedInner: Identifiable {
+	public var id: some Hashable {
+		switch self {
+		case let .typeArtistsResource(value):
+			value.id
+		case let .typeTracksResource(value):
+			value.id
+		case let .typeUsersResource(value):
+			value.id
+		case let .typeVideosResource(value):
+			value.id
+		}
+	}
+}

--- a/Sources/TidalAPI/Generated/OpenAPIClient/Classes/OpenAPIs/Models/PlaylistsMultiDataRelationshipDocumentIncludedInner.swift
+++ b/Sources/TidalAPI/Generated/OpenAPIClient/Classes/OpenAPIs/Models/PlaylistsMultiDataRelationshipDocumentIncludedInner.swift
@@ -51,6 +51,20 @@ public enum PlaylistsMultiDataRelationshipDocumentIncludedInner: Codable, JSONEn
     }
 }
 
-
 @available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
-extension PlaylistsMultiDataRelationshipDocumentIncludedInner: Identifiable {}
+extension PlaylistsMultiDataRelationshipDocumentIncludedInner: Identifiable {
+	public var id: some Hashable {
+		switch self {
+		case let .typeArtistsResource(value):
+			value.id
+		case let .typePlaylistsResource(value):
+			value.id
+		case let .typeTracksResource(value):
+			value.id
+		case let .typeUsersResource(value):
+			value.id
+		case let .typeVideosResource(value):
+			value.id
+		}
+	}
+}

--- a/Sources/TidalAPI/Generated/OpenAPIClient/Classes/OpenAPIs/Models/SearchresultsMultiDataDocumentIncludedInner.swift
+++ b/Sources/TidalAPI/Generated/OpenAPIClient/Classes/OpenAPIs/Models/SearchresultsMultiDataDocumentIncludedInner.swift
@@ -51,6 +51,20 @@ public enum SearchresultsMultiDataDocumentIncludedInner: Codable, JSONEncodable,
     }
 }
 
-
 @available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
-extension SearchresultsMultiDataDocumentIncludedInner: Identifiable {}
+extension SearchresultsMultiDataDocumentIncludedInner: Identifiable {
+	public var id: some Hashable {
+		switch self {
+		case let .typeAlbumsResource(value):
+			value.id
+		case let .typeArtistsResource(value):
+			value.id
+		case let .typePlaylistsResource(value):
+			value.id
+		case let .typeTracksResource(value):
+			value.id
+		case let .typeVideosResource(value):
+			value.id
+		}
+	}
+}

--- a/Sources/TidalAPI/Generated/OpenAPIClient/Classes/OpenAPIs/Models/SearchresultsMultiDataRelationshipDocumentIncludedInner.swift
+++ b/Sources/TidalAPI/Generated/OpenAPIClient/Classes/OpenAPIs/Models/SearchresultsMultiDataRelationshipDocumentIncludedInner.swift
@@ -56,6 +56,22 @@ public enum SearchresultsMultiDataRelationshipDocumentIncludedInner: Codable, JS
     }
 }
 
-
 @available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
-extension SearchresultsMultiDataRelationshipDocumentIncludedInner: Identifiable {}
+extension SearchresultsMultiDataRelationshipDocumentIncludedInner: Identifiable {
+	public var id: some Hashable {
+		switch self {
+		case let .typeAlbumsResource(value):
+			value.id
+		case let .typeArtistsResource(value):
+			value.id
+		case let .typePlaylistsResource(value):
+			value.id
+		case let .typeSearchresultsResource(value):
+			value.id
+		case let .typeTracksResource(value):
+			value.id
+		case let .typeVideosResource(value):
+			value.id
+		}
+	}
+}

--- a/Sources/TidalAPI/Generated/OpenAPIClient/Classes/OpenAPIs/Models/TracksMultiDataDocumentIncludedInner.swift
+++ b/Sources/TidalAPI/Generated/OpenAPIClient/Classes/OpenAPIs/Models/TracksMultiDataDocumentIncludedInner.swift
@@ -51,6 +51,20 @@ public enum TracksMultiDataDocumentIncludedInner: Codable, JSONEncodable, Hashab
     }
 }
 
-
 @available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
-extension TracksMultiDataDocumentIncludedInner: Identifiable {}
+extension TracksMultiDataDocumentIncludedInner: Identifiable {
+	public var id: some Hashable {
+		switch self {
+		case let .typeAlbumsResource(value):
+			value.id
+		case let .typeArtistsResource(value):
+			value.id
+		case let .typePlaylistsResource(value):
+			value.id
+		case let .typeProvidersResource(value):
+			value.id
+		case let .typeTracksResource(value):
+			value.id
+		}
+	}
+}

--- a/Sources/TidalAPI/Generated/OpenAPIClient/Classes/OpenAPIs/Models/UserCollectionsMultiDataDocumentIncludedInner.swift
+++ b/Sources/TidalAPI/Generated/OpenAPIClient/Classes/OpenAPIs/Models/UserCollectionsMultiDataDocumentIncludedInner.swift
@@ -41,6 +41,16 @@ public enum UserCollectionsMultiDataDocumentIncludedInner: Codable, JSONEncodabl
     }
 }
 
-
 @available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
-extension UserCollectionsMultiDataDocumentIncludedInner: Identifiable {}
+extension UserCollectionsMultiDataDocumentIncludedInner: Identifiable {
+	public var id: some Hashable {
+		switch self {
+		case let .typeAlbumsResource(value):
+			value.id
+		case let .typeArtistsResource(value):
+			value.id
+		case let .typePlaylistsResource(value):
+			value.id
+		}
+	}
+}

--- a/Sources/TidalAPI/Generated/OpenAPIClient/Classes/OpenAPIs/Models/UserRecommendationsMultiDataDocumentIncludedInner.swift
+++ b/Sources/TidalAPI/Generated/OpenAPIClient/Classes/OpenAPIs/Models/UserRecommendationsMultiDataDocumentIncludedInner.swift
@@ -31,6 +31,12 @@ public enum UserRecommendationsMultiDataDocumentIncludedInner: Codable, JSONEnco
     }
 }
 
-
 @available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
-extension UserRecommendationsMultiDataDocumentIncludedInner: Identifiable {}
+extension UserRecommendationsMultiDataDocumentIncludedInner: Identifiable {
+    public var id: some Hashable {
+        switch self {
+        case .typePlaylistsResource(let value):
+            return value.id
+        }
+    }
+}

--- a/Sources/TidalAPI/Generated/OpenAPIClient/Classes/OpenAPIs/Models/UserRecommendationsMultiDataRelationshipDocumentIncludedInner.swift
+++ b/Sources/TidalAPI/Generated/OpenAPIClient/Classes/OpenAPIs/Models/UserRecommendationsMultiDataRelationshipDocumentIncludedInner.swift
@@ -36,6 +36,14 @@ public enum UserRecommendationsMultiDataRelationshipDocumentIncludedInner: Codab
     }
 }
 
-
 @available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
-extension UserRecommendationsMultiDataRelationshipDocumentIncludedInner: Identifiable {}
+extension UserRecommendationsMultiDataRelationshipDocumentIncludedInner: Identifiable {
+	public var id: some Hashable {
+		switch self {
+		case let .typePlaylistsResource(value):
+			value.id
+		case let .typeUserRecommendationsResource(value):
+			value.id
+		}
+	}
+}

--- a/Sources/TidalAPI/Generated/OpenAPIClient/Classes/OpenAPIs/Models/VideosMultiDataDocumentIncludedInner.swift
+++ b/Sources/TidalAPI/Generated/OpenAPIClient/Classes/OpenAPIs/Models/VideosMultiDataDocumentIncludedInner.swift
@@ -41,6 +41,16 @@ public enum VideosMultiDataDocumentIncludedInner: Codable, JSONEncodable, Hashab
     }
 }
 
-
 @available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
-extension VideosMultiDataDocumentIncludedInner: Identifiable {}
+extension VideosMultiDataDocumentIncludedInner: Identifiable {
+	public var id: some Hashable {
+		switch self {
+		case let .typeAlbumsResource(value):
+			value.id
+		case let .typeArtistsResource(value):
+			value.id
+		case let .typeProvidersResource(value):
+			value.id
+		}
+	}
+}

--- a/Sources/TidalAPI/Generated/OpenAPIClient/Classes/OpenAPIs/Models/VideosMultiDataRelationshipDocumentIncludedInner.swift
+++ b/Sources/TidalAPI/Generated/OpenAPIClient/Classes/OpenAPIs/Models/VideosMultiDataRelationshipDocumentIncludedInner.swift
@@ -46,6 +46,18 @@ public enum VideosMultiDataRelationshipDocumentIncludedInner: Codable, JSONEncod
     }
 }
 
-
 @available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)
-extension VideosMultiDataRelationshipDocumentIncludedInner: Identifiable {}
+extension VideosMultiDataRelationshipDocumentIncludedInner: Identifiable {
+	public var id: some Hashable {
+		switch self {
+		case let .typeAlbumsResource(value):
+			value.id
+		case let .typeArtistsResource(value):
+			value.id
+		case let .typeProvidersResource(value):
+			value.id
+		case let .typeVideosResource(value):
+			value.id
+		}
+	}
+}


### PR DESCRIPTION
Some of the generated code, in concrete types that can be a number of different types, do not conform to the Identifiable protocol properly.

All the possible types do, so the fix is just a proper passthrough of the inner ID value.

This PR does a manual fix, but we should find out how to fix this in the generator, either by changing the generator settings, or tweaking the schema definition.