### PR TITLE
OpenAPI generator improvements

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,6 +27,9 @@ jobs:
         elif [ "${{ github.event_name }}" = "merge_group" ]; then
             echo "BASE_BRANCH=${{ github.event.merge_group.base_ref }}" >> $GITHUB_OUTPUT
             echo "FEATURE_BRANCH=" >> $GITHUB_OUTPUT  # Leave empty; already checked out
+        elif [ "${{ github.event_name }}" = "push" ]; then
+            echo "BASE_BRANCH=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+            echo "FEATURE_BRANCH=" >> $GITHUB_OUTPUT
         else
             echo "Unsupported event: ${{ github.event_name }}"
             exit 1

--- a/Sources/TidalAPI/Config/custom_template/modelOneOf.mustache
+++ b/Sources/TidalAPI/Config/custom_template/modelOneOf.mustache
@@ -19,25 +19,23 @@
         {{/oneOfUnknownDefaultCase}}
         }
     }
+    
+    private enum CodingKeys: String, CodingKey {
+        case {{discriminator.propertyName}}
+    }
 
     public init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        {{#oneOf}}
-        {{#-first}}
-        if let value = try? container.decode({{.}}.self) {
-        {{/-first}}
-        {{^-first}}
-        } else if let value = try? container.decode({{.}}.self) {
-        {{/-first}}
-            self = .type{{.}}(value)
-        {{/oneOf}}
-        } else {
-            {{#oneOfUnknownDefaultCase}}
-            self = .unknownDefaultOpenApi
-            {{/oneOfUnknownDefaultCase}}
-            {{^oneOfUnknownDefaultCase}}
-            throw DecodingError.typeMismatch(Self.Type.self, .init(codingPath: decoder.codingPath, debugDescription: "Unable to decode instance of {{classname}}"))
-            {{/oneOfUnknownDefaultCase}}
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(String.self, forKey: .{{discriminator.propertyName}})
+
+        switch type {
+        {{#discriminator.mappedModels}}
+        case "{{mappingName}}":
+            let value = try {{modelName}}(from: decoder)
+            self = .type{{modelName}}(value)
+        {{/discriminator.mappedModels}}
+        default:
+            throw DecodingError.dataCorruptedError(forKey: .{{discriminator.propertyName}}, in: container, debugDescription: "Unknown type: \\(type)")
         }
     }
 }

--- a/Sources/TidalAPI/generate_and_clean.sh
+++ b/Sources/TidalAPI/generate_and_clean.sh
@@ -4,30 +4,47 @@
 input_dir="Config/input"
 output_dir="Generated"
 
-# Step 1: Clear the contents of the input directory
-rm -rf "$input_dir"/*
-mkdir -p "$input_dir"
+# Parse command line arguments
+SKIP_DOWNLOAD=false
+for arg in "$@"; do
+  case $arg in
+    --skip-download)
+      SKIP_DOWNLOAD=true
+      shift
+      ;;
+    *)
+      ;;
+  esac
+done
 
-# Step 2: Download the JSON files and save them in the input directory
-echo "Dowloading API specs from developer.tidal.com"
+# Step 1: Clear the contents of the input directory (only if not skipping download)
+if [ "$SKIP_DOWNLOAD" = false ]; then
+  echo "Clearing the contents of the input directory"
+  rm -rf "$input_dir"/*
+  mkdir -p "$input_dir"
 
-curl -o "$input_dir/tidal-api-oas-prod.json" https://tidal-music.github.io/tidal-api-reference/tidal-api-oas.json
+  # Step 2: Download the JSON files and save them in the input directory
+  echo "Downloading API specs from developer.tidal.com"
+  curl -o "$input_dir/tidal-api-oas-prod.json" https://tidal-music.github.io/tidal-api-reference/tidal-api-oas.json
+else
+  echo "Skipping API spec download"
+fi
 
 # Step 3: Clear the contents of the output directory
-echo "Clear the contents of the output directory"
+echo "Clearing the contents of the output directory"
 rm -rf "$output_dir"/*
 mkdir -p "$output_dir"
 
 # Step 4: Loop through all JSON files in the input folder
 for json_file in "$input_dir"/*.json; do
-  # Run the OpenAPI generator for each JSON file
+  echo "Generating Swift code for $(basename "$json_file")"
   openapi-generator generate \
     -i "$json_file" \
     -g swift5 \
     -o "$output_dir" \
     -c Config/openapi-config.yml \
     --skip-validate-spec
-    
+
   # Step 5: Remove the unwanted files
   rm -f "$output_dir/Package.swift"
   rm -f "$output_dir/Cartfile"


### PR DESCRIPTION
* Fix the `modelOneOf` custom template to properly support discriminators in the schema
* Improved the generator script with a new cli option `--skip-download` so we can regenerate the code from a local schema (without redownloading the schema from the server)
