### PR TITLE
Daily check for tidalapi updates

### DIFF
--- a/.github/actions/check-api-pr/action.yml
+++ b/.github/actions/check-api-pr/action.yml
@@ -1,0 +1,44 @@
+name: 'Check API PR'
+description: 'Checks for an existing API update PR and returns its details'
+outputs:
+  existing_pr:
+    description: 'Whether an existing PR was found (true/false)'
+    value: ${{ steps.check_pr.outputs.existing_pr }}
+  pr_number:
+    description: 'The PR number if found'
+    value: ${{ steps.check_pr.outputs.pr_number }}
+  pr_branch:
+    description: 'The branch name of the PR if found'
+    value: ${{ steps.check_pr.outputs.pr_branch }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Check for existing PR
+      id: check_pr
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+        # Search for open PRs that contain "Automatic Tidal API module update" in the title
+        pr_data=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+          "https://api.github.com/repos/${{ github.repository }}/pulls?state=open")
+        
+        existing_pr_number=$(echo "$pr_data" | jq -r '.[] | select(.title | contains("Automatic Tidal API module update")) | .number' | head -n 1)
+        
+        if [ -n "$existing_pr_number" ] && [ "$existing_pr_number" != "null" ]; then
+          echo "Found existing PR #$existing_pr_number"
+          echo "existing_pr=true" >> $GITHUB_OUTPUT
+          echo "pr_number=$existing_pr_number" >> $GITHUB_OUTPUT
+          
+          # Get the branch name from the PR
+          pr_details=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+            "https://api.github.com/repos/${{ github.repository }}/pulls/$existing_pr_number")
+          branch_name=$(echo "$pr_details" | jq -r '.head.ref')
+          echo "pr_branch=$branch_name" >> $GITHUB_OUTPUT
+          
+          echo "Will use branch: $branch_name"
+        else
+          echo "No existing PR found"
+          echo "existing_pr=false" >> $GITHUB_OUTPUT
+        fi

--- a/.github/workflows/check-tidalapi-spec.yml
+++ b/.github/workflows/check-tidalapi-spec.yml
@@ -1,0 +1,87 @@
+name: Check API Spec Changes
+
+on:
+  schedule:
+    # Runs at 00:00 UTC every day
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  actions: write
+  pull-requests: write
+
+jobs:
+  check-api-spec:
+    runs-on: ubuntu-latest
+    outputs:
+      changes_found: ${{ steps.compare.outputs.changes_found }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Check for existing PR
+        id: check_pr
+        uses: ./.github/actions/check-api-pr
+
+      - name: Checkout PR branch if exists
+        if: steps.check_pr.outputs.existing_pr == 'true'
+        run: |
+          git fetch origin ${{ steps.check_pr.outputs.pr_branch }}
+          git checkout ${{ steps.check_pr.outputs.pr_branch }}
+          echo "Using API spec from PR branch: ${{ steps.check_pr.outputs.pr_branch }}"
+
+      - name: Download latest API spec
+        run: |
+          mkdir -p /tmp/api-check
+          curl -s https://tidal-music.github.io/tidal-api-reference/tidal-api-oas.json -o /tmp/api-check/latest-api.json
+          # Save the spec to a location that can be used by the regeneration workflow
+          mkdir -p Sources/TidalAPI/Config/input
+          cp /tmp/api-check/latest-api.json Sources/TidalAPI/Config/input/tidal-api-oas.json
+      
+      - name: Compare API specs
+        id: compare
+        run: |
+          if cmp -s "Sources/TidalAPI/Config/input/tidal-api-oas.json" "/tmp/api-check/latest-api.json"; then
+            echo "No changes found in the API specification"
+            echo "changes_found=false" >> $GITHUB_OUTPUT
+          else
+            echo "Changes found in the API specification"
+            echo "changes_found=true" >> $GITHUB_OUTPUT
+            echo "::group::API Specification Diff"
+            diff -u "Sources/TidalAPI/Config/input/tidal-api-oas.json" "/tmp/api-check/latest-api.json" || true
+            echo "::endgroup::"
+          fi
+          
+      - name: Upload API spec as artifact
+        if: steps.compare.outputs.changes_found == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: api-spec
+          path: /tmp/api-check/latest-api.json
+          retention-days: 1
+
+      - name: Output result
+        run: |
+          if [ "${{ steps.compare.outputs.changes_found }}" == "true" ]; then
+            echo "Changes found - see diff above"
+            if [ "${{ steps.check_pr.outputs.existing_pr }}" == "true" ]; then
+                echo "Updating the existing PR..."
+            else
+              echo "Creating a new PR..."
+            fi
+          else
+            echo "No Changes found"
+          fi
+
+  regenerate-api:
+    needs: check-api-spec
+    if: needs.check-api-spec.outputs.changes_found == 'true'
+    uses: ./.github/workflows/generate-tidal-api.yml
+    permissions:
+      contents: write
+      pull-requests: write
+    with:
+      use_downloaded_spec: "true"
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-tidalapi-spec.yml
+++ b/.github/workflows/check-tidalapi-spec.yml
@@ -35,10 +35,7 @@ jobs:
         run: |
           mkdir -p /tmp/api-check
           curl -s https://tidal-music.github.io/tidal-api-reference/tidal-api-oas.json -o /tmp/api-check/latest-api.json
-          # Save the spec to a location that can be used by the regeneration workflow
-          mkdir -p Sources/TidalAPI/Config/input
-          cp /tmp/api-check/latest-api.json Sources/TidalAPI/Config/input/tidal-api-oas.json
-      
+ 
       - name: Compare API specs
         id: compare
         run: |

--- a/.github/workflows/generate-tidal-api.yml
+++ b/.github/workflows/generate-tidal-api.yml
@@ -29,6 +29,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Check for existing PR
+        id: check_pr
+        uses: ./.github/actions/check-api-pr
+
+      - name: Checkout PR branch if exists
+        if: steps.check_pr.outputs.existing_pr == 'true'
+        run: |
+          git fetch origin ${{ steps.check_pr.outputs.pr_branch }}
+          git checkout ${{ steps.check_pr.outputs.pr_branch }}
+          echo "Using existing PR branch: ${{ steps.check_pr.outputs.pr_branch }}"
+
       - name: Download API spec artifact
         if: ${{ inputs.use_downloaded_spec == 'true' }}
         uses: actions/download-artifact@v4
@@ -106,49 +117,94 @@ jobs:
         run: |
           git config user.email "svc-github-tidal-music-tools@block.xyz"
           git config user.name "TIDAL Music Tools"
-          timestamp=$(date +"%Y-%m-%d-%H-%M-%S")
-          branch_name="tidal-music-tools/Update-TidalAPI-${timestamp}"
+          
+          # Use a consistent branch name for API updates, so we can edit the PR later
+          standard_branch_name="tidal-music-tools/auto-update-tidal-api"
+          
+          if [ "${{ steps.check_pr.outputs.existing_pr }}" == "true" ]; then
+            # Try to find the branch of the existing PR
+            branch_name="${{ steps.check_pr.outputs.pr_branch }}"
+            
+            # Check if branch exists locally
+            if git rev-parse --verify "$branch_name" >/dev/null 2>&1; then
+              git checkout "$branch_name"
+            else
+              # Try to fetch and checkout the branch
+              git fetch origin "$branch_name":"$branch_name" || true
+              if git rev-parse --verify "$branch_name" >/dev/null 2>&1; then
+                git checkout "$branch_name"
+              else
+                # If branch doesn't exist, use the standard branch name
+                git checkout -b "$standard_branch_name"
+                branch_name="$standard_branch_name"
+              fi
+            fi
+          else
+            # Use standard branch name
+            git checkout -b "$standard_branch_name"
+            branch_name="$standard_branch_name"
+          fi
+          
           echo "BRANCH_NAME=$branch_name" >> "$GITHUB_OUTPUT"
 
       - name: Commit changes
         if: ${{ steps.check_for_changes.outputs.CHANGES_DETECTED == 'true' }}
         run: |
-          git checkout -b "${{steps.prepare_git_and_define_branch_name.outputs.BRANCH_NAME }}"
-          git commit -m "Changed ${{ steps.check_for_changes.outputs.CHANGED_FILE_COUNT }} files via GitHub Actions"
+          # Generate commit message with the number of changed files in the title and the list in the body
+          commit_title="Update Tidal API - ${{ steps.check_for_changes.outputs.CHANGED_FILE_COUNT }} files changed"
+          
+          # Create commit message with changes in input and generated folders
+          commit_body="Changes in Input folder:\n${{ steps.check_for_changes.outputs.CHANGES_IN_INPUT }}\n\nChanges in Generated folder:\n${{ steps.check_for_changes.outputs.CHANGES_IN_GENERATED }}"
+          
+          git add .
+          git commit -m "$commit_title"$'\n\n'"$commit_body"
   
       - name: Push changes
         if: ${{ steps.check_for_changes.outputs.CHANGES_DETECTED == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH_NAME: ${{ steps.prepare_git_and_define_branch_name.outputs.BRANCH_NAME }}
         run: |
-            git push origin "${{steps.prepare_git_and_define_branch_name.outputs.BRANCH_NAME }}"
+            git push --set-upstream origin "${{env.BRANCH_NAME}}" --force
 
-      - name: Create Pull Request
+      - name: Create or Update Pull Request
         if: ${{ steps.check_for_changes.outputs.CHANGES_DETECTED == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          current_date=$(date)
           pr_title="Automatic Tidal API module update - ${{ steps.check_for_changes.outputs.CHANGED_FILE_COUNT }} files changed"
-          pr_body=$(cat <<EOF
-
-          This PR was created by GitHub Actions.
-
-          **Changes in Input folder:**
-          ${{ steps.check_for_changes.outputs.CHANGES_IN_INPUT }}
-
-          **Changes in Generated folder:**
-          ${{ steps.check_for_changes.outputs.CHANGES_IN_GENERATED }}          
-          EOF
-          )
-
-          pr_data=$(jq -n --arg title "$pr_title" \
-                            --arg head "${{steps.prepare_git_and_define_branch_name.outputs.BRANCH_NAME }}" \
-                            --arg base "main" \
-                            --arg body "$pr_body" \
-                            '{title: $title, head: $head, base: $base, body: $body}')
-
-          curl -X POST \
-            -H "Authorization: token $GITHUB_TOKEN" \
-            -H "Accept: application/vnd.github.v3+json" \
-            -d "$pr_data" \
-            https://api.github.com/repos/${{ github.repository }}/pulls
+          
+          # Create PR body with current date and note about automatic updates
+          pr_body="**Changes in Input folder:**\n\n${{ steps.check_for_changes.outputs.CHANGES_IN_INPUT }}\n\n**Changes in Generated folder:**\n\n${{ steps.check_for_changes.outputs.CHANGES_IN_GENERATED }}\n\nAutomatically generated on $current_date\n\nThis PR is automatically updated when API changes are detected."
+          pr_body=$(echo -e "$pr_body")
+          
+          if [ "${{ steps.check_pr.outputs.existing_pr }}" == "true" ]; then
+            # Update existing PR
+            pr_data=$(jq -n --arg title "$pr_title" \
+                              --arg body "$pr_body" \
+                              '{title: $title, body: $body}')
+            
+            curl -X PATCH \
+              -H "Authorization: token $GITHUB_TOKEN" \
+              -H "Accept: application/vnd.github.v3+json" \
+              -d "$pr_data" \
+              "https://api.github.com/repos/${{ github.repository }}/pulls/${{ steps.check_pr.outputs.pr_number }}"
+            
+            echo "Updated existing PR #${{ steps.check_pr.outputs.pr_number }}"
+          else
+            # Create new PR
+            pr_data=$(jq -n --arg title "$pr_title" \
+                              --arg head "${{steps.prepare_git_and_define_branch_name.outputs.BRANCH_NAME }}" \
+                              --arg base "main" \
+                              --arg body "$pr_body" \
+                              '{title: $title, head: $head, base: $base, body: $body}')
+            
+            curl -X POST \
+              -H "Authorization: token $GITHUB_TOKEN" \
+              -H "Accept: application/vnd.github.v3+json" \
+              -d "$pr_data" \
+              "https://api.github.com/repos/${{ github.repository }}/pulls"
+            
+            echo "Created new PR"
+          fi

--- a/.github/workflows/generate-tidal-api.yml
+++ b/.github/workflows/generate-tidal-api.yml
@@ -47,13 +47,6 @@ jobs:
           name: api-spec
           path: /tmp/api-check
 
-      - name: Copy downloaded spec to input folder
-        if: ${{ inputs.use_downloaded_spec == 'true' }}
-        run: |
-          mkdir -p $API_FOLDER/$INPUT_FOLDER_NAME
-          cp /tmp/api-check/latest-api.json $API_FOLDER/$INPUT_FOLDER_NAME/tidal-api-oas.json
-          echo "Using downloaded API spec"
-
       # Step 2: Install OpenAPI Generator via Homebrew
       - name: Install OpenAPI Generator with Homebrew
         run: |
@@ -63,7 +56,13 @@ jobs:
         run: |
           cd $API_FOLDER
           chmod +x $SCRIPT_NAME
-          ./$SCRIPT_NAME
+          if [ "${{ inputs.use_downloaded_spec }}" == "true" ] && [ -f "/tmp/api-check/latest-api.json" ]; then
+            echo "Using downloaded API spec"
+            ./generate_and_clean.sh --local-file "/tmp/api-check/latest-api.json"
+          else
+            echo "Downloading API spec as part of generation"
+            ./generate_and_clean.sh
+          fi
 
       - name: Check for changes
         id: check_for_changes

--- a/.github/workflows/generate-tidal-api.yml
+++ b/.github/workflows/generate-tidal-api.yml
@@ -2,6 +2,16 @@ name: Generate API in the TidalAPI module and create a PR if there are changes
 
 on:
   workflow_dispatch: # manual triggering of this workflow
+  workflow_call:
+    inputs:
+      use_downloaded_spec:
+        description: 'Whether to use the downloaded spec from the artifacts'
+        required: false
+        type: string
+        default: 'false'
+    secrets:
+      token:
+        required: true
 
 permissions:
   contents: write
@@ -18,6 +28,20 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Download API spec artifact
+        if: ${{ inputs.use_downloaded_spec == 'true' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: api-spec
+          path: /tmp/api-check
+
+      - name: Copy downloaded spec to input folder
+        if: ${{ inputs.use_downloaded_spec == 'true' }}
+        run: |
+          mkdir -p $API_FOLDER/$INPUT_FOLDER_NAME
+          cp /tmp/api-check/latest-api.json $API_FOLDER/$INPUT_FOLDER_NAME/tidal-api-oas.json
+          echo "Using downloaded API spec"
 
       # Step 2: Install OpenAPI Generator via Homebrew
       - name: Install OpenAPI Generator with Homebrew

--- a/Sources/TidalAPI/generate_and_clean.sh
+++ b/Sources/TidalAPI/generate_and_clean.sh
@@ -6,18 +6,36 @@ output_dir="Generated"
 
 # Parse command line arguments
 SKIP_DOWNLOAD=false
-for arg in "$@"; do
-  case $arg in
+LOCAL_FILE=""
+
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
     --skip-download)
       SKIP_DOWNLOAD=true
       shift
       ;;
+    --local-file)
+      LOCAL_FILE="$2"
+      SKIP_DOWNLOAD=true
+      shift 2
+      ;;
     *)
+      shift
       ;;
   esac
 done
 
-# Step 1: Clear the contents of the input directory (only if not skipping download)
+# Display usage information
+usage() {
+  echo "Usage: $0 [options]"
+  echo "Options:"
+  echo "  --skip-download         Skip downloading the API spec (use existing files in input dir)"
+  echo "  --local-file <path>     Use a local OpenAPI JSON file instead of downloading"
+  exit 1
+}
+
+# Step 1: Clear the contents of the input directory (only if not using existing files)
 if [ "$SKIP_DOWNLOAD" = false ]; then
   echo "Clearing the contents of the input directory"
   rm -rf "$input_dir"/*
@@ -25,9 +43,25 @@ if [ "$SKIP_DOWNLOAD" = false ]; then
 
   # Step 2: Download the JSON files and save them in the input directory
   echo "Downloading API specs from developer.tidal.com"
-  curl -o "$input_dir/tidal-api-oas-prod.json" https://tidal-music.github.io/tidal-api-reference/tidal-api-oas.json
+  curl -o "$input_dir/tidal-api-oas.json" https://tidal-music.github.io/tidal-api-reference/tidal-api-oas.json
+elif [ -n "$LOCAL_FILE" ]; then
+  echo "Using local file: $LOCAL_FILE"
+  # Check if the local file exists
+  if [ ! -f "$LOCAL_FILE" ]; then
+    echo "Error: Local file '$LOCAL_FILE' not found."
+    exit 1
+  fi
+  
+  # Clear the input directory and copy the local file
+  echo "Clearing the contents of the input directory"
+  rm -rf "$input_dir"/*
+  mkdir -p "$input_dir"
+  
+  # Copy the local file to the input directory
+  cp "$LOCAL_FILE" "$input_dir/tidal-api-oas.json"
+  echo "Copied local file to $input_dir/tidal-api-oas.json"
 else
-  echo "Skipping API spec download"
+  echo "Skipping API spec download, using existing files in $input_dir"
 fi
 
 # Step 3: Clear the contents of the output directory


### PR DESCRIPTION
This adds 
- Daily automatic checks for the Api spec changes.
- Reuse of already downloaded spec file to avoid double work
- Update of already open PRs created by this workflow
- Generator script now can take a local file as na argument instead of pointing to a fixed location


### Commits in this PR

* Check daily for API updates (edbdacd)
* Update existing PR if needed (5b015c2)
* Use already downloaded spec file on CI (23dd5fb)