### PR TITLE
Fix workflow checkout conflicts

### DIFF
--- a/.github/workflows/generate-tidal-api.yml
+++ b/.github/workflows/generate-tidal-api.yml
@@ -120,33 +120,10 @@ jobs:
           # Use a consistent branch name for API updates, so we can edit the PR later
           standard_branch_name="tidal-music-tools/auto-update-tidal-api"
           
-          if [ "${{ steps.check_pr.outputs.existing_pr }}" == "true" ]; then
-            # Try to find the branch of the existing PR
-            branch_name="${{ steps.check_pr.outputs.pr_branch }}"
-            
-            # Check if branch exists locally
-            if git rev-parse --verify "$branch_name" >/dev/null 2>&1; then
-              git checkout "$branch_name"
-            else
-              # Try to fetch and checkout the branch
-              git fetch origin "$branch_name":"$branch_name" || true
-              if git rev-parse --verify "$branch_name" >/dev/null 2>&1; then
-                git checkout "$branch_name"
-              else
-                # If branch doesn't exist, use the standard branch name
-                git checkout -b "$standard_branch_name"
-                branch_name="$standard_branch_name"
-              fi
-            fi
-          else
-            # Use standard branch name
-            git checkout -b "$standard_branch_name"
-            branch_name="$standard_branch_name"
-          fi
-          
-          echo "BRANCH_NAME=$branch_name" >> "$GITHUB_OUTPUT"
+          echo "BRANCH_NAME=$standard_branch_name" >> "$GITHUB_OUTPUT"
 
       - name: Commit changes
+        id: commit_changes
         if: ${{ steps.check_for_changes.outputs.CHANGES_DETECTED == 'true' }}
         run: |
           # Generate commit message with the number of changed files in the title and the list in the body
@@ -156,18 +133,55 @@ jobs:
           commit_body="Changes in Input folder:\n${{ steps.check_for_changes.outputs.CHANGES_IN_INPUT }}\n\nChanges in Generated folder:\n${{ steps.check_for_changes.outputs.CHANGES_IN_GENERATED }}"
           
           git add .
-          git commit -m "$commit_title"$'\n\n'"$commit_body"
+          
+          # Use a consistent branch name for API updates, so we can edit the PR later
+          standard_branch_name="tidal-music-tools/auto-update-tidal-api"
+          
+          if [ "${{ steps.check_pr.outputs.existing_pr }}" == "true" ]; then
+            # Use the branch name from the existing PR
+            branch_name="${{ steps.check_pr.outputs.pr_branch }}"
+            
+            # Fetch the existing PR branch to compare against
+            git fetch origin "$branch_name" || true
+            
+            # Check if current changes are different from existing PR branch
+            if git diff --quiet "origin/$branch_name" HEAD -- $API_FOLDER; then
+              echo "No new changes compared to existing PR branch - skipping update"
+              echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
+              echo "commit_made=false" >> $GITHUB_OUTPUT
+            else
+              echo "Changes detected compared to existing PR branch - updating"
+              git commit -m "$commit_title"$'\n\n'"$commit_body"
+              echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
+              echo "commit_made=true" >> $GITHUB_OUTPUT
+            fi
+          else
+            # Create new branch for new PR
+            git checkout -b "$standard_branch_name"
+            git commit -m "$commit_title"$'\n\n'"$commit_body"
+            branch_name="$standard_branch_name"
+            echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
+            echo "commit_made=true" >> $GITHUB_OUTPUT
+          fi
   
       - name: Push changes
-        if: ${{ steps.check_for_changes.outputs.CHANGES_DETECTED == 'true' }}
+        if: ${{ steps.check_for_changes.outputs.CHANGES_DETECTED == 'true' && steps.commit_changes.outputs.commit_made == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH_NAME: ${{ steps.prepare_git_and_define_branch_name.outputs.BRANCH_NAME }}
+          BRANCH_NAME: ${{ steps.commit_changes.outputs.branch_name }}
         run: |
-            git push --set-upstream origin "${{env.BRANCH_NAME}}" --force
+          if [ "${{ steps.check_pr.outputs.existing_pr }}" == "true" ]; then
+            # Force push current state to existing PR branch
+            echo "Force pushing changes to existing PR branch: ${{env.BRANCH_NAME}}"
+            git push origin HEAD:"${{env.BRANCH_NAME}}" --force
+          else
+            # Push new branch
+            echo "Pushing new branch: ${{env.BRANCH_NAME}}"
+            git push --set-upstream origin "${{env.BRANCH_NAME}}"
+          fi
 
       - name: Create or Update Pull Request
-        if: ${{ steps.check_for_changes.outputs.CHANGES_DETECTED == 'true' }}
+        if: ${{ steps.check_for_changes.outputs.CHANGES_DETECTED == 'true' && steps.commit_changes.outputs.commit_made == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
In the Android repo, we had the issue that when checking out another branch to compare the two, there can be conflicts. To mitigate this, we switched to only comparing the diffs - after all, that is all we want.

### Commits in this PR

* Fix workflow checkout conflicts by diffing instead of checkout (a831763)