### PR TITLE
Remove unnecessary double branch comparison

### DIFF
--- a/.github/workflows/check-tidalapi-spec.yml
+++ b/.github/workflows/check-tidalapi-spec.yml
@@ -74,6 +74,7 @@ jobs:
   regenerate-api:
     needs: check-api-spec
     if: needs.check-api-spec.outputs.changes_found == 'true'
+
     uses: ./.github/workflows/generate-tidal-api.yml
     permissions:
       contents: write

--- a/.github/workflows/generate-tidal-api.yml
+++ b/.github/workflows/generate-tidal-api.yml
@@ -164,9 +164,9 @@ jobs:
             echo "Force pushing changes to existing PR branch: ${{env.BRANCH_NAME}}"
             git push origin HEAD:"${{env.BRANCH_NAME}}" --force
           else
-            # Push new branch
-            echo "Pushing new branch: ${{env.BRANCH_NAME}}"
-            git push --set-upstream origin "${{env.BRANCH_NAME}}"
+            # Force push new branch
+            echo "Force pushing new branch: ${{env.BRANCH_NAME}}"
+            git push --set-upstream origin "${{env.BRANCH_NAME}}" --force
           fi
 
       - name: Create or Update Pull Request

--- a/.github/workflows/generate-tidal-api.yml
+++ b/.github/workflows/generate-tidal-api.yml
@@ -177,8 +177,16 @@ jobs:
           current_date=$(date)
           pr_title="Automatic Tidal API module update - ${{ steps.check_for_changes.outputs.CHANGED_FILE_COUNT }} files changed"
           
+          # Extract API spec version for the generation timestamp
+          api_spec_file="$API_FOLDER/$INPUT_FOLDER_NAME/tidal-api-oas.json"
+          if [ -f "$api_spec_file" ]; then
+            api_version=$(jq -r '.info.version // "unknown"' "$api_spec_file")
+          else
+            api_version="unknown"
+          fi
+          
           # Create PR body with current date and note about automatic updates
-          pr_body="**Changes in Input folder:**\n\n${{ steps.check_for_changes.outputs.CHANGES_IN_INPUT }}\n\n**Changes in Generated folder:**\n\n${{ steps.check_for_changes.outputs.CHANGES_IN_GENERATED }}\n\nAutomatically generated on $current_date\n\nThis PR is automatically updated when API changes are detected."
+          pr_body="**Automatically generated on $current_date, using API spec version $api_version\n\nThis PR is automatically updated when API changes are detected.**\n\nChanges in Input folder:**\n\n${{ steps.check_for_changes.outputs.CHANGES_IN_INPUT }}\n\n*Changes in Generated folder:*\n\n${{ steps.check_for_changes.outputs.CHANGES_IN_GENERATED }}\n\n"
           pr_body=$(echo -e "$pr_body")
           
           if [ "${{ steps.check_pr.outputs.existing_pr }}" == "true" ]; then

--- a/.github/workflows/generate-tidal-api.yml
+++ b/.github/workflows/generate-tidal-api.yml
@@ -138,31 +138,20 @@ jobs:
           standard_branch_name="tidal-music-tools/auto-update-tidal-api"
           
           if [ "${{ steps.check_pr.outputs.existing_pr }}" == "true" ]; then
-            # Use the branch name from the existing PR
+            # We're already on the PR branch, just use it
             branch_name="${{ steps.check_pr.outputs.pr_branch }}"
-            
-            # Fetch the existing PR branch to compare against
-            git fetch origin "$branch_name" || true
-            
-            # Check if current changes are different from existing PR branch
-            if git diff --quiet "origin/$branch_name" HEAD -- $API_FOLDER; then
-              echo "No new changes compared to existing PR branch - skipping update"
-              echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
-              echo "commit_made=false" >> $GITHUB_OUTPUT
-            else
-              echo "Changes detected compared to existing PR branch - updating"
-              git commit -m "$commit_title"$'\n\n'"$commit_body"
-              echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
-              echo "commit_made=true" >> $GITHUB_OUTPUT
-            fi
+            echo "Updated existing PR branch with new changes"
           else
             # Create new branch for new PR
             git checkout -b "$standard_branch_name"
-            git commit -m "$commit_title"$'\n\n'"$commit_body"
             branch_name="$standard_branch_name"
-            echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
-            echo "commit_made=true" >> $GITHUB_OUTPUT
+            echo "Created new PR branch for generated code changes"
           fi
+          
+          # Commit the changes
+          git commit -m "$commit_title"$'\n\n'"$commit_body"
+          echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
+          echo "commit_made=true" >> $GITHUB_OUTPUT
   
       - name: Push changes
         if: ${{ steps.check_for_changes.outputs.CHANGES_DETECTED == 'true' && steps.commit_changes.outputs.commit_made == 'true' }}


### PR DESCRIPTION
If we're in the workflow generating new code, we already know there are changes. So there's no ned to later double-check (In addition, the check was faulty, too).

I also improved the PR description a bit, now also adding the spec version the code was generated from.