### PR TITLE
TDAPEX-661 - Fix TIDAL API generator: Handle array of enums

### DIFF
--- a/Sources/TidalAPI/Config/custom_template/TidalAPI.mustache
+++ b/Sources/TidalAPI/Config/custom_template/TidalAPI.mustache
@@ -73,7 +73,7 @@ public enum {{classname}}Tidal {
      */
 	public static func {{operationId}}({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}[{{classname}}Tidal.{{enumName}}_{{operationId}}]{{/isContainer}}{{^isContainer}}{{classname}}Tidal.{{enumName}}_{{operationId}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{^-last}}, {{/-last}}{{/allParams}}) async throws{{#returnType}} -> {{{returnType}}}{{#returnType}}{{#isResponseOptional}}?{{/isResponseOptional}}{{/returnType}}{{/returnType}} {
 		return try await RequestHelper.createRequest {
-			{{classname}}.{{operationId}}WithRequestBuilder({{#allParams}}{{paramName}}: {{#isEnum}}{{paramName}}{{^required}}?{{/required}}.to{{classname}}Enum(){{/isEnum}}{{^isEnum}}{{paramName}}{{/isEnum}}{{^-last}}, {{/-last}}{{/allParams}})
+			{{classname}}.{{operationId}}WithRequestBuilder({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}{{paramName}}{{^required}}?{{/required}}.compactMap { $0.to{{classname}}Enum() }{{/isContainer}}{{^isContainer}}{{paramName}}{{^required}}?{{/required}}.to{{classname}}Enum(){{/isContainer}}{{/isEnum}}{{^isEnum}}{{paramName}}{{/isEnum}}{{^-last}}, {{/-last}}{{/allParams}})
 		}
 	}
 {{/operation}}


### PR DESCRIPTION
Resolves compilation errors where array enum parameters were calling conversion methods directly on arrays instead of mapping over elements.

Changes:
- Update TidalAPI.mustache template to use compactMap for array enum parameters
- Single enums: paramName?.toClassnameEnum()
- Array enums: paramName?.compactMap { $0.toClassnameEnum() }

🤖 Generated with [Claude Code](https://claude.ai/code)