### PR TITLE
Fix CI linting to respect .swiftlint.yml exclusion rules

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -66,15 +66,11 @@ jobs:
             exit 0
         fi
 
-        files_argument=""
-        for i in "${modified_files[@]}"; do
-            files_argument="$files_argument $i"
-        done
-
         echo "Base branch: $BASE_BRANCH"
         echo "Feature branch: $FEATURE_BRANCH"
-        echo "Modified files: $files_argument"
+        echo "Modified Swift files found: ${#modified_files[@]}"
+        printf '%s\n' "${modified_files[@]}"
 
-        # Run SwiftLint on the changed files
-        echo "Executing: ./bin/swiftlint/run-swiftlint.sh -i $files_argument"
-        ./bin/swiftlint/run-swiftlint.sh -i "$files_argument"
+        # Run SwiftLint normally - it will respect exclusion rules in .swiftlint.yml
+        echo "Executing: ./bin/swiftlint/run-swiftlint.sh"
+        ./bin/swiftlint/run-swiftlint.sh


### PR DESCRIPTION
## Summary
- Fixes CI linting workflow to properly exclude Generated files
- Removes `-i` flag from SwiftLint execution in CI to respect `.swiftlint.yml` exclusion rules

## Problem
The CI lint workflow was failing when Generated files were modified because:
1. CI collected all modified Swift files (including those in `Sources/TidalAPI/Generated/`)
2. Used `./bin/swiftlint/run-swiftlint.sh -i` to explicitly lint those files
3. The `-i` flag overrides exclusion rules in `.swiftlint.yml`, causing Generated files to be linted despite being excluded

## Solution
- Remove the `-i` flag and file list from SwiftLint execution
- Let SwiftLint run normally and respect the exclusion patterns in `.swiftlint.yml`
- Still check if Swift files were modified to avoid unnecessary CI runs

## Test plan
- [x] Verify the workflow file syntax is valid (validated by pre-commit hook)
- [ ] Test with a PR that modifies Generated files to ensure they're properly excluded
- [ ] Confirm regular Swift files are still linted correctly

This ensures consistent linting behavior between local development and CI.