### PR TITLE
Auth: Add jitter to retry delays (+/-20%)

### DIFF
--- a/Sources/Auth/Utils/Utils.swift
+++ b/Sources/Auth/Utils/Utils.swift
@@ -79,7 +79,11 @@ func retryWithPolicyUnwrapped<T>(_ retryPolicy: RetryPolicy, block: () async thr
 }
 
 private func sleep(currentDelay: Int) async {
-	try? await Task.sleep(nanoseconds: UInt64(currentDelay * 1_000_000))
+	// Apply jitter (+/- 20%) to reduce thundering herds
+	let lower = max(0, Int(Double(currentDelay) * 0.8))
+	let upper = max(lower, Int(Double(currentDelay) * 1.2))
+	let jittered = Int.random(in: lower ... upper)
+	try? await Task.sleep(nanoseconds: UInt64(jittered * 1_000_000))
 }
 
 extension Int {


### PR DESCRIPTION
## Why
When transient failures occur (outages, network blips) or access-token TTL is short, many clients retry at the same intervals. This causes synchronized spikes (thundering herds) and makes recovery slower. Jitter spreads retries over time to smooth load.

## What
- Add bounded jitter (+/-20%) to the retry backoff delay used by `retryWithPolicy(...)`.
- Keeps the number of retries and the nominal backoff progression unchanged; only the per-attempt sleep duration is randomized within a small window.

## Code
- `Sources/Auth/Utils/Utils.swift`: `sleep(currentDelay:)` now computes a random delay in `[0.8x, 1.2x]` around the current delay.

## Impact
- Reduces synchronized load on token endpoints during transient incidents.
- Improves tail latencies and chances of success for clients spread over time.
- No functional change to error handling, retry limits, or outcomes.

## Independence from Coalescing
- This change is independent of refresh coalescing. It can land as soon as the base fix (#259) is merged.
- It does not require #261 (coalescing) to be present, though it complements it under high contention.

## Risks & Mitigations
- Introduces small non-determinism in sleep durations; unit tests do not rely on exact timings.
- Jitter window kept conservative (+/-20%) to balance smoothness and responsiveness.

## Base / Stack
- Base PR: #259 (stored-credential fallback on transient refresh failures)
- This PR no longer depends on #261 and can be reviewed/merged on top of #259.
