### PR TITLE
Fix API automation bumping version on every PR

### DIFF
--- a/.github/workflows/generate-tidal-api.yml
+++ b/.github/workflows/generate-tidal-api.yml
@@ -110,8 +110,10 @@ jobs:
         run: |
             echo "No changes found. Good bye"
 
-      - name: Bump version
-        if: ${{ steps.check_for_changes.outputs.CHANGES_DETECTED == 'true' && steps.check_pr.outputs.existing_pr != 'true' }}
+      - name: Bump version or update changelog
+        if: ${{ steps.check_for_changes.outputs.CHANGES_DETECTED == 'true' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           chmod +x ./bin/bump-version.sh
 
@@ -120,26 +122,29 @@ jobs:
           api_version=$(jq -r '.info.version' "$api_spec_file")
           changelog_entry="Generated API code using spec version $api_version"
 
-          ./bin/bump-version.sh patch "$changelog_entry"
+          # Get the latest published (non-draft) release version
+          latest_released=$(gh release list --exclude-drafts --limit 1 --json tagName --jq '.[0].tagName')
+          current_version=$(cat version.txt | tr -d '\n')
 
-      - name: Update changelog entry for existing PR
-        if: ${{ steps.check_for_changes.outputs.CHANGES_DETECTED == 'true' && steps.check_pr.outputs.existing_pr == 'true' }}
-        run: |
-          # Extract new API spec version
-          api_spec_file="$API_FOLDER/$INPUT_FOLDER_NAME/tidal-api-oas.json"
-          api_version=$(jq -r '.info.version' "$api_spec_file")
+          echo "Latest published release: $latest_released"
+          echo "Current version in version.txt: $current_version"
 
-          # Update only the first changelog entry (most recent version) to reference the latest API version
-          # Uses awk to only modify the first occurrence of the pattern
-          awk -v new_version="$api_version" '
-            !done && /Generated API code using spec version .* \(TidalAPI\)/ {
-              sub(/spec version [0-9.]+/, "spec version " new_version)
-              done = 1
-            }
-            { print }
-          ' CHANGELOG.md > CHANGELOG.md.tmp && mv CHANGELOG.md.tmp CHANGELOG.md
-
-          echo "Updated changelog entry to reference API spec version $api_version"
+          if [ "$current_version" == "$latest_released" ]; then
+            # Version matches the latest release, so we need to bump
+            echo "Version matches latest release — bumping patch version"
+            ./bin/bump-version.sh patch "$changelog_entry"
+          else
+            # Version is already ahead of the latest release, just update the changelog entry
+            echo "Version already bumped beyond latest release — updating changelog entry only"
+            awk -v new_version="$api_version" '
+              !done && /Generated API code using spec version .* \(TidalAPI\)/ {
+                sub(/spec version [0-9.]+/, "spec version " new_version)
+                done = 1
+              }
+              { print }
+            ' CHANGELOG.md > CHANGELOG.md.tmp && mv CHANGELOG.md.tmp CHANGELOG.md
+            echo "Updated changelog entry to reference API spec version $api_version"
+          fi
 
       - name: Prepare git and define a branch name
         id: prepare_git_and_define_branch_name


### PR DESCRIPTION
## Summary
- Compare `version.txt` against the latest **published** (non-draft) release instead of relying on whether an open PR exists
- Prevents redundant patch bumps when the previous API PR was merged but the release was never published (e.g., `0.11.7` → `0.11.8` → `0.11.9` when only `0.11.7` was released)

## Test plan
- [ ] Verify workflow runs correctly when version matches latest release (should bump)
- [ ] Verify workflow runs correctly when version is already ahead of latest release (should only update changelog entry)