### PR TITLE
Update changelog for 0.11.11 with missing entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.11.11] - 2026-04-10
 
 ### Changed
+- Migrate video playback info to videoManifests endpoint (Player)
+- Simplify StoreUserCollectionTracksTask to use resourceId instead of included object (Offliner)
 - Generated API code using spec version 1.4.17 (TidalAPI)
 
 ## [0.11.10] - 2026-04-07


### PR DESCRIPTION
## Summary
- Add missing changelog entries for PRs #358 and #359 that were merged before the 0.11.11 release but not included in the changelog:
  - Player: Migrate video playback info to videoManifests endpoint
  - Offliner: Simplify StoreUserCollectionTracksTask to use resourceId instead of included object