### PR TITLE
Offliner: Add dedicated downloadUserCollectionTracks/removeUserCollectionTracks methods

### DIFF
--- a/Sources/Offliner/Internal/OfflineStore.swift
+++ b/Sources/Offliner/Internal/OfflineStore.swift
@@ -171,7 +171,7 @@ final class OfflineStore {
 		deleteFiles(for: bookmarksToDelete)
 	}
 
-	func getCollection(collectionType: OfflineCollectionType, resourceId: String) async throws -> OfflineCollection? {
+	func getCollection(collectionType: OfflineCollectionTypeInternal, resourceId: String) async throws -> OfflineCollection? {
 		try await databaseQueue.write { [self] database in
 			let row = try Row.fetchOne(
 				database,
@@ -185,7 +185,7 @@ final class OfflineStore {
 
 			guard let row else { return nil }
 
-			let collectionType = OfflineCollectionType(rawValue: row["resource_type"])!
+			let collectionType = OfflineCollectionTypeInternal(rawValue: row["resource_type"])!
 
 			return OfflineCollection(
 				catalogMetadata: try OfflineCollection.Metadata.deserialize(collectionType: collectionType, json: row["catalog_metadata"]),
@@ -238,7 +238,7 @@ final class OfflineStore {
 		}
 	}
 
-	func getCollections(collectionType: OfflineCollectionType) async throws -> [OfflineCollection] {
+	func getCollections(collectionType: OfflineCollectionTypeInternal) async throws -> [OfflineCollection] {
 		try await databaseQueue.write { [self] database in
 			let rows = try Row.fetchAll(
 				database,
@@ -252,7 +252,7 @@ final class OfflineStore {
 			)
 
 			return try rows.map { row in
-				let collectionType = OfflineCollectionType(rawValue: row["resource_type"])!
+				let collectionType = OfflineCollectionTypeInternal(rawValue: row["resource_type"])!
 
 				return OfflineCollection(
 					catalogMetadata: try OfflineCollection.Metadata.deserialize(collectionType: collectionType, json: row["catalog_metadata"]),
@@ -262,7 +262,7 @@ final class OfflineStore {
 		}
 	}
 
-	func countCollectionItems(collectionType: OfflineCollectionType, resourceId: String) async throws -> Int {
+	func countCollectionItems(collectionType: OfflineCollectionTypeInternal, resourceId: String) async throws -> Int {
 		try await databaseQueue.read { database in
 			let count = try Int.fetchOne(
 				database,
@@ -279,7 +279,7 @@ final class OfflineStore {
 	}
 
 	func getCollectionItems(
-		collectionType: OfflineCollectionType,
+		collectionType: OfflineCollectionTypeInternal,
 		resourceId: String,
 		limit: Int,
 		after cursor: Int64? = nil
@@ -324,7 +324,7 @@ final class OfflineStore {
 	}
 
 	func getAudioFormatOfCollection(
-		collectionType: OfflineCollectionType,
+		collectionType: OfflineCollectionTypeInternal,
 		resourceId: String
 	) async throws -> AudioFormat? {
 		try await databaseQueue.read { database in
@@ -351,7 +351,7 @@ final class OfflineStore {
 	}
 
 	func getCollectionDuration(
-		collectionType: OfflineCollectionType,
+		collectionType: OfflineCollectionTypeInternal,
 		resourceId: String
 	) async throws -> Int {
 		try await databaseQueue.read { database in
@@ -427,7 +427,7 @@ struct StoreItemTaskResult {
 }
 
 struct StoreCollectionTaskResult {
-	let resourceType: OfflineCollectionType
+	let resourceType: OfflineCollectionTypeInternal
 	let resourceId: String
 	let catalogMetadata: OfflineCollection.Metadata
 	let artworkURL: URL?
@@ -481,7 +481,7 @@ extension OfflineCollection.Metadata {
 		}
 	}
 
-	static func deserialize(collectionType: OfflineCollectionType, json: String) throws -> OfflineCollection.Metadata {
+	static func deserialize(collectionType: OfflineCollectionTypeInternal, json: String) throws -> OfflineCollection.Metadata {
 		let decoder = JSONDecoder()
 		let data = json.data(using: .utf8)!
 

--- a/Sources/Offliner/Offliner.swift
+++ b/Sources/Offliner/Offliner.swift
@@ -119,18 +119,18 @@ public final class Offliner {
 		collectionType: OfflineCollectionType,
 		resourceId: String
 	) async throws -> OfflineCollection? {
-		try await offlineStore.getCollection(collectionType: collectionType, resourceId: resourceId)
+		try await offlineStore.getCollection(collectionType: collectionType.toInternal, resourceId: resourceId)
 	}
 
 	public func getOfflineCollections(collectionType: OfflineCollectionType) async throws -> [OfflineCollection] {
-		try await offlineStore.getCollections(collectionType: collectionType)
+		try await offlineStore.getCollections(collectionType: collectionType.toInternal)
 	}
 
 	public func countOfflineCollectionItems(
 		collectionType: OfflineCollectionType,
 		resourceId: String
 	) async throws -> Int {
-		try await offlineStore.countCollectionItems(collectionType: collectionType, resourceId: resourceId)
+		try await offlineStore.countCollectionItems(collectionType: collectionType.toInternal, resourceId: resourceId)
 	}
 
 	public func getOfflineCollectionItems(
@@ -140,7 +140,7 @@ public final class Offliner {
 		after cursor: Int64? = nil
 	) async throws -> OfflineCollectionItemsPage {
 		let (page, failures) = try await offlineStore.getCollectionItems(
-			collectionType: collectionType,
+			collectionType: collectionType.toInternal,
 			resourceId: resourceId,
 			limit: limit,
 			after: cursor
@@ -161,14 +161,14 @@ public final class Offliner {
 		collectionType: OfflineCollectionType,
 		resourceId: String
 	) async throws -> AudioFormat? {
-		try await offlineStore.getAudioFormatOfCollection(collectionType: collectionType, resourceId: resourceId)
+		try await offlineStore.getAudioFormatOfCollection(collectionType: collectionType.toInternal, resourceId: resourceId)
 	}
 
 	public func getCollectionDuration(
 		collectionType: OfflineCollectionType,
 		resourceId: String
 	) async throws -> Int {
-		try await offlineStore.getCollectionDuration(collectionType: collectionType, resourceId: resourceId)
+		try await offlineStore.getCollectionDuration(collectionType: collectionType.toInternal, resourceId: resourceId)
 	}
 
 	// MARK: - Download/Remove
@@ -190,6 +190,16 @@ public final class Offliner {
 
 	public func remove(collectionType: OfflineCollectionType, resourceId: String) async throws {
 		try await offlineApiClient.removeItem(type: collectionType.toResourceType, id: resourceId)
+		await taskRunner.run()
+	}
+
+	public func downloadUserCollectionTracks() async throws {
+		try await offlineApiClient.addItem(type: .userCollectionTracks, id: "me")
+		await taskRunner.run()
+	}
+
+	public func removeUserCollectionTracks() async throws {
+		try await offlineApiClient.removeItem(type: .userCollectionTracks, id: "me")
 		await taskRunner.run()
 	}
 
@@ -233,9 +243,21 @@ extension OfflineCollectionType {
 		switch self {
 		case .albums: return .album
 		case .playlists: return .playlist
-		case .userCollectionTracks: return .userCollectionTracks
 		}
 	}
+
+	var toInternal: OfflineCollectionTypeInternal {
+		switch self {
+		case .albums: return .albums
+		case .playlists: return .playlists
+		}
+	}
+}
+
+enum OfflineCollectionTypeInternal: String {
+	case albums
+	case playlists
+	case userCollectionTracks
 }
 
 // MARK: - OfflinePlaybackItem from OfflineMediaItem

--- a/Sources/Offliner/Types.swift
+++ b/Sources/Offliner/Types.swift
@@ -13,7 +13,6 @@ public enum OfflineMediaItemType: String {
 public enum OfflineCollectionType: String {
 	case albums
 	case playlists
-	case userCollectionTracks
 }
 
 // MARK: - OfflineMediaItem

--- a/Tests/OfflinerTests/TestFakes.swift
+++ b/Tests/OfflinerTests/TestFakes.swift
@@ -6,7 +6,14 @@ import TidalAPI
 // MARK: - Backend Client Fakes
 
 final class StubOfflineApiClient: OfflineApiClientProtocol {
+	struct RecordedItem {
+		let type: ResourceType
+		let id: String
+	}
+
 	private(set) var tasks: [OfflineTask] = []
+	private(set) var addedItems: [RecordedItem] = []
+	private(set) var removedItems: [RecordedItem] = []
 	var taskIdCounter = 0
 
 	func enqueueTasks(_ newTasks: [OfflineTask]) {
@@ -14,6 +21,7 @@ final class StubOfflineApiClient: OfflineApiClientProtocol {
 	}
 
 	func addItem(type: ResourceType, id: String) async throws {
+		addedItems.append(RecordedItem(type: type, id: id))
 		let taskId = "task-\(taskIdCounter)"
 		let position = taskIdCounter + 1
 		taskIdCounter += 1
@@ -72,6 +80,7 @@ final class StubOfflineApiClient: OfflineApiClientProtocol {
 	}
 
 	func removeItem(type: ResourceType, id: String) async throws {
+		removedItems.append(RecordedItem(type: type, id: id))
 		let taskId = "task-\(taskIdCounter)"
 		taskIdCounter += 1
 

--- a/Tests/OfflinerTests/UserCollectionTracksTests.swift
+++ b/Tests/OfflinerTests/UserCollectionTracksTests.swift
@@ -12,21 +12,13 @@ final class UserCollectionTracksTests: OfflinerTestCase {
 			mediaDownloader: SucceedingMediaDownloader()
 		)
 
-		try await offliner.download(collectionType: .userCollectionTracks, resourceId: "uct-123")
+		try await offliner.downloadUserCollectionTracks()
 		await offliner.run()
 		await backend.waitForTasksToComplete()
 
-		let storedCollection = try await offliner.getOfflineCollection(
-			collectionType: .userCollectionTracks,
-			resourceId: "uct-123"
-		)
-		XCTAssertNotNil(storedCollection)
-		XCTAssertEqual(storedCollection?.catalogMetadata.id, "uct-123")
-
-		if case .userCollectionTracks = storedCollection?.catalogMetadata {
-		} else {
-			XCTFail("Expected userCollectionTracks metadata")
-		}
+		XCTAssertEqual(backend.addedItems.count, 1)
+		XCTAssertEqual(backend.addedItems.first?.type, .userCollectionTracks)
+		XCTAssertEqual(backend.addedItems.first?.id, "me")
 	}
 
 	func testDownloadUserCollectionTracksDoesNotCreateDownloadObject() async throws {
@@ -36,40 +28,16 @@ final class UserCollectionTracksTests: OfflinerTestCase {
 			mediaDownloader: SucceedingMediaDownloader()
 		)
 
-		try await offliner.download(collectionType: .userCollectionTracks, resourceId: "uct-123")
+		try await offliner.downloadUserCollectionTracks()
 		await offliner.run()
 
 		let downloads = await offliner.currentDownloads
 		XCTAssertEqual(downloads.count, 0)
 	}
 
-	func testGetUserCollectionTracksListsAllStored() async throws {
-		let backend = StubOfflineApiClient()
-		let offliner = createOffliner(
-			offlineApiClient: backend,
-			artworkDownloader: SucceedingArtworkDownloader(),
-			mediaDownloader: SucceedingMediaDownloader()
-		)
-
-		try await offliner.download(collectionType: .userCollectionTracks, resourceId: "uct-1")
-		await offliner.run()
-		await backend.waitForTasksToComplete()
-
-		try await offliner.download(collectionType: .userCollectionTracks, resourceId: "uct-2")
-		await offliner.run()
-		await backend.waitForTasksToComplete()
-
-		let collections = try await offliner.getOfflineCollections(collectionType: .userCollectionTracks)
-		XCTAssertEqual(collections.count, 2)
-
-		let ids = collections.map(\.catalogMetadata.id)
-		XCTAssertTrue(ids.contains("uct-1"))
-		XCTAssertTrue(ids.contains("uct-2"))
-	}
-
 	// MARK: - Remove
 
-	func testRemoveUserCollectionTracksDeletesFromLocalDatabase() async throws {
+	func testRemoveUserCollectionTracks() async throws {
 		let backend = StubOfflineApiClient()
 		let offliner = createOffliner(
 			offlineApiClient: backend,
@@ -77,24 +45,10 @@ final class UserCollectionTracksTests: OfflinerTestCase {
 			mediaDownloader: SucceedingMediaDownloader()
 		)
 
-		try await offliner.download(collectionType: .userCollectionTracks, resourceId: "uct-123")
-		await offliner.run()
-		await backend.waitForTasksToComplete()
+		try await offliner.removeUserCollectionTracks()
 
-		let storedCollection = try await offliner.getOfflineCollection(
-			collectionType: .userCollectionTracks,
-			resourceId: "uct-123"
-		)
-		XCTAssertNotNil(storedCollection)
-
-		try await offliner.remove(collectionType: .userCollectionTracks, resourceId: "uct-123")
-		await offliner.run()
-		await backend.waitForTasksToComplete()
-
-		let removedCollection = try await offliner.getOfflineCollection(
-			collectionType: .userCollectionTracks,
-			resourceId: "uct-123"
-		)
-		XCTAssertNil(removedCollection)
+		XCTAssertEqual(backend.removedItems.count, 1)
+		XCTAssertEqual(backend.removedItems.first?.type, .userCollectionTracks)
+		XCTAssertEqual(backend.removedItems.first?.id, "me")
 	}
 }


### PR DESCRIPTION
## Summary

Add public `downloadUserCollectionTracks()` and `removeUserCollectionTracks()` methods that send `"me"` as the resourceId to the offline API client.

Remove `userCollectionTracks` from the public `OfflineCollectionType` enum and introduce an internal `OfflineCollectionTypeInternal` enum that retains the case for internal store operations.

## Changes

- **Types.swift**: Removed `userCollectionTracks` from public `OfflineCollectionType`
- **Offliner.swift**: Added `downloadUserCollectionTracks()` / `removeUserCollectionTracks()`, introduced `OfflineCollectionTypeInternal` with mapping from public enum
- **OfflineStore.swift**: Uses `OfflineCollectionTypeInternal` instead of `OfflineCollectionType`
- **Tests**: Updated to use new public API