### PR TITLE
Player: Use injected credentialsProvider instead of TidalAuth.shared

### DIFF
--- a/Sources/Player/Common/PlaybackInfo/PlaybackInfoFetcher.swift
+++ b/Sources/Player/Common/PlaybackInfo/PlaybackInfoFetcher.swift
@@ -79,7 +79,7 @@ private extension PlaybackInfoFetcher {
 
 			// Ensure credentials provider is set
 			if OpenAPIClientAPI.credentialsProvider == nil {
-				OpenAPIClientAPI.credentialsProvider = TidalAuth.shared
+				OpenAPIClientAPI.credentialsProvider = credentialsProvider
 			}
 
 			let manifestResponse = try await TrackManifestsAPITidal.trackManifestsIdGet(
@@ -193,7 +193,7 @@ private extension PlaybackInfoFetcher {
 		do {
 			// Ensure credentials provider is set
 			if OpenAPIClientAPI.credentialsProvider == nil {
-				OpenAPIClientAPI.credentialsProvider = TidalAuth.shared
+				OpenAPIClientAPI.credentialsProvider = credentialsProvider
 			}
 
 			let response = try await VideoManifestsAPITidal.videoManifestsIdGet(
@@ -388,7 +388,6 @@ private extension PlaybackInfoFetcher {
 
 		return .STEREO
 	}
-
 }
 
 extension PlaybackInfoFetcher {


### PR DESCRIPTION
## Summary
- Fix `PlaybackInfoFetcher` falling back to `TidalAuth.shared` when `OpenAPIClientAPI.credentialsProvider` is nil
- Use the already-injected `credentialsProvider` (from init) instead, which respects the mock passed via `Player.bootstrap(credentialsProvider:)`
- Fixes test crashes caused by `TidalAuth.shared` having unconfigured implicitly unwrapped optionals

## Test plan
- [x] Verify existing Player tests pass without `TidalAuth.shared` crash
- [x] Confirm playback info fetching still works in the test app with a real credentials provider