### PR TITLE
Player: Add fade-out support to pause for sleep timer

### DIFF
--- a/Sources/Player/Mocks/PlaybackEngine/PlayerMock.swift
+++ b/Sources/Player/Mocks/PlaybackEngine/PlayerMock.swift
@@ -93,7 +93,7 @@ public final class PlayerMock: GenericMediaPlayer {
 		playCallCount += 1
 	}
 
-	public func pause() {
+	public func pause(fadeDuration: TimeInterval? = nil) {
 		pauseCallCount += 1
 	}
 

--- a/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/AVQueuePlayerWrapper.swift
+++ b/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/AVQueuePlayerWrapper.swift
@@ -167,18 +167,8 @@ final class AVQueuePlayerWrapper: GenericMediaPlayer {
 				return
 			}
 
-			let currentTime = self.player.currentTime()
-			let timeRange = CMTimeRange(
-				start: currentTime,
-				duration: CMTime(seconds: fadeDuration, preferredTimescale: 600)
-			)
-
-			let inputParameters = AVMutableAudioMixInputParameters()
-			inputParameters.setVolumeRamp(
-				fromStartVolume: 1.0,
-				toEndVolume: 0,
-				timeRange: timeRange
-			)
+			let timeRange = self.getFadeTimeRange(fadeDuration: fadeDuration)
+			let inputParameters = self.getVolumeRampInputParameters(timeRange: timeRange)
 
 			let audioMix = AVMutableAudioMix()
 			audioMix.inputParameters = [inputParameters]
@@ -296,6 +286,27 @@ extension AVQueuePlayerWrapper: VideoPlayer {
 				view.player = self.player
 			}
 		}
+	}
+}
+
+// MARK: - Fade Helpers
+
+private extension AVQueuePlayerWrapper {
+	func getFadeTimeRange(fadeDuration: TimeInterval) -> CMTimeRange {
+		CMTimeRange(
+			start: player.currentTime(),
+			duration: CMTime(seconds: fadeDuration, preferredTimescale: 600)
+		)
+	}
+
+	func getVolumeRampInputParameters(timeRange: CMTimeRange) -> AVMutableAudioMixInputParameters {
+		let inputParameters = AVMutableAudioMixInputParameters()
+		inputParameters.setVolumeRamp(
+			fromStartVolume: 1.0,
+			toEndVolume: 0,
+			timeRange: timeRange
+		)
+		return inputParameters
 	}
 }
 

--- a/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/AVQueuePlayerWrapper.swift
+++ b/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/AVQueuePlayerWrapper.swift
@@ -160,9 +160,38 @@ final class AVQueuePlayerWrapper: GenericMediaPlayer {
 		}
 	}
 
-	func pause() {
+	func pause(fadeDuration: TimeInterval? = nil) {
 		queue.dispatch {
-			self.player.pause()
+			guard let fadeDuration, fadeDuration > 0, let playerItem = self.player.currentItem else {
+				self.player.pause()
+				return
+			}
+
+			let currentTime = self.player.currentTime()
+			let timeRange = CMTimeRange(
+				start: currentTime,
+				duration: CMTime(seconds: fadeDuration, preferredTimescale: 600)
+			)
+
+			let inputParameters = AVMutableAudioMixInputParameters()
+			inputParameters.setVolumeRamp(
+				fromStartVolume: 1.0,
+				toEndVolume: 0,
+				timeRange: timeRange
+			)
+
+			let audioMix = AVMutableAudioMix()
+			audioMix.inputParameters = [inputParameters]
+			playerItem.audioMix = audioMix
+
+			let currentVolume = self.player.volume
+			DispatchQueue.global().asyncAfter(deadline: .now() + fadeDuration) { [weak self] in
+				self?.queue.dispatch {
+					self?.player.pause()
+					self?.player.volume = currentVolume
+					playerItem.audioMix = nil
+				}
+			}
 		}
 	}
 

--- a/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/CrossfadingPlayerWrapper.swift
+++ b/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/CrossfadingPlayerWrapper.swift
@@ -102,10 +102,10 @@ final class CrossfadingPlayerWrapper: GenericMediaPlayer {
 		}
 	}
 
-	func pause() {
-		currentPlayer.pause()
+	func pause(fadeDuration: TimeInterval? = nil) {
+		currentPlayer.pause(fadeDuration: fadeDuration)
 		if isCrossfading {
-			nextPlayer.pause()
+			nextPlayer.pause(fadeDuration: fadeDuration)
 		}
 	}
 

--- a/Sources/Player/PlaybackEngine/Internal/MediaPlayers/GenericMediaPlayer.swift
+++ b/Sources/Player/PlaybackEngine/Internal/MediaPlayers/GenericMediaPlayer.swift
@@ -24,7 +24,7 @@ public protocol GenericMediaPlayer: AnyObject {
 	) async -> Asset
 
 	func play()
-	func pause()
+	func pause(fadeDuration: TimeInterval?)
 	func seek(to time: Double)
 
 	func updateVolume(loudnessNormalizer: LoudnessNormalizer?)
@@ -35,4 +35,8 @@ public protocol GenericMediaPlayer: AnyObject {
 	func unload()
 
 	func reset()
+}
+
+extension GenericMediaPlayer {
+	func pause() { pause(fadeDuration: nil) }
 }

--- a/Sources/Player/PlaybackEngine/Internal/PlayerItem.swift
+++ b/Sources/Player/PlaybackEngine/Internal/PlayerItem.swift
@@ -133,8 +133,8 @@ final class PlayerItem {
 		asset?.player.play()
 	}
 
-	func pause() {
-		asset?.player.pause()
+	func pause(fadeDuration: TimeInterval? = nil) {
+		asset?.player.pause(fadeDuration: fadeDuration)
 	}
 
 	func seek(to time: Double) {

--- a/Sources/Player/PlaybackEngine/PlayerEngine.swift
+++ b/Sources/Player/PlaybackEngine/PlayerEngine.swift
@@ -281,8 +281,8 @@ final class PlayerEngine {
 		}
 	}
 
-	func pause() {
-		currentItem?.pause()
+	func pause(fadeDuration: TimeInterval? = nil) {
+		currentItem?.pause(fadeDuration: fadeDuration)
 	}
 
 	func seek(_ time: Double) {

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -313,9 +313,9 @@ public extension Player {
 		}
 	}
 
-	func pause() {
+	func pause(fadeDuration: TimeInterval? = nil) {
 		queue.dispatch {
-			self.playerEngine.pause()
+			self.playerEngine.pause(fadeDuration: fadeDuration)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Extends `pause()` with an optional `fadeDuration: TimeInterval?` parameter across the full player stack: `GenericMediaPlayer` → `AVQueuePlayerWrapper` → `CrossfadingPlayerWrapper` → `PlayerItem` → `PlayerEngine` → `Player`
- When a fade duration is provided, applies an `AVMutableAudioMix` volume ramp from 1.0 to 0 over the specified duration, then pauses and restores volume — reuses the same `setVolumeRamp` mechanism as crossfade
- A protocol extension provides the default `pause()` → `pause(fadeDuration: nil)` for backward compatibility

## Context
This enables the sleep timer feature in the TIDAL iOS app to fade out audio smoothly before pausing, instead of an abrupt stop.

## Test plan
- [ ] Verify normal `pause()` behavior is unchanged (no fade)
- [ ] Verify `pause(fadeDuration: 8)` produces a smooth 8-second fade-out then pauses
- [ ] Verify volume is restored to its original level after pause so next play starts normally
- [ ] Verify crossfade between tracks still works correctly
- [ ] Verify fade works with both FLAC and AAC streams

🤖 Generated with [Claude Code](https://claude.com/claude-code)