### PR TITLE
Remove version bump from API auto-update workflow

### DIFF
--- a/.github/workflows/generate-tidal-api.yml
+++ b/.github/workflows/generate-tidal-api.yml
@@ -110,37 +110,6 @@ jobs:
         run: |
             echo "No changes found. Good bye"
 
-      - name: Bump version
-        if: ${{ steps.check_for_changes.outputs.CHANGES_DETECTED == 'true' && steps.check_pr.outputs.existing_pr != 'true' }}
-        run: |
-          chmod +x ./bin/bump-version.sh
-
-          # Extract API spec version for changelog entry
-          api_spec_file="$API_FOLDER/$INPUT_FOLDER_NAME/tidal-api-oas.json"
-          api_version=$(jq -r '.info.version' "$api_spec_file")
-          changelog_entry="Generated API code using spec version $api_version"
-
-          ./bin/bump-version.sh patch "$changelog_entry"
-
-      - name: Update changelog entry for existing PR
-        if: ${{ steps.check_for_changes.outputs.CHANGES_DETECTED == 'true' && steps.check_pr.outputs.existing_pr == 'true' }}
-        run: |
-          # Extract new API spec version
-          api_spec_file="$API_FOLDER/$INPUT_FOLDER_NAME/tidal-api-oas.json"
-          api_version=$(jq -r '.info.version' "$api_spec_file")
-
-          # Update only the first changelog entry (most recent version) to reference the latest API version
-          # Uses awk to only modify the first occurrence of the pattern
-          awk -v new_version="$api_version" '
-            !done && /Generated API code using spec version .* \(TidalAPI\)/ {
-              sub(/spec version [0-9.]+/, "spec version " new_version)
-              done = 1
-            }
-            { print }
-          ' CHANGELOG.md > CHANGELOG.md.tmp && mv CHANGELOG.md.tmp CHANGELOG.md
-
-          echo "Updated changelog entry to reference API spec version $api_version"
-
       - name: Prepare git and define a branch name
         id: prepare_git_and_define_branch_name
         if: ${{ steps.check_for_changes.outputs.CHANGES_DETECTED == 'true' }}


### PR DESCRIPTION
## Summary

Removes the version bump and changelog update steps from the automated TidalAPI code generation workflow.

These are now handled by the `/create-release-pr` Claude command (#374), which generates human-friendly changelog entries from all merged PRs (including API updates) when cutting a release.

### What changes
- `generate-tidal-api.yml`: Removed "Bump version" and "Update changelog entry for existing PR" steps
- API auto-update PRs will now only contain generated code changes — no version.txt or CHANGELOG.md modifications

### Why
- Decouples code generation from release decisions
- Changelog entries are now AI-generated and human-readable instead of templated
- One place for all release logic instead of two
