### PR TITLE
TM-1148: Add per-track backgroundColorHex to OfflineMediaItem.TrackMetadata

### DIFF
--- a/Sources/Offliner/Internal/Handlers/StoreTrackHandler.swift
+++ b/Sources/Offliner/Internal/Handlers/StoreTrackHandler.swift
@@ -92,12 +92,15 @@ private final class InternalTrackTask: InternalTask {
 			)
 			cleanup.mediaLocation = mediaResult.mediaLocation
 
+			let backgroundColorHex = task.artwork?.attributes?.visualMetadata?.selectedPaletteColor
+
 			let catalogMetadata = OfflineMediaItem.Metadata.track(OfflineMediaItem.TrackMetadata(
 				id: task.track.id,
 				title: task.track.attributes?.title ?? "",
 				artists: task.artists.compactMap(\.attributes?.name),
 				duration: mediaResult.duration,
-				explicit: task.track.attributes?.explicit ?? false
+				explicit: task.track.attributes?.explicit ?? false,
+				backgroundColorHex: backgroundColorHex
 			))
 
 			let storeResult = StoreItemTaskResult(

--- a/Sources/Offliner/Mocks/OfflineMediaItem+Mock.swift
+++ b/Sources/Offliner/Mocks/OfflineMediaItem+Mock.swift
@@ -28,14 +28,16 @@ public extension OfflineMediaItem.TrackMetadata {
 		title: String = "Mock Track",
 		artists: [String] = ["Mock Artist"],
 		duration: Int = 210,
-		explicit: Bool = false
+		explicit: Bool = false,
+		backgroundColorHex: String? = nil
 	) -> Self {
 		.init(
 			id: id,
 			title: title,
 			artists: artists,
 			duration: duration,
-			explicit: explicit
+			explicit: explicit,
+			backgroundColorHex: backgroundColorHex
 		)
 	}
 }

--- a/Sources/Offliner/Types.swift
+++ b/Sources/Offliner/Types.swift
@@ -16,6 +16,8 @@ public enum OfflineCollectionType: String {
 	case userCollectionTracks
 }
 
+// MARK: - ResourceId
+
 public enum ResourceId {
 	case identifier(String)
 	case me
@@ -37,6 +39,7 @@ public struct OfflineMediaItem {
 		public let artists: [String]
 		public let duration: Int
 		public let explicit: Bool
+		public let backgroundColorHex: String?
 	}
 
 	public struct VideoMetadata: Codable {


### PR DESCRIPTION
## Summary
Extracts `selectedPaletteColor` from the track's album cover artwork at download time and stores it as `backgroundColorHex` on `OfflineMediaItem.TrackMetadata`.

Online Now Playing reads the track-level album cover color via the API. Until now, offline storage only persisted the enclosing collection's color, so a playlist of mixed-album tracks would show the same color for every track. This change matches the online behavior per track.

## Test plan
- [ ] Existing offline content still decodes (new field is optional)
- [ ] Newly downloaded tracks store the album cover color
- [ ] Geneva client side: https://github.com/tidal-engineering/iOS PR (TM-1148)