### PR TITLE
Bump Swift tools to 5.9 and tvOS deployment target to 17

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.8
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import class Foundation.ProcessInfo
@@ -14,7 +14,7 @@ let package = Package(
 	platforms: [
 		.iOS(.v15),
 		.macOS(.v12),
-		.tvOS(.v15),
+		.tvOS(.v17),
 		.watchOS(.v7),
 	],
 	products: [

--- a/Sources/Offliner/Internal/LicenseDownloader.swift
+++ b/Sources/Offliner/Internal/LicenseDownloader.swift
@@ -103,11 +103,28 @@ extension ActiveLicenseDownload: AVContentKeySessionDelegate {
 		_ session: AVContentKeySession,
 		didProvide keyRequest: AVContentKeyRequest
 	) {
-		do {
-			try keyRequest.respondByRequestingPersistableContentKeyRequest()
-		} catch {
+		#if os(iOS)
+			do {
+				try keyRequest.respondByRequestingPersistableContentKeyRequestAndReturnError()
+			} catch {
+				keyRequest.processContentKeyResponseError(error)
+			}
+		#elseif os(macOS)
+			do {
+				try keyRequest.respondByRequestingPersistableContentKeyRequest()
+			} catch {
+				keyRequest.processContentKeyResponseError(error)
+			}
+		#else
+			let error = NSError(
+				domain: "com.tidal.offliner",
+				code: -1,
+				userInfo: [NSLocalizedDescriptionKey: "Offline DRM is not supported on this platform."]
+			)
 			keyRequest.processContentKeyResponseError(error)
-		}
+			continuation?.resume(throwing: error)
+			continuation = nil
+		#endif
 	}
 
 	func contentKeySession(

--- a/Sources/Offliner/Internal/MediaDownloader.swift
+++ b/Sources/Offliner/Internal/MediaDownloader.swift
@@ -24,6 +24,17 @@ protocol MediaDownloaderProtocol {
 	func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void)
 }
 
+// MARK: - MediaDownloaderError
+
+enum MediaDownloaderError: Error {
+	case failedToCreateTask
+	case noDownloadedFile
+	case manifestNotFound
+	case unsupportedPlatform
+}
+
+#if os(iOS)
+
 // MARK: - MediaDownloader
 
 final class MediaDownloader: NSObject, MediaDownloaderProtocol {
@@ -198,10 +209,31 @@ private final class ActiveDownload {
 	}
 }
 
-// MARK: - MediaDownloaderError
+#else
 
-enum MediaDownloaderError: Error {
-	case failedToCreateTask
-	case noDownloadedFile
-	case manifestNotFound
+// tvOS / other Apple platforms: AVAssetDownloadURLSession is iOS-only.
+// This stub keeps Offliner compilable on non-iOS platforms; calls always fail
+// with .unsupportedPlatform so callers can degrade gracefully.
+final class MediaDownloader: NSObject, MediaDownloaderProtocol {
+	static let backgroundSessionIdentifier = "com.tidal.offliner.download.session"
+
+	init(configuration: Configuration) {
+		super.init()
+	}
+
+	func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void) {
+		DispatchQueue.main.async { completionHandler() }
+	}
+
+	func download(
+		taskId: String,
+		manifestURL: URL,
+		licenseDownloadResult: LicenseDownloadResult?,
+		title: String,
+		onProgress: @escaping @Sendable (Double) async -> Void
+	) async throws -> MediaDownloadResult {
+		throw MediaDownloaderError.unsupportedPlatform
+	}
 }
+
+#endif

--- a/Sources/Player/Common/DRM/StoredLicenseLoader.swift
+++ b/Sources/Player/Common/DRM/StoredLicenseLoader.swift
@@ -28,8 +28,15 @@ extension StoredLicenseLoader: AVContentKeySessionDelegate {
 		do {
 			#if os(iOS)
 				try keyRequest.respondByRequestingPersistableContentKeyRequestAndReturnError()
-			#else
+			#elseif os(macOS)
 				try keyRequest.respondByRequestingPersistableContentKeyRequest()
+			#else
+				keyRequest.processContentKeyResponseError(NSError(
+					domain: "com.tidal.player",
+					code: -1,
+					userInfo: [NSLocalizedDescriptionKey: "Persistable content keys are not supported on this platform."]
+				))
+				return
 			#endif
 		} catch {
 			PlayerWorld.logger?.log(loggable: PlayerLoggable.licenseLoaderContentKeyRequestFailed(error: error))

--- a/Sources/Player/Common/World/DeviceInfoProvider.swift
+++ b/Sources/Player/Common/World/DeviceInfoProvider.swift
@@ -2,7 +2,9 @@ import Foundation
 #if canImport(UIKit)
 	import UIKit
 #endif
-import CoreTelephony
+#if canImport(CoreTelephony)
+	import CoreTelephony
+#endif
 
 // MARK: - DeviceInfoProvider
 
@@ -44,8 +46,12 @@ extension DeviceInfoProvider {
 				guard networkType == .MOBILE else {
 					return Constants.NA
 				}
-				let networkInfo = CTTelephonyNetworkInfo()
-				return networkInfo.serviceCurrentRadioAccessTechnology?.first?.value ?? Constants.NA
+				#if canImport(CoreTelephony)
+					let networkInfo = CTTelephonyNetworkInfo()
+					return networkInfo.serviceCurrentRadioAccessTechnology?.first?.value ?? Constants.NA
+				#else
+					return Constants.NA
+				#endif
 			},
 			deviceType: { audioInfoProvider in
 				#if os(iOS)

--- a/Sources/Player/OfflineEngine/Internal/LicenseDownloader.swift
+++ b/Sources/Player/OfflineEngine/Internal/LicenseDownloader.swift
@@ -70,8 +70,15 @@ extension LicenseDownloader: AVContentKeySessionDelegate {
 		do {
 			#if os(iOS)
 				try keyRequest.respondByRequestingPersistableContentKeyRequestAndReturnError()
-			#else
+			#elseif os(macOS)
 				try keyRequest.respondByRequestingPersistableContentKeyRequest()
+			#else
+				downloadTask.failed(with: NSError(
+					domain: "com.tidal.player",
+					code: -1,
+					userInfo: [NSLocalizedDescriptionKey: "Offline DRM is not supported on this platform."]
+				))
+				return
 			#endif
 		} catch {
 			PlayerWorld.logger?.log(loggable: PlayerLoggable.licenseDownloaderContentKeyRequestFailed(error: error))
@@ -86,8 +93,15 @@ extension LicenseDownloader: AVContentKeySessionDelegate {
 		do {
 			#if os(iOS)
 				try keyRequest.respondByRequestingPersistableContentKeyRequestAndReturnError()
-			#else
+			#elseif os(macOS)
 				try keyRequest.respondByRequestingPersistableContentKeyRequest()
+			#else
+				downloadTask.failed(with: NSError(
+					domain: "com.tidal.player",
+					code: -1,
+					userInfo: [NSLocalizedDescriptionKey: "Offline DRM is not supported on this platform."]
+				))
+				return
 			#endif
 		} catch {
 			PlayerWorld.logger?.log(loggable: PlayerLoggable.licenseDownloaderContentKeyRequestFailed(error: error))

--- a/Sources/Player/OfflineEngine/Internal/MediaDownloader.swift
+++ b/Sources/Player/OfflineEngine/Internal/MediaDownloader.swift
@@ -1,6 +1,8 @@
 import AVFoundation
 import Foundation
 
+#if os(iOS)
+
 // MARK: - MediaDownloader
 
 final class MediaDownloader: NSObject {
@@ -159,3 +161,22 @@ extension MediaDownloader: AVAssetDownloadDelegate {
 		activeTasks[assetDownloadTask]?.reportProgress(progress)
 	}
 }
+
+#else
+
+// tvOS / other Apple platforms: AVAssetDownloadURLSession is iOS-only, so offline
+// downloads are not supported. This stub keeps the surface area used by
+// Downloader.swift available so the Player target compiles. Callers should never
+// reach this path on non-iOS platforms (the host app should not initiate downloads).
+final class MediaDownloader: NSObject {
+	override init() {
+		super.init()
+	}
+
+	func download(asset: AVURLAsset, for downloadTask: DownloadTask) {}
+	func download(url: URL, for downloadTask: DownloadTask) {}
+	func cancel(for mediaProduct: MediaProduct) {}
+	func cancelAll() {}
+}
+
+#endif

--- a/Sources/Player/OfflineEngine/Internal/Storage/GRDBStorage/GRDBOfflineStorage.swift
+++ b/Sources/Player/OfflineEngine/Internal/Storage/GRDBStorage/GRDBOfflineStorage.swift
@@ -115,6 +115,21 @@ extension GRDBOfflineStorage: OfflineStorage {
 
 private extension GRDBOfflineStorage {
 	static func databaseURL() throws -> URL {
+		// tvOS: Application Support is restricted; only Caches is reliably writable.
+		// tvOS also doesn't honor `URLFileProtection` (Data Protection is iOS-only),
+		// so we skip the protectionKey attribute.
+		#if os(tvOS)
+		let baseURL = PlayerWorld.fileManagerClient.cachesDirectory()
+		let directoryURL = baseURL.appendingPathComponent("PlayerOfflineDatabase", isDirectory: true)
+		if !PlayerWorld.fileManagerClient.fileExists(atPath: directoryURL.path, isDirectory: nil) {
+			try PlayerWorld.fileManagerClient.createDirectory(
+				at: directoryURL,
+				withIntermediateDirectories: true,
+				attributes: nil
+			)
+		}
+		return directoryURL.appendingPathComponent("db.sqlite")
+		#else
 		let appSupportURL = PlayerWorld.fileManagerClient.applicationSupportDirectory()
 		let directoryURL = appSupportURL.appendingPathComponent("PlayerOfflineDatabase", isDirectory: true)
 		if PlayerWorld.fileManagerClient.fileExists(atPath: directoryURL.path, isDirectory: nil) {
@@ -137,6 +152,7 @@ private extension GRDBOfflineStorage {
 			)
 		}
 		return directoryURL.appendingPathComponent("db.sqlite")
+		#endif
 	}
 
 	func calculateTotalSize(_ db: Database) throws -> Int {

--- a/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/AVPlayerItemErrorLogEvent.swift
+++ b/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/AVPlayerItemErrorLogEvent.swift
@@ -3,7 +3,7 @@ import Foundation
 
 public extension AVPlayerItemErrorLogEvent {
 	override var description: String {
-		let httpResponseHeaderFields: String = if #available(iOS 17.5, macOS 14.5, *) {
+		let httpResponseHeaderFields: String = if #available(iOS 17.5, macOS 14.5, tvOS 17.5, *) {
 			self.allHTTPResponseHeaderFields?.description ?? "N/A"
 		} else {
 			"N/A"


### PR DESCRIPTION
Package.swift already declares tvOS as a supported platform, but the source
contains iOS-only API calls (AVAssetDownloadURLSession, persistable-key DRM,
CTTelephonyNetworkInfo, AVPlayerItemErrorLogEvent availability, ...) that
fail to compile on tvOS. Adds the minimal set of conditional-compile guards
needed to make tvOS a buildable target, plus one runtime fallback in
GRDBOfflineStorage for tvOS's restricted filesystem. No behavioural changes
for iOS or macOS.