### PR TITLE
TM-1155: Cancel removed collection downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Cancel pending and running child media downloads when removing an offline collection (Offliner)
+
 ## [0.11.17] - 2026-05-04
 
 ### Added

--- a/Sources/Offliner/Internal/Handlers/RemoveCollectionHandler.swift
+++ b/Sources/Offliner/Internal/Handlers/RemoveCollectionHandler.swift
@@ -14,6 +14,7 @@ final class RemoveCollectionHandler {
 
 private final class InternalRemoveCollectionTask: InternalTask {
 	let id: String
+	let removedCollectionScope: CollectionTaskScope?
 
 	private let task: RemoveCollectionTask
 	private let offlineStore: OfflineStore
@@ -21,6 +22,10 @@ private final class InternalRemoveCollectionTask: InternalTask {
 	init(task: RemoveCollectionTask, offlineStore: OfflineStore) {
 		self.id = task.id
 		self.task = task
+		removedCollectionScope = CollectionTaskScope(
+			resourceType: task.resourceType,
+			resourceId: task.resolvedResourceId
+		)
 		self.offlineStore = offlineStore
 	}
 

--- a/Sources/Offliner/Internal/Handlers/StoreTrackHandler.swift
+++ b/Sources/Offliner/Internal/Handlers/StoreTrackHandler.swift
@@ -42,6 +42,7 @@ final class StoreTrackHandler {
 private final class InternalTrackTask: InternalTask {
 	let id: String
 	let download: Download?
+	let collectionScope: CollectionTaskScope?
 
 	private let task: StoreTrackTask
 	private let offlineStore: OfflineStore
@@ -62,6 +63,10 @@ private final class InternalTrackTask: InternalTask {
 		self.id = task.id
 		self.task = task
 		self.download = download
+		collectionScope = CollectionTaskScope(
+			resourceType: task.collectionResourceType,
+			resourceId: task.resolvedCollectionResourceId
+		)
 		self.offlineStore = offlineStore
 		self.artworkDownloader = artworkDownloader
 		self.mediaDownloader = mediaDownloader
@@ -119,6 +124,10 @@ private final class InternalTrackTask: InternalTask {
 
 			try offlineStore.storeMediaItem(storeResult)
 		}
+	}
+
+	func cancel() async {
+		await mediaDownloader.cancel(taskId: task.id)
 	}
 }
 

--- a/Sources/Offliner/Internal/Handlers/StoreVideoHandler.swift
+++ b/Sources/Offliner/Internal/Handlers/StoreVideoHandler.swift
@@ -42,6 +42,7 @@ final class StoreVideoHandler {
 private final class InternalVideoTask: InternalTask {
 	let id: String
 	let download: Download?
+	let collectionScope: CollectionTaskScope?
 
 	private let task: StoreVideoTask
 	private let offlineStore: OfflineStore
@@ -62,6 +63,10 @@ private final class InternalVideoTask: InternalTask {
 		self.id = task.id
 		self.task = task
 		self.download = download
+		collectionScope = CollectionTaskScope(
+			resourceType: task.collectionResourceType,
+			resourceId: task.resolvedCollectionResourceId
+		)
 		self.offlineStore = offlineStore
 		self.artworkDownloader = artworkDownloader
 		self.mediaDownloader = mediaDownloader
@@ -116,6 +121,10 @@ private final class InternalVideoTask: InternalTask {
 
 			try offlineStore.storeMediaItem(storeResult)
 		}
+	}
+
+	func cancel() async {
+		await mediaDownloader.cancel(taskId: task.id)
 	}
 }
 

--- a/Sources/Offliner/Internal/MediaDownloader.swift
+++ b/Sources/Offliner/Internal/MediaDownloader.swift
@@ -21,6 +21,8 @@ protocol MediaDownloaderProtocol {
 		onProgress: @escaping @Sendable (Double) async -> Void
 	) async throws -> MediaDownloadResult
 
+	func cancel(taskId: String) async
+
 	func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void)
 }
 
@@ -58,6 +60,16 @@ final class MediaDownloader: NSObject, MediaDownloaderProtocol {
 		}
 	}
 
+	func cancel(taskId: String) async {
+		await withCheckedContinuation { continuation in
+			queue.async {
+				let task = self.activeDownloads.values.first { $0.task.taskDescription == taskId }?.task
+				task?.cancel()
+				continuation.resume()
+			}
+		}
+	}
+
 	func download(
 		taskId: String,
 		manifestURL: URL,
@@ -85,6 +97,7 @@ final class MediaDownloader: NSObject, MediaDownloaderProtocol {
 				}
 
 				let activeDownload = ActiveDownload(
+					task: task,
 					duration: duration,
 					continuation: continuation,
 					onProgress: onProgress
@@ -181,6 +194,7 @@ extension MediaDownloader: AVAssetDownloadDelegate {
 // MARK: - ActiveDownload
 
 private final class ActiveDownload {
+	let task: AVAssetDownloadTask
 	let duration: Int
 	let continuation: CheckedContinuation<MediaDownloadResult, Error>
 	let onProgress: @Sendable (Double) async -> Void
@@ -188,10 +202,12 @@ private final class ActiveDownload {
 	var downloadedLocation: URL?
 
 	init(
+		task: AVAssetDownloadTask,
 		duration: Int,
 		continuation: CheckedContinuation<MediaDownloadResult, Error>,
 		onProgress: @escaping @Sendable (Double) async -> Void
 	) {
+		self.task = task
 		self.duration = duration
 		self.continuation = continuation
 		self.onProgress = onProgress

--- a/Sources/Offliner/Internal/TaskRunner.swift
+++ b/Sources/Offliner/Internal/TaskRunner.swift
@@ -99,8 +99,16 @@ actor TaskRunner {
 		}
 	}
 
+	func cancelDownloads(collectionType: OfflineCollectionType, resourceId: ResourceId) async {
+		await cancelDownloads(matching: CollectionTaskScope(
+			resourceType: collectionType.rawValue,
+			resourceId: resourceId.stringValue
+		))
+	}
+
 	private func refresh() async throws {
 		let (tasks, cursor) = try await offlineApiClient.getTasks(cursor: self.cursor)
+		var collectionsToCancel: [CollectionTaskScope] = []
 
 		for task in tasks where taskIds.insert(task.id).inserted {
 			let pendingTask = handle(task)
@@ -109,10 +117,17 @@ actor TaskRunner {
 				currentDownloads.append(download)
 				downloadsContinuation?.yield(download)
 			}
+			if let collectionScope = pendingTask.removedCollectionScope {
+				collectionsToCancel.append(collectionScope)
+			}
 		}
 
 		if let cursor {
 			self.cursor = cursor
+		}
+
+		for collectionScope in collectionsToCancel {
+			await cancelDownloads(matching: collectionScope)
 		}
 	}
 
@@ -139,12 +154,12 @@ actor TaskRunner {
 			}
 
 			for await _ in group {
-				if let task = pendingTasks.first {
-					group.addTask { await self.start(task) }
-				}
-
 				if pendingTasks.count < Self.maxQueueSize {
 					try? await refresh()
+				}
+
+				if let task = pendingTasks.first {
+					group.addTask { await self.start(task) }
 				}
 			}
 		}
@@ -170,6 +185,27 @@ actor TaskRunner {
 		}
 
 		runningTasks.removeAll { $0 === task }
+		taskIds.remove(task.id)
+		if let download = task.download {
+			currentDownloads.removeAll { $0 === download }
+		}
+	}
+
+	private func cancelDownloads(matching collectionScope: CollectionTaskScope) async {
+		let pendingTasksToCancel = pendingTasks.filter { $0.collectionScope == collectionScope }
+		pendingTasks.removeAll { $0.collectionScope == collectionScope }
+
+		let runningTasksToCancel = runningTasks.filter { $0.collectionScope == collectionScope }
+
+		for task in pendingTasksToCancel + runningTasksToCancel {
+			await cancel(task)
+		}
+	}
+
+	private func cancel(_ task: InternalTask) async {
+		await task.cancel()
+		await task.download?.updateState(.failed)
+		try? await offlineApiClient.updateTask(taskId: task.id, state: .failed)
 		taskIds.remove(task.id)
 		if let download = task.download {
 			currentDownloads.removeAll { $0 === download }
@@ -203,9 +239,20 @@ private actor Network {
 protocol InternalTask: AnyObject {
 	var id: String { get }
 	var download: Download? { get }
+	var collectionScope: CollectionTaskScope? { get }
+	var removedCollectionScope: CollectionTaskScope? { get }
 	func run() async throws
+	func cancel() async
 }
 
 extension InternalTask {
 	var download: Download? { nil }
+	var collectionScope: CollectionTaskScope? { nil }
+	var removedCollectionScope: CollectionTaskScope? { nil }
+	func cancel() async {}
+}
+
+struct CollectionTaskScope: Equatable {
+	let resourceType: String
+	let resourceId: String
 }

--- a/Sources/Offliner/Offliner.swift
+++ b/Sources/Offliner/Offliner.swift
@@ -190,6 +190,7 @@ public final class Offliner {
 
 	public func remove(collectionType: OfflineCollectionType, resourceId: ResourceId) async throws {
 		try await offlineApiClient.removeItem(type: collectionType.toResourceType, id: resourceId.stringValue)
+		await taskRunner.cancelDownloads(collectionType: collectionType, resourceId: resourceId)
 		await taskRunner.run()
 	}
 

--- a/Tests/OfflinerTests/RemoveTests.swift
+++ b/Tests/OfflinerTests/RemoveTests.swift
@@ -130,6 +130,70 @@ final class RemoveTests: OfflinerTestCase {
 		XCTAssertFalse(FileManager.default.fileExists(atPath: artworkURL.path))
 	}
 
+	func testRemovePlaylistCancelsPendingChildDownloads() async throws {
+		let backend = StubOfflineApiClient()
+		backend.enqueueTasks([
+			.storeTrack(StoreTrackTask(
+				id: "track-task",
+				track: TracksResourceObject(id: "track-123", type: "tracks"),
+				artists: [],
+				artwork: nil,
+				collectionResourceType: "playlists",
+				collectionResourceId: "playlist-123",
+				volume: 1,
+				position: 1
+			)),
+		])
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+
+		try await offliner.remove(collectionType: .playlists, resourceId: .identifier("playlist-123"))
+		await backend.waitForTasksToComplete()
+
+		let downloads = await offliner.currentDownloads
+		let storedItem = try await offliner.getOfflineMediaItem(mediaType: .tracks, resourceId: .identifier("track-123"))
+		XCTAssertEqual(downloads.count, 0)
+		XCTAssertNil(storedItem)
+	}
+
+	func testRemovePlaylistCancelsRunningChildDownloads() async throws {
+		let backend = StubOfflineApiClient()
+		backend.enqueueTasks([
+			.storeTrack(StoreTrackTask(
+				id: "track-task",
+				track: TracksResourceObject(id: "track-123", type: "tracks"),
+				artists: [],
+				artwork: nil,
+				collectionResourceType: "playlists",
+				collectionResourceId: "playlist-123",
+				volume: 1,
+				position: 1
+			)),
+		])
+		let mediaDownloader = CancellableMediaDownloader()
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: mediaDownloader
+		)
+
+		await offliner.run()
+		await mediaDownloader.waitUntilDownloadStarts()
+
+		try await offliner.remove(collectionType: .playlists, resourceId: .identifier("playlist-123"))
+		await backend.waitForTasksToComplete()
+
+		let downloads = await offliner.currentDownloads
+		let storedItem = try await offliner.getOfflineMediaItem(mediaType: .tracks, resourceId: .identifier("track-123"))
+		let cancelledTaskIds = await mediaDownloader.cancelledTaskIds()
+		XCTAssertEqual(downloads.count, 0)
+		XCTAssertNil(storedItem)
+		XCTAssertEqual(cancelledTaskIds, ["track-task"])
+	}
+
 	func testRemoveNonExistentItemDoesNotThrow() async throws {
 		let backend = StubOfflineApiClient()
 		let offliner = createOffliner(

--- a/Tests/OfflinerTests/TestFakes.swift
+++ b/Tests/OfflinerTests/TestFakes.swift
@@ -239,6 +239,8 @@ final class SucceedingMediaDownloader: MediaDownloaderProtocol {
 
 	func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void) {}
 
+	func cancel(taskId: String) async {}
+
 	func download(
 		taskId: String,
 		manifestURL: URL,
@@ -264,6 +266,8 @@ final class SucceedingMediaDownloader: MediaDownloaderProtocol {
 final class FailingMediaDownloader: MediaDownloaderProtocol {
 	func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void) {}
 
+	func cancel(taskId: String) async {}
+
 	func download(
 		taskId: String,
 		manifestURL: URL,
@@ -272,6 +276,68 @@ final class FailingMediaDownloader: MediaDownloaderProtocol {
 		onProgress: @escaping @Sendable (Double) async -> Void
 	) async throws -> MediaDownloadResult {
 		throw FakeError.downloadFailed
+	}
+}
+
+final class CancellableMediaDownloader: MediaDownloaderProtocol {
+	private let state = CancellableMediaDownloaderState()
+
+	func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void) {}
+
+	func cancel(taskId: String) async {
+		await state.cancel(taskId: taskId)
+	}
+
+	func waitUntilDownloadStarts() async {
+		await state.waitUntilDownloadStarts()
+	}
+
+	func cancelledTaskIds() async -> [String] {
+		await state.cancelledTaskIds
+	}
+
+	func download(
+		taskId: String,
+		manifestURL: URL,
+		licenseDownloadResult: LicenseDownloadResult?,
+		title: String,
+		onProgress: @escaping @Sendable (Double) async -> Void
+	) async throws -> MediaDownloadResult {
+		await onProgress(0.1)
+		return try await state.download(taskId: taskId)
+	}
+}
+
+private actor CancellableMediaDownloaderState {
+	private(set) var cancelledTaskIds: [String] = []
+	private var downloadContinuation: CheckedContinuation<MediaDownloadResult, Error>?
+	private var startedContinuation: CheckedContinuation<Void, Never>?
+	private var hasStarted = false
+
+	func waitUntilDownloadStarts() async {
+		if hasStarted {
+			return
+		}
+
+		await withCheckedContinuation { continuation in
+			startedContinuation = continuation
+		}
+	}
+
+	func download(taskId: String) async throws -> MediaDownloadResult {
+		hasStarted = true
+		startedContinuation?.resume()
+		startedContinuation = nil
+
+		return try await withCheckedThrowingContinuation { continuation in
+			downloadContinuation = continuation
+		}
+	}
+
+	func cancel(taskId: String) {
+		cancelledTaskIds.append(taskId)
+		downloadContinuation?.resume(throwing: CancellationError())
+		downloadContinuation = nil
 	}
 }
 


### PR DESCRIPTION
## Summary
- The SDK could remove offline collections, but removal did not cancel child track/video downloads that were already queued or running.
- Add collection scoping to store/remove tasks so playlist/album removal prunes matching pending work and cancels active AVAsset downloads.
- Cover pending and running playlist child downloads in RemoveTests.

## Tests
- swift test --filter RemoveTests
- make lint-file FILE="Sources/Offliner/Internal/Handlers/RemoveCollectionHandler.swift Sources/Offliner/Internal/Handlers/StoreTrackHandler.swift Sources/Offliner/Internal/Handlers/StoreVideoHandler.swift Sources/Offliner/Internal/MediaDownloader.swift Sources/Offliner/Internal/TaskRunner.swift Sources/Offliner/Offliner.swift Tests/OfflinerTests/RemoveTests.swift Tests/OfflinerTests/TestFakes.swift"

Linear: TM-1155