### PR TITLE
Remove HTTP error body print

### DIFF
--- a/Sources/TidalAPI/Utils/TidalAPIRetryHandler.swift
+++ b/Sources/TidalAPI/Utils/TidalAPIRetryHandler.swift
@@ -34,7 +34,6 @@ final class TidalAPIRetryHandler<T> {
 		do {
 			return try await executionBlock()
 		} catch let httpError as HTTPErrorResponse {
-			print("HttpError data is: \(String(data: httpError.data!, encoding: .utf8))")
 			try Task.checkCancellation()
 
             let strategy: RetryStrategy = switch httpError.statusCode {


### PR DESCRIPTION
## Summary
- Remove the raw HTTP error response body `print` from `TidalAPIRetryHandler` spamming console logs
- Stop logging expected 403 Square connection responses and avoid dumping other API error payloads from the shared retry layer.

## Testing
- Not run, per repository policy unless explicitly requested.