### PR TITLE
Auth: Fix race in LoginRepository.deviceLoginPollHelper (top watchOS crash)

### DIFF
--- a/Sources/Auth/Login/DeviceLoginPollHelper.swift
+++ b/Sources/Auth/Login/DeviceLoginPollHelper.swift
@@ -1,7 +1,7 @@
 import Common
 import Foundation
 
-struct DeviceLoginPollHelper {
+final class DeviceLoginPollHelper {
 	let loginService: LoginService
 	private var pollRetryPolicy: RetryPolicy?
 
@@ -9,7 +9,7 @@ struct DeviceLoginPollHelper {
 		self.loginService = loginService
 	}
 
-	mutating func prepareForPoll(interval: Int, maxDuration: Int) {
+	func prepareForPoll(interval: Int, maxDuration: Int) {
 		pollRetryPolicy = DeviceLoginRetryPolicy(maxDuration: maxDuration, interval: interval)
 	}
 

--- a/Sources/Auth/Login/LoginRepository.swift
+++ b/Sources/Auth/Login/LoginRepository.swift
@@ -11,6 +11,7 @@ final class LoginRepository {
 	private let tokensStore: TokensStore
 	private let exponentialBackoffPolicy: RetryPolicy
 	private let logger: TidalLogger?
+	private let deviceLoginPollHelper: DeviceLoginPollHelper
 
 	private var codeVerifier: String?
 
@@ -30,9 +31,8 @@ final class LoginRepository {
 		self.loginService = loginService
 		self.exponentialBackoffPolicy = exponentialBackoffPolicy
 		self.logger = logger
+		deviceLoginPollHelper = DeviceLoginPollHelper(loginService: loginService)
 	}
-
-	private lazy var deviceLoginPollHelper: DeviceLoginPollHelper = DeviceLoginPollHelper(loginService: loginService)
 
 	var isLoggedIn: Bool {
 		let tokens = try? tokensStore.getLatestTokens()


### PR DESCRIPTION
## Summary

Fixes the top Apple Watch crash family in TIDAL iOS — a thread-safety bug in `LoginRepository.deviceLoginPollHelper`.

## Root cause

`DeviceLoginPollHelper` was a `struct` with a `mutating func prepareForPoll(...)`, held by `LoginRepository` as a `private lazy var`. Two independent bugs combine:

1. **Mutating-method write-back.** Calling a `mutating` method on a class-owned struct property compiles to a read-modify-write through the property *setter*. Crash signature: `setter + N`.
2. **`lazy var` is not thread-safe.** Concurrent first-accesses can corrupt the backing storage. The setter write-back then hits the corrupted store.

watchOS scheduling makes both bugs far more reachable than iPhone — the Watch device-login flow runs in async contexts (`SessionControl` → `LoginContainerView` → `getAuthorizationCode` → `initializeDeviceLogin`) that can be entered concurrently on cold launch, especially when network is flaky.

## Impact

Filtering Xcode Organizer → Crashes to watchOS App, last year, all versions of TIDAL iOS:

| Crash signature | Devices |
|---|---:|
| `LoginRepository.deviceLoginPollHelper.setter + 8` | 1,128 |
| `LoginRepository.deviceLoginPollHelper.setter + 64` | 397 |
| `outlined destroy of DeviceLoginPollHelper + 36` | 94 |
| **Total** | **~1,619** |

Same family of crashes — the `setter +N` rows are the mutating-method write-back at different inlining offsets; `outlined destroy +36` is the same root cause showing at value-release time. May also explain some `sleep(currentDelay:)` (463 devices) and `???: 0x0` (958 devices) entries in the same neighbourhood.

**iPhone unaffected** — iPhone login uses `getTokenFromLoginCode`, never instantiates `DeviceLoginPollHelper`. **Apple TV uses the same device-login flow and likely benefits.**

## Fix

Two changes, 4-line net diff:

- `DeviceLoginPollHelper`: `struct` → `final class`, drop `mutating` on `prepareForPoll`. Mutation now flows through a reference — no setter write-back.
- `LoginRepository.deviceLoginPollHelper`: `lazy var` → `let` initialized in `init`. Eliminates the lazy-init race entirely.

`DeviceLoginPollHelper` is only used inside `LoginRepository` via direct method dispatch (`initializeDeviceLogin()` and `pollForDeviceLoginResponse(deviceCode:)`), never by-value copy. So the value-type → reference-type change has no behavioural impact.

## Risk

Low. No public API surface change. No test changes needed for production behaviour; no tests existed for `DeviceLoginPollHelper`. Local testing on Apple Watch Ultra confirmed login still works through the device-code flow.

## Out of scope

`DeviceLoginPollHelper.poll()` still contains a `fatalError("prepareForPoll must be called before the poll function")` at line 23. It can't fire in normal flow (every `poll` call is preceded by `prepareForPoll` in `LoginRepository`), but it's a footgun for any future caller and a candidate for follow-up replacement with a thrown error.

## Ticket

[TM-1278](https://linear.app/squareup/issue/TM-1278/tidal-sdk-ios-fix-race-in-loginrepositorydeviceloginpollhelper-top)
