### PR TITLE
Fix release scripts resolving wrong ROOT_DIR (auto-release skipped)

### DIFF
--- a/.agents/skills/prepare-release/scripts/bump-version.sh
+++ b/.agents/skills/prepare-release/scripts/bump-version.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && cd .. && pwd)
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && cd ../../../.. && pwd)
 readonly ROOT_DIR
 
 VERSION_FILE="$ROOT_DIR/version.txt"

--- a/.agents/skills/prepare-release/scripts/check-version-bump.sh
+++ b/.agents/skills/prepare-release/scripts/check-version-bump.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && cd .. && pwd)
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && cd ../../../.. && pwd)
 readonly ROOT_DIR
 
 VERSION_FILE="$ROOT_DIR/version.txt"


### PR DESCRIPTION
## Problem

The auto-release pipeline (`trigger-releases.yml`) silently skipped the 0.11.24 release. The run completed in ~8s with the lint/test/release jobs all skipped, because **no version bump was detected** — even though `version.txt` was bumped to `0.11.24`.

Root cause: PR #384 moved the release scripts into `.agents/skills/prepare-release/scripts/`, but `check-version-bump.sh` and `bump-version.sh` still computed `ROOT_DIR` with a single `cd ..`:

```bash
ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && cd .. && pwd)
```

From `.agents/skills/prepare-release/scripts/`, `cd ..` lands in `.agents/skills/prepare-release/`, so the scripts looked for `version.txt` there (which doesn't exist) instead of the repo root. CI log:

```
Checking '/home/runner/work/tidal-sdk-ios/tidal-sdk-ios/.agents/skills/prepare-release/version.txt'
```

## Fix

Align both scripts with their siblings (`check-release-needed.sh`, `extract-release-notes.sh`, `suggest-changelog.sh`), which already use `cd ../../../..` to reach the repo root.

Verified locally: `check-version-bump.sh` now reads the repo-root `version.txt` and prints `Version bump detected` (exit 0).

## Note

The 0.11.24 release itself was cut manually (tag + draft GitHub release) since the merge already landed and the trigger won't re-fire. This PR ensures future releases auto-trigger correctly.
