### PR TITLE
Build: exclude unhandled package files to silence SwiftPM warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Declare unhandled package files (`TidalAPI` generated docs/config, module READMEs, EventProducer seed `.sqlite`) as `exclude:` so `swift build` no longer warns (Build)
+
 ## [0.11.24] - 2026-06-23
 
 ### Changed

--- a/Package.swift
+++ b/Package.swift
@@ -53,7 +53,10 @@ let package = Package(
 	] + (shouldIncludeDocCPlugin ? [.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0")] : []),
 	targets: [
 		.target(
-			name: "Template"
+			name: "Template",
+			exclude: [
+				"README.md",
+			]
 		),
 		.testTarget(
 			name: "TemplateTests",
@@ -67,6 +70,11 @@ let package = Package(
 				.AnyCodable,
 				.auth,
 				.common,
+			],
+			exclude: [
+				"Generated/docs",
+				"Config",
+				"README.md",
 			]
 		),
 		.target(
@@ -74,6 +82,9 @@ let package = Package(
 			dependencies: [
 				.Logging,
 				.AnyCodable,
+			],
+			exclude: [
+				"README.md",
 			]
 		),
 		.testTarget(
@@ -89,6 +100,11 @@ let package = Package(
 				.GRDB,
 				.SWXMLHash,
 				.auth,
+			],
+			exclude: [
+				"README.md",
+				"Monitoring/Persistence/MonitoringDatabase.sqlite",
+				"Events/Persistence/EventQueueDatabase.sqlite",
 			]
 		),
 		.testTarget(
@@ -105,6 +121,9 @@ let package = Package(
 				.common,
 				.KeychainAccess,
 				.Logging,
+			],
+			exclude: [
+				"README.md",
 			]
 		),
 		.testTarget(
@@ -145,6 +164,9 @@ let package = Package(
 				.tidalAPI,
 				.auth,
 				.player,
+			],
+			exclude: [
+				"README.md",
 			],
 			resources: [
 				.process("Internal/Resources"),


### PR DESCRIPTION
## What

`swift build` emits ~800 `found N file(s) which are unhandled; explicitly declare them as resources or exclude from the target` warnings. This declares those non-source files via `exclude:` on the affected targets:

- `TidalAPI`: `Generated/docs`, `Config`, `README.md`
- `EventProducer`: `README.md`, the two seed `*.sqlite` files under `Monitoring/Persistence` and `Events/Persistence`
- `Auth`, `Common`, `Offliner`, `Template`: `README.md`

## Why

These files are shipped inside source targets but aren't compiled or bundled — the SQLite databases are created at runtime by GRDB (the source only references them by filename), and the docs/README/config are not build inputs. Declaring them as `exclude:` removes the warning noise with no build or runtime change.

Verified: `swift build` goes from ~800 unhandled-file warnings to **0**, build still succeeds.