### PR TITLE
fix(offliner): TDAPEX-2064 prevent license continuation double resume

### DIFF
--- a/Sources/Offliner/Internal/LicenseDownloader.swift
+++ b/Sources/Offliner/Internal/LicenseDownloader.swift
@@ -19,29 +19,30 @@ actor LicenseDownloader {
 	private var certificateTask: Task<Data, Error>?
 
 	init() {
-		self.httpClient = HttpClient()
+		httpClient = HttpClient()
 	}
 
 	func downloadLicense(drmData: DrmData?) async throws -> LicenseDownloadResult? {
 		guard let keyIdentifier = drmData?.initData?.first,
-			  let certificateURLString = drmData?.certificateUrl,
-			  let certificateURL = URL(string: certificateURLString),
-			  let licenseURLString = drmData?.licenseUrl,
-			  let licenseURL = URL(string: licenseURLString)
+		      let certificateURLString = drmData?.certificateUrl,
+		      let certificateURL = URL(string: certificateURLString),
+		      let licenseURLString = drmData?.licenseUrl,
+		      let licenseURL = URL(string: licenseURLString)
 		else {
 			return nil
 		}
 
 		let contentKeySession = AVContentKeySession(keySystem: .fairPlayStreaming)
+		let certificate = try await getCertificate(url: certificateURL)
 		let delegate = ActiveLicenseDownload(
-			certificate: try await getCertificate(url: certificateURL),
+			certificate: certificate,
 			httpClient: httpClient,
 			licenseURL: licenseURL
 		)
 
 		let storedLicenseURL: URL = try await withCheckedThrowingContinuation { continuation in
 			self.queue.async {
-				delegate.continuation = continuation
+				delegate.setContinuation(continuation)
 				contentKeySession.setDelegate(delegate, queue: self.queue)
 				contentKeySession.processContentKeyRequest(
 					withIdentifier: keyIdentifier,
@@ -87,16 +88,50 @@ private final class ActiveLicenseDownload: NSObject {
 	let certificate: Data
 	let httpClient: HttpClient
 	let licenseURL: URL
-	var continuation: CheckedContinuation<URL, Error>?
+	private let continuationLock = NSLock()
+	private var continuation: CheckedContinuation<URL, Error>?
 
 	init(certificate: Data, httpClient: HttpClient, licenseURL: URL) {
 		self.certificate = certificate
 		self.httpClient = httpClient
 		self.licenseURL = licenseURL
 	}
+
+	func setContinuation(_ continuation: CheckedContinuation<URL, Error>) {
+		continuationLock.lock()
+		self.continuation = continuation
+		continuationLock.unlock()
+	}
+
+	func finish(returning url: URL) {
+		guard let continuation = takeContinuation() else {
+			return
+		}
+
+		continuation.resume(returning: url)
+	}
+
+	func finish(throwing error: Error) {
+		guard let continuation = takeContinuation() else {
+			return
+		}
+
+		continuation.resume(throwing: error)
+	}
+
+	private func takeContinuation() -> CheckedContinuation<URL, Error>? {
+		continuationLock.lock()
+		defer {
+			continuationLock.unlock()
+		}
+
+		let continuation = continuation
+		self.continuation = nil
+		return continuation
+	}
 }
 
-// MARK: - AVContentKeySessionDelegate
+// MARK: AVContentKeySessionDelegate
 
 extension ActiveLicenseDownload: AVContentKeySessionDelegate {
 	func contentKeySession(
@@ -107,6 +142,7 @@ extension ActiveLicenseDownload: AVContentKeySessionDelegate {
 			try keyRequest.respondByRequestingPersistableContentKeyRequest()
 		} catch {
 			keyRequest.processContentKeyResponseError(error)
+			finish(throwing: error)
 		}
 	}
 
@@ -114,7 +150,9 @@ extension ActiveLicenseDownload: AVContentKeySessionDelegate {
 		_ session: AVContentKeySession,
 		didProvide keyRequest: AVPersistableContentKeyRequest
 	) {
-		Task {
+		Task { [session] in
+			_ = session
+
 			do {
 				let spc = try await createSpc(keyRequest: keyRequest)
 				let license = try await fetchLicense(spc: spc)
@@ -129,12 +167,10 @@ extension ActiveLicenseDownload: AVContentKeySessionDelegate {
 				let keyResponse = AVContentKeyResponse(fairPlayStreamingKeyResponseData: persistableKey)
 				keyRequest.processContentKeyResponse(keyResponse)
 
-				continuation?.resume(returning: url)
-				continuation = nil
+				finish(returning: url)
 			} catch {
 				keyRequest.processContentKeyResponseError(error)
-				continuation?.resume(throwing: error)
-				continuation = nil
+				finish(throwing: error)
 			}
 		}
 	}
@@ -144,8 +180,7 @@ extension ActiveLicenseDownload: AVContentKeySessionDelegate {
 		contentKeyRequest keyRequest: AVContentKeyRequest,
 		didFailWithError error: Error
 	) {
-		continuation?.resume(throwing: error)
-		continuation = nil
+		finish(throwing: error)
 	}
 }
 
@@ -168,7 +203,7 @@ private extension ActiveLicenseDownload {
 			url: licenseURL,
 			headers: [
 				"Authorization": "Bearer \(token)",
-				"Content-Type": "application/octet-stream"
+				"Content-Type": "application/octet-stream",
 			],
 			body: spc
 		)
@@ -227,12 +262,16 @@ final class HttpClient {
 	}
 }
 
+// MARK: - HttpClientError
+
 private enum HttpClientError: Error {
 	case noResponse
 	case emptyResponse
 	case clientError(statusCode: Int)
 	case serverError(statusCode: Int)
 }
+
+// MARK: - LicenseDownloaderError
 
 enum LicenseDownloaderError: Error {
 	case missingCredentialsProvider


### PR DESCRIPTION
## Summary
- Guard Offliner license download continuation completion so AVFoundation callbacks can only resume it once.
- Finish the continuation when persistable key request conversion fails.
- Keep the AVContentKeySession alive while the async persistable key response task runs.

## Crash
- Crashlytics issue: https://console.firebase.google.com/project/tidal-release/crashlytics/app/ios:com.aspiro.TIDAL/issues/ad4a13b481b3d70d0b84bd3db98aacbc?time=7d&sessionEventKey=c935de20efe74694a580edb96b44ced4_2235506462023795646
- Crashed thread: `com.tidal.offliner.license-downloader`
- Signature: Swift checked continuation assertion in `ActiveLicenseDownload.contentKeySession(_:contentKeyRequest:didFailWithError:)` at `LicenseDownloader.swift:147`.
- Likely cause: AVFoundation can call `didFailWithError` while the async persistable key task is also completing, allowing the same `CheckedContinuation` to be resumed twice.

## Verification
- Pre-commit hook ran SwiftFormat and SwiftLint during commit.
- Did not run builds or tests, per repo instructions to only run them when explicitly requested.