### PR TITLE
NO-TICKET: Fix release script root detection

### DIFF
--- a/.agents/skills/prepare-release/scripts/bump-version.sh
+++ b/.agents/skills/prepare-release/scripts/bump-version.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && cd .. && pwd)
+ROOT_DIR=$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)
 readonly ROOT_DIR
 
 VERSION_FILE="$ROOT_DIR/version.txt"

--- a/.agents/skills/prepare-release/scripts/check-version-bump.sh
+++ b/.agents/skills/prepare-release/scripts/check-version-bump.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && cd .. && pwd)
+ROOT_DIR=$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)
 readonly ROOT_DIR
 
 VERSION_FILE="$ROOT_DIR/version.txt"
@@ -11,15 +11,15 @@ readonly SEMVER_REGEX='(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d
 
 echo "Checking '$VERSION_FILE'"
 
-last_commit="$(git rev-parse @)"
-previous_commit="$(git rev-parse @~)"
+last_commit="$(git -C "$ROOT_DIR" rev-parse @)"
+previous_commit="$(git -C "$ROOT_DIR" rev-parse @~)"
 
 # Check if the submitted file exists and is correctly named
 verify_file_validity() {
     file=$1
     if [ ! -f "$file" ]; then
         echo "File '$file' not found. Cannot check for version bump in '$DIR'"
-        exit 1
+        exit 2
     fi
 }
 
@@ -43,7 +43,7 @@ is_version_bump() {
 
 verify_file_validity "$VERSION_FILE"
 
-version_diff="$(git diff $previous_commit $last_commit -- "$VERSION_FILE")"
+version_diff="$(git -C "$ROOT_DIR" diff "$previous_commit" "$last_commit" -- "$VERSION_FILE")"
 should_build_release=false
 
 if [ -n "$version_diff" ]; then

--- a/.github/workflows/trigger-releases.yml
+++ b/.github/workflows/trigger-releases.yml
@@ -1,7 +1,8 @@
 name: Trigger Releases
 on:
   push:
-    branches: 'main'
+    branches:
+      - main
 
 jobs: 
   check-bump:
@@ -21,10 +22,13 @@ jobs:
           result="false"
           version="$(cat version.txt)"
           ./.agents/skills/prepare-release/scripts/check-version-bump.sh
+          status=$?
           
-          # check-version-bump exits with 0 if it detects a bump, otherwise with 1
-          if [ $? != "1" ]; then
+          # check-version-bump exits with 0 for a bump, 1 for no bump, and >1 for errors.
+          if [ "$status" = "0" ]; then
             result="true"
+          elif [ "$status" != "1" ]; then
+            exit "$status"
           fi
           echo "version=$version" >> $GITHUB_OUTPUT
           echo "bump_detected=$result" >> $GITHUB_OUTPUT
@@ -53,5 +57,3 @@ jobs:
     with: 
         version: ${{ needs.check-bump.outputs.version }}
     secrets: inherit
-
-


### PR DESCRIPTION
## Why
Release `0.11.25` did not draft because the version-bump gate looked for `version.txt` under `.agents/skills/prepare-release` instead of the repo root.

## What
- Resolve release script roots with `git rev-parse --show-toplevel`
- Make the release trigger fail on script errors instead of treating them as no bump
- Update the `main` branch trigger shape so workflow schema validation passes

## Risk Assessment
Low — this only affects release automation and keeps non-bump pushes skipped. Script errors now fail visibly instead of silently skipping or accidentally triggering release jobs.

## References
- Failed run: https://github.com/tidal-music/tidal-sdk-ios/actions/runs/28586025249
- Local verification: `check-version-bump.sh` exits `0` from repo root and `/tmp`
- Pre-commit `check-github-workflows` passed