### PR TITLE
TM-1573: Enable account-safe Offliner on watchOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.8
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import class Foundation.ProcessInfo
@@ -15,7 +15,7 @@ let package = Package(
 		.iOS(.v15),
 		.macOS(.v12),
 		.tvOS(.v15),
-		.watchOS(.v7),
+		.watchOS(.v10),
 	],
 	products: [
 		.library(
@@ -163,7 +163,6 @@ let package = Package(
 				.GRDB,
 				.tidalAPI,
 				.auth,
-				.player,
 			],
 			exclude: [
 				"README.md",

--- a/Sources/Offliner/Download.swift
+++ b/Sources/Offliner/Download.swift
@@ -16,6 +16,12 @@ public actor Download {
 	public nonisolated let title: String
 	public nonisolated let artists: [String]
 	public nonisolated let imageURL: URL?
+	/// The backend task identifier used to correlate this transfer with task processing.
+	public nonisolated let taskId: String
+	/// The track or video transferred by this download.
+	public nonisolated let resource: OfflineResource
+	/// The collection that caused the transfer, when applicable.
+	public nonisolated let collection: OfflineResource?
 	public nonisolated let events: AsyncStream<Event>
 	nonisolated let relatedCollection: OfflineCollectionReference?
 
@@ -25,12 +31,19 @@ public actor Download {
 		title: String,
 		artists: [String],
 		imageURL: URL?,
+		taskId: String,
+		resource: OfflineResource,
 		relatedCollection: OfflineCollectionReference? = nil
 	) {
 		self.title = title
 		self.artists = artists
 		self.imageURL = imageURL
+		self.taskId = taskId
+		self.resource = resource
 		self.relatedCollection = relatedCollection
+		self.collection = relatedCollection.map {
+			.collection(type: $0.collectionType, resourceId: $0.resourceId)
+		}
 
 		let (stream, continuation) = AsyncStream<Event>.makeStream()
 		self.events = stream

--- a/Sources/Offliner/Download.swift
+++ b/Sources/Offliner/Download.swift
@@ -26,6 +26,7 @@ public actor Download {
 	nonisolated let relatedCollection: OfflineCollectionReference?
 
 	private let continuation: AsyncStream<Event>.Continuation
+	private let progressHandler: (@Sendable (Double) async -> Void)?
 
 	internal init(
 		title: String,
@@ -33,7 +34,8 @@ public actor Download {
 		imageURL: URL?,
 		taskId: String,
 		resource: OfflineResource,
-		relatedCollection: OfflineCollectionReference? = nil
+		relatedCollection: OfflineCollectionReference? = nil,
+		progressHandler: (@Sendable (Double) async -> Void)? = nil
 	) {
 		self.title = title
 		self.artists = artists
@@ -44,6 +46,7 @@ public actor Download {
 		self.collection = relatedCollection.map {
 			.collection(type: $0.collectionType, resourceId: $0.resourceId)
 		}
+		self.progressHandler = progressHandler
 
 		let (stream, continuation) = AsyncStream<Event>.makeStream()
 		self.events = stream
@@ -58,7 +61,8 @@ public actor Download {
 		}
 	}
 
-	internal func updateProgress(_ newProgress: Double) {
+	internal func updateProgress(_ newProgress: Double) async {
 		continuation.yield(.progress(newProgress))
+		await progressHandler?(newProgress)
 	}
 }

--- a/Sources/Offliner/Internal/ArtworkDownloader.swift
+++ b/Sources/Offliner/Internal/ArtworkDownloader.swift
@@ -7,8 +7,10 @@ protocol ArtworkDownloaderProtocol {
 
 final class ArtworkDownloader: ArtworkDownloaderProtocol {
 	private let urlSession: URLSession
+	private let fileStorage: FileStorage
 
-	init(urlSession: URLSession = .shared) {
+	init(fileStorage: FileStorage, urlSession: URLSession = .shared) {
+		self.fileStorage = fileStorage
 		self.urlSession = urlSession
 	}
 
@@ -34,7 +36,8 @@ final class ArtworkDownloader: ArtworkDownloaderProtocol {
 		let fileExtension = imageURL.pathExtension.isEmpty ? "jpg" : imageURL.pathExtension
 		let filename = "\(UUID().uuidString).\(fileExtension)"
 
-		return try FileStorage.move(from: tempURL, subdirectory: "Artworks", filename: filename)
+		try Task.checkCancellation()
+		return try fileStorage.move(from: tempURL, subdirectory: "Artworks", filename: filename)
 	}
 }
 

--- a/Sources/Offliner/Internal/FileStorage.swift
+++ b/Sources/Offliner/Internal/FileStorage.swift
@@ -1,14 +1,28 @@
 import Foundation
 
-enum FileStorage {
-	static func store(_ data: Data, subdirectory: String, filename: String) throws -> URL {
+final class FileStorage {
+	let rootDirectory: URL
+	private let writeLock = NSLock()
+	private var acceptsWrites = true
+
+	init(rootDirectory: URL) {
+		self.rootDirectory = rootDirectory
+	}
+
+	func store(_ data: Data, subdirectory: String, filename: String) throws -> URL {
+		writeLock.lock()
+		defer { writeLock.unlock() }
+		try ensureAcceptsWrites()
 		let dir = try directory(for: subdirectory)
 		let url = dir.appendingPathComponent(filename)
 		try data.write(to: url, options: .atomic)
 		return url
 	}
 
-	static func move(from source: URL, subdirectory: String, filename: String) throws -> URL {
+	func move(from source: URL, subdirectory: String, filename: String) throws -> URL {
+		writeLock.lock()
+		defer { writeLock.unlock() }
+		try ensureAcceptsWrites()
 		let dir = try directory(for: subdirectory)
 		let destination = dir.appendingPathComponent(filename)
 		_ = try FileManager.default.replaceItemAt(destination, withItemAt: source)
@@ -30,12 +44,18 @@ enum FileStorage {
 		try delete(url: url)
 	}
 
-	private static func directory(for subdirectory: String) throws -> URL {
-		let appSupportURLs = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
-		guard let appSupportDirectory = appSupportURLs.first else {
-			throw FileStorageError.noApplicationSupportDirectory
-		}
-		let directory = appSupportDirectory.appendingPathComponent("Offliner/\(subdirectory)", isDirectory: true)
+	func invalidateWrites() {
+		writeLock.lock()
+		acceptsWrites = false
+		writeLock.unlock()
+	}
+
+	private func ensureAcceptsWrites() throws {
+		guard acceptsWrites else { throw OfflinerLifecycleError.reset }
+	}
+
+	private func directory(for subdirectory: String) throws -> URL {
+		let directory = rootDirectory.appendingPathComponent(subdirectory, isDirectory: true)
 		try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
 		return directory
 	}

--- a/Sources/Offliner/Internal/Handlers/StoreTrackHandler.swift
+++ b/Sources/Offliner/Internal/Handlers/StoreTrackHandler.swift
@@ -1,4 +1,3 @@
-import AVFoundation
 import Foundation
 import TidalAPI
 

--- a/Sources/Offliner/Internal/Handlers/StoreTrackHandler.swift
+++ b/Sources/Offliner/Internal/Handlers/StoreTrackHandler.swift
@@ -7,19 +7,22 @@ final class StoreTrackHandler {
 	private let mediaDownloader: MediaDownloaderProtocol
 	private let manifestFetcher: TrackManifestFetcherProtocol
 	private let licenseDownloader: LicenseDownloader
+	private let resourceStateTracker: ResourceStateTracker
 
 	init(
 		offlineStore: OfflineStore,
 		artworkDownloader: ArtworkDownloaderProtocol,
 		mediaDownloader: MediaDownloaderProtocol,
 		manifestFetcher: TrackManifestFetcherProtocol,
-		licenseDownloader: LicenseDownloader
+		licenseDownloader: LicenseDownloader,
+		resourceStateTracker: ResourceStateTracker
 	) {
 		self.offlineStore = offlineStore
 		self.artworkDownloader = artworkDownloader
 		self.mediaDownloader = mediaDownloader
 		self.manifestFetcher = manifestFetcher
 		self.licenseDownloader = licenseDownloader
+		self.resourceStateTracker = resourceStateTracker
 	}
 
 	func handle(_ task: StoreTrackTask) -> InternalTask {
@@ -38,7 +41,10 @@ final class StoreTrackHandler {
 				imageURL: imageURL,
 				taskId: task.id,
 				resource: .media(type: .tracks, resourceId: task.track.id),
-				relatedCollection: relatedCollection
+				relatedCollection: relatedCollection,
+				progressHandler: { [resourceStateTracker] progress in
+					await resourceStateTracker.updateProgress(taskId: task.id, progress: progress)
+				}
 			),
 			offlineStore: offlineStore,
 			artworkDownloader: artworkDownloader,

--- a/Sources/Offliner/Internal/Handlers/StoreTrackHandler.swift
+++ b/Sources/Offliner/Internal/Handlers/StoreTrackHandler.swift
@@ -36,6 +36,8 @@ final class StoreTrackHandler {
 				title: title,
 				artists: artists,
 				imageURL: imageURL,
+				taskId: task.id,
+				resource: .media(type: .tracks, resourceId: task.track.id),
 				relatedCollection: relatedCollection
 			),
 			offlineStore: offlineStore,

--- a/Sources/Offliner/Internal/Handlers/StoreVideoHandler.swift
+++ b/Sources/Offliner/Internal/Handlers/StoreVideoHandler.swift
@@ -1,4 +1,3 @@
-import AVFoundation
 import Foundation
 import TidalAPI
 

--- a/Sources/Offliner/Internal/Handlers/StoreVideoHandler.swift
+++ b/Sources/Offliner/Internal/Handlers/StoreVideoHandler.swift
@@ -36,6 +36,8 @@ final class StoreVideoHandler {
 				title: title,
 				artists: artists,
 				imageURL: imageURL,
+				taskId: task.id,
+				resource: .media(type: .videos, resourceId: task.video.id),
 				relatedCollection: relatedCollection
 			),
 			offlineStore: offlineStore,

--- a/Sources/Offliner/Internal/Handlers/StoreVideoHandler.swift
+++ b/Sources/Offliner/Internal/Handlers/StoreVideoHandler.swift
@@ -7,19 +7,22 @@ final class StoreVideoHandler {
 	private let mediaDownloader: MediaDownloaderProtocol
 	private let manifestFetcher: VideoManifestFetcherProtocol
 	private let licenseDownloader: LicenseDownloader
+	private let resourceStateTracker: ResourceStateTracker
 
 	init(
 		offlineStore: OfflineStore,
 		artworkDownloader: ArtworkDownloaderProtocol,
 		mediaDownloader: MediaDownloaderProtocol,
 		manifestFetcher: VideoManifestFetcherProtocol,
-		licenseDownloader: LicenseDownloader
+		licenseDownloader: LicenseDownloader,
+		resourceStateTracker: ResourceStateTracker
 	) {
 		self.offlineStore = offlineStore
 		self.artworkDownloader = artworkDownloader
 		self.mediaDownloader = mediaDownloader
 		self.manifestFetcher = manifestFetcher
 		self.licenseDownloader = licenseDownloader
+		self.resourceStateTracker = resourceStateTracker
 	}
 
 	func handle(_ task: StoreVideoTask) -> InternalTask {
@@ -38,7 +41,10 @@ final class StoreVideoHandler {
 				imageURL: imageURL,
 				taskId: task.id,
 				resource: .media(type: .videos, resourceId: task.video.id),
-				relatedCollection: relatedCollection
+				relatedCollection: relatedCollection,
+				progressHandler: { [resourceStateTracker] progress in
+					await resourceStateTracker.updateProgress(taskId: task.id, progress: progress)
+				}
 			),
 			offlineStore: offlineStore,
 			artworkDownloader: artworkDownloader,

--- a/Sources/Offliner/Internal/LicenseDownloader.swift
+++ b/Sources/Offliner/Internal/LicenseDownloader.swift
@@ -1,6 +1,7 @@
 import Auth
 import AVFoundation
 import Foundation
+import OSLog
 import TidalAPI
 
 // MARK: - LicenseDownloadResult
@@ -21,6 +22,16 @@ actor LicenseDownloader {
 	private var activeDownloads: [UUID: ActiveLicenseDownload] = [:]
 	private var isCancelled = false
 
+	private static let logger = Logger(subsystem: "com.tidal.sdk.offliner", category: "LicenseDownloader")
+
+	private static let isSimulator: Bool = {
+		#if targetEnvironment(simulator)
+			true
+		#else
+			false
+		#endif
+	}()
+
 	init(fileStorage: FileStorage) {
 		httpClient = HttpClient()
 		self.fileStorage = fileStorage
@@ -28,13 +39,23 @@ actor LicenseDownloader {
 
 	func downloadLicense(drmData: DrmData?) async throws -> LicenseDownloadResult? {
 		try Task.checkCancellation()
-		guard !isCancelled else { throw CancellationError() }
+		guard !isCancelled else {
+			throw CancellationError()
+		}
 		guard let keyIdentifier = drmData?.initData?.first,
 		      let certificateURLString = drmData?.certificateUrl,
 		      let certificateURL = URL(string: certificateURLString),
 		      let licenseURLString = drmData?.licenseUrl,
 		      let licenseURL = URL(string: licenseURLString)
 		else {
+			return nil
+		}
+
+		// AVContentKeySession(keySystem: .fairPlayStreaming) raises an uncatchable Objective-C exception on
+		// simulators. Skip license acquisition there so downloads complete for development and UI validation;
+		// playback of protected media is not possible on simulators either way.
+		guard !Self.isSimulator else {
+			Self.logger.warning("Skipping FairPlay license download: FairPlay is not supported on simulators")
 			return nil
 		}
 

--- a/Sources/Offliner/Internal/LicenseDownloader.swift
+++ b/Sources/Offliner/Internal/LicenseDownloader.swift
@@ -14,15 +14,21 @@ struct LicenseDownloadResult {
 
 actor LicenseDownloader {
 	private let httpClient: HttpClient
+	private let fileStorage: FileStorage
 	private let queue = DispatchQueue(label: "com.tidal.offliner.license-downloader")
 	private var certificate: Data?
 	private var certificateTask: Task<Data, Error>?
+	private var activeDownloads: [UUID: ActiveLicenseDownload] = [:]
+	private var isCancelled = false
 
-	init() {
+	init(fileStorage: FileStorage) {
 		httpClient = HttpClient()
+		self.fileStorage = fileStorage
 	}
 
 	func downloadLicense(drmData: DrmData?) async throws -> LicenseDownloadResult? {
+		try Task.checkCancellation()
+		guard !isCancelled else { throw CancellationError() }
 		guard let keyIdentifier = drmData?.initData?.first,
 		      let certificateURLString = drmData?.certificateUrl,
 		      let certificateURL = URL(string: certificateURLString),
@@ -37,22 +43,46 @@ actor LicenseDownloader {
 		let delegate = ActiveLicenseDownload(
 			certificate: certificate,
 			httpClient: httpClient,
-			licenseURL: licenseURL
+			licenseURL: licenseURL,
+			fileStorage: fileStorage
 		)
+		let downloadId = UUID()
+		activeDownloads[downloadId] = delegate
 
-		let storedLicenseURL: URL = try await withCheckedThrowingContinuation { continuation in
-			self.queue.async {
-				delegate.setContinuation(continuation)
-				contentKeySession.setDelegate(delegate, queue: self.queue)
-				contentKeySession.processContentKeyRequest(
-					withIdentifier: keyIdentifier,
-					initializationData: nil,
-					options: nil
-				)
+		let storedLicenseURL: URL
+		do {
+			storedLicenseURL = try await withTaskCancellationHandler {
+				try await withCheckedThrowingContinuation { continuation in
+					self.queue.async {
+						delegate.setContinuation(continuation)
+						contentKeySession.setDelegate(delegate, queue: self.queue)
+						contentKeySession.processContentKeyRequest(
+							withIdentifier: keyIdentifier,
+							initializationData: nil,
+							options: nil
+						)
+					}
+				}
+			} onCancel: {
+				delegate.cancel()
 			}
+		} catch {
+			activeDownloads.removeValue(forKey: downloadId)
+			throw error
 		}
+		activeDownloads.removeValue(forKey: downloadId)
 
 		return LicenseDownloadResult(contentKeySession: contentKeySession, licenseURL: storedLicenseURL)
+	}
+
+	func cancelAll() {
+		isCancelled = true
+		certificateTask?.cancel()
+		certificateTask = nil
+		for download in activeDownloads.values {
+			download.cancel()
+		}
+		activeDownloads.removeAll()
 	}
 
 	private func getCertificate(url: URL) async throws -> Data {
@@ -88,17 +118,25 @@ private final class ActiveLicenseDownload: NSObject {
 	let certificate: Data
 	let httpClient: HttpClient
 	let licenseURL: URL
+	let fileStorage: FileStorage
 	private let continuationLock = NSLock()
 	private var continuation: CheckedContinuation<URL, Error>?
+	private var isCancelled = false
 
-	init(certificate: Data, httpClient: HttpClient, licenseURL: URL) {
+	init(certificate: Data, httpClient: HttpClient, licenseURL: URL, fileStorage: FileStorage) {
 		self.certificate = certificate
 		self.httpClient = httpClient
 		self.licenseURL = licenseURL
+		self.fileStorage = fileStorage
 	}
 
 	func setContinuation(_ continuation: CheckedContinuation<URL, Error>) {
 		continuationLock.lock()
+		guard !isCancelled else {
+			continuationLock.unlock()
+			continuation.resume(throwing: CancellationError())
+			return
+		}
 		self.continuation = continuation
 		continuationLock.unlock()
 	}
@@ -117,6 +155,15 @@ private final class ActiveLicenseDownload: NSObject {
 		}
 
 		continuation.resume(throwing: error)
+	}
+
+	func cancel() {
+		continuationLock.lock()
+		isCancelled = true
+		let continuation = continuation
+		self.continuation = nil
+		continuationLock.unlock()
+		continuation?.resume(throwing: CancellationError())
 	}
 
 	private func takeContinuation() -> CheckedContinuation<URL, Error>? {
@@ -158,7 +205,8 @@ extension ActiveLicenseDownload: AVContentKeySessionDelegate {
 				let license = try await fetchLicense(spc: spc)
 				let persistableKey = try keyRequest.persistableContentKey(fromKeyVendorResponse: license)
 
-				let url = try FileStorage.store(
+				try Task.checkCancellation()
+				let url = try fileStorage.store(
 					persistableKey,
 					subdirectory: "Licenses",
 					filename: "\(UUID().uuidString).key"

--- a/Sources/Offliner/Internal/ManifestFetcher.swift
+++ b/Sources/Offliner/Internal/ManifestFetcher.swift
@@ -36,7 +36,7 @@ final class TrackManifestFetcher: TrackManifestFetcherProtocol {
 			id: trackId,
 			manifestType: .hls,
 			formats: audioFormats.map(\.toAPIFormat),
-			uriScheme: .data,
+			uriScheme: simulatorSafeURIScheme(.data),
 			usage: .download,
 			adaptive: false
 		)
@@ -46,7 +46,8 @@ final class TrackManifestFetcher: TrackManifestFetcherProtocol {
 		try validateFullTrackPresentation(attributes?.trackPresentation)
 
 		guard let uriString = attributes?.uri,
-			  let url = URL(string: uriString) else {
+		      let url = URL(string: uriString)
+		else {
 			throw MediaDownloaderError.manifestNotFound
 		}
 
@@ -65,7 +66,9 @@ final class TrackManifestFetcher: TrackManifestFetcherProtocol {
 }
 
 func validateFullTrackPresentation(_ presentation: TrackManifestsAttributes.TrackPresentation?) throws {
-	guard presentation == .full else { throw MediaDownloaderError.previewManifest }
+	guard presentation == .full else {
+		throw MediaDownloaderError.previewManifest
+	}
 }
 
 // MARK: - VideoManifestFetcher
@@ -74,14 +77,15 @@ final class VideoManifestFetcher: VideoManifestFetcherProtocol {
 	func fetchVideoManifest(videoId: String) async throws -> ManifestFetchResult {
 		let response = try await VideoManifestsAPITidal.videoManifestsIdGet(
 			id: videoId,
-			uriScheme: .data,
+			uriScheme: simulatorSafeURIScheme(.data),
 			usage: .download
 		)
 
 		let attributes = response.data.attributes
 
 		guard let hrefString = attributes?.link?.href,
-			  let url = URL(string: hrefString) else {
+		      let url = URL(string: hrefString)
+		else {
 			throw MediaDownloaderError.manifestNotFound
 		}
 
@@ -89,11 +93,38 @@ final class VideoManifestFetcher: VideoManifestFetcherProtocol {
 	}
 }
 
+// MARK: - Simulator URI Scheme
+
+/// Simulators reject `data:` manifest URIs in `AVAssetDownloadTask` with `NSURLErrorUnsupportedURL`. Request regular
+/// HTTPS manifests there so development and UI-validation downloads can complete; devices keep the `data:` scheme,
+/// which avoids a second manifest fetch at download time.
+private func simulatorSafeURIScheme(
+	_ scheme: TrackManifestsAPITidal.UriScheme_trackManifestsIdGet
+) -> TrackManifestsAPITidal.UriScheme_trackManifestsIdGet {
+	#if targetEnvironment(simulator)
+		.https
+	#else
+		scheme
+	#endif
+}
+
+private func simulatorSafeURIScheme(
+	_ scheme: VideoManifestsAPITidal.UriScheme_videoManifestsIdGet
+) -> VideoManifestsAPITidal.UriScheme_videoManifestsIdGet {
+	#if targetEnvironment(simulator)
+		.https
+	#else
+		scheme
+	#endif
+}
+
 // MARK: - NormalizationData Conversion
 
 private extension OfflineMediaItem.NormalizationData {
 	init?(_ apiData: AudioNormalizationData?) {
-		guard let apiData else { return nil }
+		guard let apiData else {
+			return nil
+		}
 		self.init(peakAmplitude: apiData.peakAmplitude, replayGain: apiData.replayGain)
 	}
 }

--- a/Sources/Offliner/Internal/ManifestFetcher.swift
+++ b/Sources/Offliner/Internal/ManifestFetcher.swift
@@ -43,6 +43,8 @@ final class TrackManifestFetcher: TrackManifestFetcherProtocol {
 
 		let attributes = response.data.attributes
 
+		try validateFullTrackPresentation(attributes?.trackPresentation)
+
 		guard let uriString = attributes?.uri,
 			  let url = URL(string: uriString) else {
 			throw MediaDownloaderError.manifestNotFound
@@ -60,6 +62,10 @@ final class TrackManifestFetcher: TrackManifestFetcherProtocol {
 
 		return ManifestFetchResult(manifestURL: url, drmData: attributes?.drmData, playbackMetadata: playbackMetadata)
 	}
+}
+
+func validateFullTrackPresentation(_ presentation: TrackManifestsAttributes.TrackPresentation?) throws {
+	guard presentation == .full else { throw MediaDownloaderError.previewManifest }
 }
 
 // MARK: - VideoManifestFetcher

--- a/Sources/Offliner/Internal/MediaDownloader.swift
+++ b/Sources/Offliner/Internal/MediaDownloader.swift
@@ -32,17 +32,27 @@ final class MediaDownloader: NSObject, MediaDownloaderProtocol {
 	let backgroundSessionIdentifier: String
 
 	private let queue: DispatchQueue
+	private let fileStorage: FileStorage
 	private var session: AVAssetDownloadURLSession!
 	private var activeDownloads: [Int: ActiveDownload] = [:]
 	private var backgroundCompletionHandler: (() -> Void)?
 	private let cancellationLock = NSLock()
 	private var isCancelled = false
 
+	private static let isSimulator: Bool = {
+		#if targetEnvironment(simulator)
+			true
+		#else
+			false
+		#endif
+	}()
+
 	var orphanedTaskHandler: ((String?) -> Void)?
 
-	init(configuration: Configuration, backgroundSessionIdentifier: String) {
-		self.queue = DispatchQueue(label: "com.tidal.offliner.media-downloader", qos: .userInitiated)
+	init(configuration: Configuration, backgroundSessionIdentifier: String, fileStorage: FileStorage) {
+		queue = DispatchQueue(label: "com.tidal.offliner.media-downloader", qos: .userInitiated)
 		self.backgroundSessionIdentifier = backgroundSessionIdentifier
+		self.fileStorage = fileStorage
 
 		super.init()
 
@@ -50,7 +60,7 @@ final class MediaDownloader: NSObject, MediaDownloaderProtocol {
 		delegateQueue.underlyingQueue = queue
 		delegateQueue.maxConcurrentOperationCount = 1
 
-		self.session = AVAssetDownloadURLSession(
+		session = AVAssetDownloadURLSession(
 			configuration: URLSessionConfiguration.background(withIdentifier: backgroundSessionIdentifier),
 			assetDownloadDelegate: self,
 			delegateQueue: delegateQueue
@@ -58,7 +68,9 @@ final class MediaDownloader: NSObject, MediaDownloaderProtocol {
 	}
 
 	func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void) -> Bool {
-		guard identifier == backgroundSessionIdentifier else { return false }
+		guard identifier == backgroundSessionIdentifier else {
+			return false
+		}
 		DispatchQueue.main.async {
 			self.backgroundCompletionHandler = completionHandler
 		}
@@ -91,8 +103,17 @@ final class MediaDownloader: NSObject, MediaDownloaderProtocol {
 		let asset = AVURLAsset(url: manifestURL)
 		licenseDownloadResult?.contentKeySession.addContentKeyRecipient(asset)
 
-		let duration = Int(CMTimeGetSeconds(try await asset.load(.duration)))
+		let duration = try await Int(CMTimeGetSeconds(asset.load(.duration)))
 		try Task.checkCancellation()
+
+		if Self.isSimulator {
+			return try await simulatorDownload(
+				taskId: taskId,
+				manifestURL: manifestURL,
+				duration: duration,
+				onProgress: onProgress
+			)
+		}
 
 		return try await withCheckedThrowingContinuation { continuation in
 			queue.async {
@@ -125,9 +146,28 @@ final class MediaDownloader: NSObject, MediaDownloaderProtocol {
 			}
 		}
 	}
+
+	/// `AVAssetDownloadURLSession` tasks never complete on simulators. Store the manifest itself as the media file so
+	/// the download pipeline completes for development and UI validation; playback resolves the manifest's remote
+	/// segment URLs over the network.
+	private func simulatorDownload(
+		taskId: String,
+		manifestURL: URL,
+		duration: Int,
+		onProgress: @escaping @Sendable (Double) async -> Void
+	) async throws -> MediaDownloadResult {
+		Self.logger.warning(
+			"Storing manifest instead of media segments: AVAssetDownloadTask is not supported on simulators [task: \(taskId, privacy: .public)]"
+		)
+		let (data, _) = try await URLSession.shared.data(from: manifestURL)
+		try Task.checkCancellation()
+		let location = try fileStorage.store(data, subdirectory: "Media", filename: "\(UUID().uuidString).m3u8")
+		await onProgress(1.0)
+		return MediaDownloadResult(duration: duration, mediaLocation: location)
+	}
 }
 
-// MARK: - AVAssetDownloadDelegate
+// MARK: AVAssetDownloadDelegate
 
 extension MediaDownloader: AVAssetDownloadDelegate {
 	func urlSession(
@@ -170,7 +210,10 @@ extension MediaDownloader: AVAssetDownloadDelegate {
 		task: URLSessionTask,
 		didCompleteWithError error: Error?
 	) {
-		Self.logger.debug("didCompleteWithError called: \(error.map { "\($0)" } ?? "success", privacy: .public) [task: \(task.taskDescription ?? "?", privacy: .public)]")
+		Self.logger
+			.debug(
+				"didCompleteWithError called: \(error.map { "\($0)" } ?? "success", privacy: .public) [task: \(task.taskDescription ?? "?", privacy: .public)]"
+			)
 
 		guard let activeDownload = activeDownloads.removeValue(forKey: task.taskIdentifier) else {
 			Self.logger.debug("orphaned didCompleteWithError called [task: \(task.taskDescription ?? "?", privacy: .public)]")

--- a/Sources/Offliner/Internal/MediaDownloader.swift
+++ b/Sources/Offliner/Internal/MediaDownloader.swift
@@ -230,4 +230,5 @@ private final class ActiveDownload {
 enum MediaDownloaderError: Error {
 	case noDownloadedFile
 	case manifestNotFound
+	case previewManifest
 }

--- a/Sources/Offliner/Internal/MediaDownloader.swift
+++ b/Sources/Offliner/Internal/MediaDownloader.swift
@@ -21,7 +21,7 @@ protocol MediaDownloaderProtocol {
 		onProgress: @escaping @Sendable (Double) async -> Void
 	) async throws -> MediaDownloadResult
 
-	func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void)
+	func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void) -> Bool
 	func cancelAll() async
 }
 
@@ -57,11 +57,12 @@ final class MediaDownloader: NSObject, MediaDownloaderProtocol {
 		)
 	}
 
-	func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void) {
+	func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void) -> Bool {
+		guard identifier == backgroundSessionIdentifier else { return false }
 		DispatchQueue.main.async {
-			guard identifier == self.backgroundSessionIdentifier else { return }
 			self.backgroundCompletionHandler = completionHandler
 		}
+		return true
 	}
 
 	func cancelAll() async {

--- a/Sources/Offliner/Internal/MediaDownloader.swift
+++ b/Sources/Offliner/Internal/MediaDownloader.swift
@@ -22,23 +22,27 @@ protocol MediaDownloaderProtocol {
 	) async throws -> MediaDownloadResult
 
 	func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void)
+	func cancelAll() async
 }
 
 // MARK: - MediaDownloader
 
 final class MediaDownloader: NSObject, MediaDownloaderProtocol {
 	private static let logger = Logger(subsystem: "com.tidal.sdk.offliner", category: "MediaDownloader")
-	static let backgroundSessionIdentifier = "com.tidal.offliner.download.session"
+	let backgroundSessionIdentifier: String
 
 	private let queue: DispatchQueue
 	private var session: AVAssetDownloadURLSession!
 	private var activeDownloads: [Int: ActiveDownload] = [:]
 	private var backgroundCompletionHandler: (() -> Void)?
+	private let cancellationLock = NSLock()
+	private var isCancelled = false
 
 	var orphanedTaskHandler: ((String?) -> Void)?
 
-	init(configuration: Configuration) {
+	init(configuration: Configuration, backgroundSessionIdentifier: String) {
 		self.queue = DispatchQueue(label: "com.tidal.offliner.media-downloader", qos: .userInitiated)
+		self.backgroundSessionIdentifier = backgroundSessionIdentifier
 
 		super.init()
 
@@ -47,7 +51,7 @@ final class MediaDownloader: NSObject, MediaDownloaderProtocol {
 		delegateQueue.maxConcurrentOperationCount = 1
 
 		self.session = AVAssetDownloadURLSession(
-			configuration: URLSessionConfiguration.background(withIdentifier: Self.backgroundSessionIdentifier),
+			configuration: URLSessionConfiguration.background(withIdentifier: backgroundSessionIdentifier),
 			assetDownloadDelegate: self,
 			delegateQueue: delegateQueue
 		)
@@ -55,9 +59,23 @@ final class MediaDownloader: NSObject, MediaDownloaderProtocol {
 
 	func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void) {
 		DispatchQueue.main.async {
-			guard identifier == Self.backgroundSessionIdentifier else { return }
+			guard identifier == self.backgroundSessionIdentifier else { return }
 			self.backgroundCompletionHandler = completionHandler
 		}
+	}
+
+	func cancelAll() async {
+		invalidate()
+		let tasks = await session.allTasks
+		for task in tasks {
+			task.cancel()
+		}
+	}
+
+	private func invalidate() {
+		cancellationLock.lock()
+		isCancelled = true
+		cancellationLock.unlock()
 	}
 
 	func download(
@@ -73,9 +91,17 @@ final class MediaDownloader: NSObject, MediaDownloaderProtocol {
 		licenseDownloadResult?.contentKeySession.addContentKeyRecipient(asset)
 
 		let duration = Int(CMTimeGetSeconds(try await asset.load(.duration)))
+		try Task.checkCancellation()
 
 		return try await withCheckedThrowingContinuation { continuation in
 			queue.async {
+				self.cancellationLock.lock()
+				let isCancelled = self.isCancelled
+				self.cancellationLock.unlock()
+				guard !isCancelled else {
+					continuation.resume(throwing: CancellationError())
+					return
+				}
 				let downloadConfiguration = AVAssetDownloadConfiguration(asset: asset, title: title)
 				let task = self.session.makeAssetDownloadTask(downloadConfiguration: downloadConfiguration)
 

--- a/Sources/Offliner/Internal/MediaDownloader.swift
+++ b/Sources/Offliner/Internal/MediaDownloader.swift
@@ -76,24 +76,20 @@ final class MediaDownloader: NSObject, MediaDownloaderProtocol {
 
 		return try await withCheckedThrowingContinuation { continuation in
 			queue.async {
-				guard let task = self.session.makeAssetDownloadTask(
-					asset: asset,
-					assetTitle: title,
-					assetArtworkData: nil,
-					options: nil
-				) else {
-					continuation.resume(throwing: MediaDownloaderError.failedToCreateTask)
-					return
-				}
+				let downloadConfiguration = AVAssetDownloadConfiguration(asset: asset, title: title)
+				let task = self.session.makeAssetDownloadTask(downloadConfiguration: downloadConfiguration)
 
 				let activeDownload = ActiveDownload(
 					duration: duration,
-					continuation: continuation,
-					onProgress: onProgress
+					continuation: continuation
 				)
 
 				task.taskDescription = taskId
 				task.priority = 1.0
+
+				activeDownload.progressObservation = task.progress.observe(\.fractionCompleted) { progress, _ in
+					Task { await onProgress(progress.fractionCompleted) }
+				}
 
 				self.activeDownloads[task.taskIdentifier] = activeDownload
 				task.resume()
@@ -113,11 +109,29 @@ extension MediaDownloader: AVAssetDownloadDelegate {
 		didFinishDownloadingTo location: URL
 	) {
 		Self.logger.debug("didFinishDownloadingTo called [task: \(assetDownloadTask.taskDescription ?? "?", privacy: .public)]")
+		recordDownloadedLocation(location, for: assetDownloadTask, deleteIfOrphaned: true)
+	}
 
+	@available(iOS 18.0, macOS 14.0, watchOS 10.0, *)
+	func urlSession(
+		_ session: URLSession,
+		assetDownloadTask: AVAssetDownloadTask,
+		willDownloadTo location: URL
+	) {
+		Self.logger.debug("willDownloadTo called [task: \(assetDownloadTask.taskDescription ?? "?", privacy: .public)]")
+		recordDownloadedLocation(location, for: assetDownloadTask, deleteIfOrphaned: false)
+	}
+
+	private func recordDownloadedLocation(
+		_ location: URL,
+		for assetDownloadTask: AVAssetDownloadTask,
+		deleteIfOrphaned: Bool
+	) {
 		guard let activeDownload = activeDownloads[assetDownloadTask.taskIdentifier] else {
-			Self.logger.debug("orphaned didFinishDownloadingTo called [task: \(assetDownloadTask.taskDescription ?? "?", privacy: .public)]")
-
-			try? FileStorage.delete(url: location)
+			Self.logger.debug("orphaned download location [task: \(assetDownloadTask.taskDescription ?? "?", privacy: .public)]")
+			if deleteIfOrphaned {
+				try? FileStorage.delete(url: location)
+			}
 			return
 		}
 
@@ -136,6 +150,8 @@ extension MediaDownloader: AVAssetDownloadDelegate {
 			orphanedTaskHandler?(task.taskDescription)
 			return
 		}
+
+		activeDownload.progressObservation?.invalidate()
 
 		if let error {
 			try? activeDownload.downloadedLocation.map(FileStorage.delete)
@@ -156,22 +172,6 @@ extension MediaDownloader: AVAssetDownloadDelegate {
 		activeDownload.continuation.resume(returning: result)
 	}
 
-	func urlSession(
-		_ session: URLSession,
-		assetDownloadTask: AVAssetDownloadTask,
-		didLoad timeRange: CMTimeRange,
-		totalTimeRangesLoaded loadedTimeRanges: [NSValue],
-		timeRangeExpectedToLoad: CMTimeRange
-	) {
-		let loaded = loadedTimeRanges.reduce(0.0) { $0 + CMTimeGetSeconds($1.timeRangeValue.duration) }
-		let expected = CMTimeGetSeconds(timeRangeExpectedToLoad.duration)
-		let progress = expected > 0 ? loaded / expected : 0
-
-		if let onProgress = activeDownloads[assetDownloadTask.taskIdentifier]?.onProgress {
-			Task { await onProgress(progress) }
-		}
-	}
-
 	func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
 		Self.logger.debug("urlSessionDidFinishEvents forBackgroundURLSession")
 		DispatchQueue.main.async { [weak self] in
@@ -186,25 +186,22 @@ extension MediaDownloader: AVAssetDownloadDelegate {
 private final class ActiveDownload {
 	let duration: Int
 	let continuation: CheckedContinuation<MediaDownloadResult, Error>
-	let onProgress: @Sendable (Double) async -> Void
 
 	var downloadedLocation: URL?
+	var progressObservation: NSKeyValueObservation?
 
 	init(
 		duration: Int,
-		continuation: CheckedContinuation<MediaDownloadResult, Error>,
-		onProgress: @escaping @Sendable (Double) async -> Void
+		continuation: CheckedContinuation<MediaDownloadResult, Error>
 	) {
 		self.duration = duration
 		self.continuation = continuation
-		self.onProgress = onProgress
 	}
 }
 
 // MARK: - MediaDownloaderError
 
 enum MediaDownloaderError: Error {
-	case failedToCreateTask
 	case noDownloadedFile
 	case manifestNotFound
 }

--- a/Sources/Offliner/Internal/OfflineApiClient.swift
+++ b/Sources/Offliner/Internal/OfflineApiClient.swift
@@ -217,6 +217,62 @@ enum OfflineTask {
 			return resources
 		}
 	}
+
+	var downloadQueueTask: DownloadQueueTask? {
+		switch self {
+		case .storeTrack(let task):
+			return DownloadQueueTask(
+				resource: .media(type: .tracks, resourceId: task.track.id),
+				parentCollection: OfflineResourceKey(
+					resourceType: task.collectionResourceType,
+					resourceId: task.collectionResourceId
+				).publicCollection,
+				supportsProgress: true
+			)
+		case .storeVideo(let task):
+			return DownloadQueueTask(
+				resource: .media(type: .videos, resourceId: task.video.id),
+				parentCollection: OfflineResourceKey(
+					resourceType: task.collectionResourceType,
+					resourceId: task.collectionResourceId
+				).publicCollection,
+				supportsProgress: true
+			)
+		case .storeAlbum(let task):
+			return DownloadQueueTask(
+				resource: .collection(type: .albums, resourceId: task.album.id),
+				parentCollection: nil,
+				supportsProgress: false
+			)
+		case .storePlaylist(let task):
+			return DownloadQueueTask(
+				resource: .collection(type: .playlists, resourceId: task.playlist.id),
+				parentCollection: nil,
+				supportsProgress: false
+			)
+		case .storeUserCollectionTracks(let task):
+			return DownloadQueueTask(
+				resource: .collection(type: .userCollectionTracks, resourceId: task.resourceId),
+				parentCollection: nil,
+				supportsProgress: false
+			)
+		case .terminal(let task) where task.action == .store:
+			let resourceKey = OfflineResourceKey(resourceType: task.resourceType, resourceId: task.resourceId)
+			guard let resource = resourceKey.publicResource else { return nil }
+			let parentCollection = task.collectionResourceType.flatMap { type in
+				task.collectionResourceId.flatMap { id in
+					OfflineResourceKey(resourceType: type, resourceId: id).publicCollection
+				}
+			}
+			return DownloadQueueTask(
+				resource: resource,
+				parentCollection: parentCollection,
+				supportsProgress: resourceKey.publicCollection == nil
+			)
+		case .removeItem, .removeCollection, .terminal:
+			return nil
+		}
+	}
 }
 
 // MARK: - OfflineCollectionReference

--- a/Sources/Offliner/Internal/OfflineApiClient.swift
+++ b/Sources/Offliner/Internal/OfflineApiClient.swift
@@ -16,6 +16,7 @@ enum ResourceType {
 
 struct StoreTrackTask {
 	let id: String
+	let state: Download.State
 	let track: TracksResourceObject
 	let album: AlbumsResourceObject?
 	let artists: [ArtistsResourceObject]
@@ -28,6 +29,7 @@ struct StoreTrackTask {
 
 	init(
 		id: String,
+		state: Download.State = .pending,
 		track: TracksResourceObject,
 		album: AlbumsResourceObject? = nil,
 		artists: [ArtistsResourceObject],
@@ -39,6 +41,7 @@ struct StoreTrackTask {
 		addedAt: Date? = nil
 	) {
 		self.id = id
+		self.state = state
 		self.track = track
 		self.album = album
 		self.artists = artists
@@ -53,6 +56,7 @@ struct StoreTrackTask {
 
 struct StoreVideoTask {
 	let id: String
+	let state: Download.State
 	let video: VideosResourceObject
 	let artists: [ArtistsResourceObject]
 	let artwork: ArtworksResourceObject?
@@ -64,6 +68,7 @@ struct StoreVideoTask {
 
 	init(
 		id: String,
+		state: Download.State = .pending,
 		video: VideosResourceObject,
 		artists: [ArtistsResourceObject],
 		artwork: ArtworksResourceObject?,
@@ -74,6 +79,7 @@ struct StoreVideoTask {
 		addedAt: Date? = nil
 	) {
 		self.id = id
+		self.state = state
 		self.video = video
 		self.artists = artists
 		self.artwork = artwork
@@ -87,6 +93,7 @@ struct StoreVideoTask {
 
 struct StoreAlbumTask {
 	let id: String
+	var state: Download.State = .pending
 	let album: AlbumsResourceObject
 	let artists: [ArtistsResourceObject]
 	let artwork: ArtworksResourceObject?
@@ -94,17 +101,20 @@ struct StoreAlbumTask {
 
 struct StorePlaylistTask {
 	let id: String
+	var state: Download.State = .pending
 	let playlist: PlaylistsResourceObject
 	let artwork: ArtworksResourceObject?
 }
 
 struct StoreUserCollectionTracksTask {
 	let id: String
+	var state: Download.State = .pending
 	let resourceId: String
 }
 
 struct RemoveItemTask {
 	let id: String
+	var state: Download.State = .pending
 	let resourceType: String
 	let resourceId: String
 	let collectionResourceType: String
@@ -113,8 +123,19 @@ struct RemoveItemTask {
 
 struct RemoveCollectionTask {
 	let id: String
+	var state: Download.State = .pending
 	let resourceType: String
 	let resourceId: String
+}
+
+struct TerminalOfflineTask {
+	let id: String
+	let state: Download.State
+	let action: InternalOfflineResourceAction
+	let resourceType: String
+	let resourceId: String
+	let collectionResourceType: String?
+	let collectionResourceId: String?
 }
 
 // MARK: - OfflineTask
@@ -127,6 +148,7 @@ enum OfflineTask {
 	case storeUserCollectionTracks(StoreUserCollectionTracksTask)
 	case removeItem(RemoveItemTask)
 	case removeCollection(RemoveCollectionTask)
+	case terminal(TerminalOfflineTask)
 
 	var id: String {
 		switch self {
@@ -137,6 +159,62 @@ enum OfflineTask {
 		case .storeUserCollectionTracks(let task): return task.id
 		case .removeItem(let task): return task.id
 		case .removeCollection(let task): return task.id
+		case .terminal(let task): return task.id
+		}
+	}
+
+	var state: Download.State {
+		switch self {
+		case .storeTrack(let task): task.state
+		case .storeVideo(let task): task.state
+		case .storeAlbum(let task): task.state
+		case .storePlaylist(let task): task.state
+		case .storeUserCollectionTracks(let task): task.state
+		case .removeItem(let task): task.state
+		case .removeCollection(let task): task.state
+		case .terminal(let task): task.state
+		}
+	}
+
+	var action: InternalOfflineResourceAction {
+		switch self {
+		case .storeTrack, .storeVideo, .storeAlbum, .storePlaylist, .storeUserCollectionTracks: .store
+		case .removeItem, .removeCollection: .remove
+		case .terminal(let task): task.action
+		}
+	}
+
+	var resourceKeys: Set<OfflineResourceKey> {
+		switch self {
+		case .storeTrack(let task):
+			return [
+				OfflineResourceKey(resourceType: OfflineMediaItemType.tracks.rawValue, resourceId: task.track.id),
+				OfflineResourceKey(resourceType: task.collectionResourceType, resourceId: task.collectionResourceId),
+			]
+		case .storeVideo(let task):
+			return [
+				OfflineResourceKey(resourceType: OfflineMediaItemType.videos.rawValue, resourceId: task.video.id),
+				OfflineResourceKey(resourceType: task.collectionResourceType, resourceId: task.collectionResourceId),
+			]
+		case .storeAlbum(let task):
+			return [OfflineResourceKey(resourceType: OfflineCollectionType.albums.rawValue, resourceId: task.album.id)]
+		case .storePlaylist(let task):
+			return [OfflineResourceKey(resourceType: OfflineCollectionType.playlists.rawValue, resourceId: task.playlist.id)]
+		case .storeUserCollectionTracks(let task):
+			return [OfflineResourceKey(resourceType: OfflineCollectionType.userCollectionTracks.rawValue, resourceId: task.resourceId)]
+		case .removeItem(let task):
+			return [
+				OfflineResourceKey(resourceType: task.resourceType, resourceId: task.resourceId),
+				OfflineResourceKey(resourceType: task.collectionResourceType, resourceId: task.collectionResourceId),
+			]
+		case .removeCollection(let task):
+			return [OfflineResourceKey(resourceType: task.resourceType, resourceId: task.resourceId)]
+		case .terminal(let task):
+			var resources = Set([OfflineResourceKey(resourceType: task.resourceType, resourceId: task.resourceId)])
+			if let collectionType = task.collectionResourceType, let collectionId = task.collectionResourceId {
+				resources.insert(OfflineResourceKey(resourceType: collectionType, resourceId: collectionId))
+			}
+			return resources
 		}
 	}
 }
@@ -359,6 +437,17 @@ private extension OfflineTasksResourceObject {
 		let includedItem = includedItems.get(type: itemData.type, id: itemData.id)
 		let includedCollection = collectionData.flatMap { includedItems.get(type: $0.type, id: $0.id) }
 		let addedAt = includedCollection?.playlistItemAddedAt(for: itemData)
+		if attributes.state == .failed || attributes.state == .completed {
+			return .terminal(TerminalOfflineTask(
+				id: id,
+				state: attributes.state.downloadState,
+				action: attributes.action == .store ? .store : .remove,
+				resourceType: itemData.type,
+				resourceId: itemData.id,
+				collectionResourceType: collectionData?.type,
+				collectionResourceId: collectionData?.id
+			))
+		}
 
 		switch attributes.action {
 		case .store:
@@ -370,23 +459,32 @@ private extension OfflineTasksResourceObject {
 				return StoreVideoTask(self, attributes: attributes, item: includedItem, collectionData: collectionData, addedAt: addedAt)
 					.map { .storeVideo($0) }
 			case "albums":
-				return StoreAlbumTask(self, item: includedItem)
+				return StoreAlbumTask(self, attributes: attributes, item: includedItem)
 					.map { .storeAlbum($0) }
 			case "playlists":
-				return StorePlaylistTask(self, item: includedItem)
+				return StorePlaylistTask(self, attributes: attributes, item: includedItem)
 					.map { .storePlaylist($0) }
 			case "userCollectionTracks":
-				return .storeUserCollectionTracks(StoreUserCollectionTracksTask(id: id, resourceId: itemData.id))
+				return .storeUserCollectionTracks(StoreUserCollectionTracksTask(
+					id: id,
+					state: attributes.state.downloadState,
+					resourceId: itemData.id
+				))
 			default:
 				return nil
 			}
 		case .remove:
 			switch itemData.type {
 			case "tracks", "videos":
-				return RemoveItemTask(self, itemData: itemData, collectionData: collectionData)
+				return RemoveItemTask(self, attributes: attributes, itemData: itemData, collectionData: collectionData)
 					.map { .removeItem($0) }
 			case "albums", "playlists", "userCollectionTracks":
-				return .removeCollection(RemoveCollectionTask(id: id, resourceType: itemData.type, resourceId: itemData.id))
+				return .removeCollection(RemoveCollectionTask(
+					id: id,
+					state: attributes.state.downloadState,
+					resourceType: itemData.type,
+					resourceId: itemData.id
+				))
 			default:
 				return nil
 			}
@@ -605,6 +703,7 @@ private extension StoreTrackTask {
 		guard let item, case .track(let track) = item.resource, let collectionData else { return nil }
 		self.init(
 			id: resourceObject.id,
+			state: attributes.state.downloadState,
 			track: track,
 			album: item.albumObject,
 			artists: item.artistObjects,
@@ -629,6 +728,7 @@ private extension StoreVideoTask {
 		guard let item, case .video(let video) = item.resource, let collectionData else { return nil }
 		self.init(
 			id: resourceObject.id,
+			state: attributes.state.downloadState,
 			video: video,
 			artists: item.artistObjects,
 			artwork: item.artworkObject,
@@ -642,22 +742,25 @@ private extension StoreVideoTask {
 }
 
 private extension StoreAlbumTask {
-	init?(_ resourceObject: OfflineTasksResourceObject, item: IncludedItem?) {
+	init?(_ resourceObject: OfflineTasksResourceObject, attributes: OfflineTasksAttributes, item: IncludedItem?) {
 		guard let item, case .album(let album) = item.resource else { return nil }
 		self.init(id: resourceObject.id, album: album, artists: item.artistObjects, artwork: item.artworkObject)
+		state = attributes.state.downloadState
 	}
 }
 
 private extension StorePlaylistTask {
-	init?(_ resourceObject: OfflineTasksResourceObject, item: IncludedItem?) {
+	init?(_ resourceObject: OfflineTasksResourceObject, attributes: OfflineTasksAttributes, item: IncludedItem?) {
 		guard let item, case .playlist(let playlist) = item.resource else { return nil }
 		self.init(id: resourceObject.id, playlist: playlist, artwork: item.artworkObject)
+		state = attributes.state.downloadState
 	}
 }
 
 private extension RemoveItemTask {
 	init?(
 		_ resourceObject: OfflineTasksResourceObject,
+		attributes: OfflineTasksAttributes,
 		itemData: OfflineTasksItemResourceIdentifier,
 		collectionData: OfflineTasksCollectionResourceIdentifier?
 	) {
@@ -671,5 +774,17 @@ private extension RemoveItemTask {
 			collectionResourceType: collectionData.type,
 			collectionResourceId: collectionData.id
 		)
+		state = attributes.state.downloadState
+	}
+}
+
+private extension OfflineTasksAttributes.State {
+	var downloadState: Download.State {
+		switch self {
+		case .pending: .pending
+		case .inProgress: .inProgress
+		case .failed: .failed
+		case .completed: .completed
+		}
 	}
 }

--- a/Sources/Offliner/Internal/OfflineStore.swift
+++ b/Sources/Offliner/Internal/OfflineStore.swift
@@ -251,7 +251,7 @@ final class OfflineStore {
 		return item
 	}
 
-	func getPlayableMediaItem(mediaType: OfflineMediaItemType, resourceId: String) async throws -> PlayableOfflineMediaItem? {
+	func getPlaybackAsset(mediaType: OfflineMediaItemType, resourceId: String) async throws -> OfflinePlaybackAsset? {
 		let row = try await databaseQueue.read { database in
 			try Row.fetchOne(
 				database,
@@ -269,7 +269,7 @@ final class OfflineStore {
 		let playbackMetadataJson: String? = row["playback_metadata"]
 
 		var renewals: [BookmarkRenewal] = []
-		let item = PlayableOfflineMediaItem(
+		let item = OfflinePlaybackAsset(
 			playbackMetadata: try playbackMetadataJson.map { try OfflineMediaItem.PlaybackMetadata.deserialize($0) },
 			mediaURL: try Self.resolveBookmark(row, column: "media_bookmark", renewals: &renewals),
 			licenseURL: try Self.resolveBookmarkIfPresent(row, column: "license_bookmark", renewals: &renewals)

--- a/Sources/Offliner/Internal/OfflineStore.swift
+++ b/Sources/Offliner/Internal/OfflineStore.swift
@@ -77,6 +77,99 @@ final class OfflineStore {
 		}
 	}
 
+	func getDownloadQueueEntries() throws -> [OfflineDownloadQueueEntry] {
+		try databaseQueue.read { database in
+			try Row.fetchAll(
+				database,
+				sql: """
+					SELECT resource_type, resource_id, parent_collection_type, parent_collection_id, state, progress
+					FROM offline_download_queue
+					ORDER BY resource_type, resource_id
+					"""
+			).compactMap(Self.downloadQueueEntry)
+		}
+	}
+
+	func getDownloadQueueEntry(resourceType: String, resourceId: String) throws -> OfflineDownloadQueueEntry? {
+		try databaseQueue.read { database in
+			try Row.fetchOne(
+				database,
+				sql: """
+					SELECT resource_type, resource_id, parent_collection_type, parent_collection_id, state, progress
+					FROM offline_download_queue
+					WHERE resource_type = ? AND resource_id = ?
+					""",
+				arguments: [resourceType, resourceId]
+			).flatMap(Self.downloadQueueEntry)
+		}
+	}
+
+	func setDownloadQueueEntry(_ entry: OfflineDownloadQueueEntry) throws {
+		let resource = OfflineResourceKey(entry.resource)
+		let parentCollection = entry.parentCollection.map(OfflineResourceKey.init)
+		writeLock.lock()
+		defer { writeLock.unlock() }
+		try ensureAcceptsWritesLocked()
+		try databaseQueue.write { database in
+			try database.execute(
+				sql: """
+					INSERT INTO offline_download_queue \
+					(resource_type, resource_id, parent_collection_type, parent_collection_id, state, progress)
+					VALUES (?, ?, ?, ?, ?, ?)
+					ON CONFLICT (resource_type, resource_id) DO UPDATE SET
+						parent_collection_type = excluded.parent_collection_type,
+						parent_collection_id = excluded.parent_collection_id,
+						state = excluded.state,
+						progress = excluded.progress,
+						updated_at = CURRENT_TIMESTAMP
+					""",
+				arguments: [
+					resource.resourceType,
+					resource.resourceId,
+					parentCollection?.resourceType,
+					parentCollection?.resourceId,
+					entry.state.storageValue,
+					entry.progress,
+				]
+			)
+		}
+	}
+
+	func deleteDownloadQueueEntry(resourceType: String, resourceId: String) throws {
+		writeLock.lock()
+		defer { writeLock.unlock() }
+		try ensureAcceptsWritesLocked()
+		try databaseQueue.write { database in
+			try database.execute(
+				sql: "DELETE FROM offline_download_queue WHERE resource_type = ? AND resource_id = ?",
+				arguments: [resourceType, resourceId]
+			)
+		}
+	}
+
+	private static func downloadQueueEntry(_ row: Row) -> OfflineDownloadQueueEntry? {
+		guard let resource = OfflineResourceKey(
+			resourceType: row["resource_type"],
+			resourceId: row["resource_id"]
+		).publicResource,
+		let state = OfflineDownloadQueueEntry.State(storageValue: row["state"])
+		else { return nil }
+
+		let parentCollection: OfflineResource?
+		if let parentType: String = row["parent_collection_type"],
+		   let parentId: String = row["parent_collection_id"] {
+			parentCollection = OfflineResourceKey(resourceType: parentType, resourceId: parentId).publicCollection
+		} else {
+			parentCollection = nil
+		}
+		return OfflineDownloadQueueEntry(
+			resource: resource,
+			parentCollection: parentCollection,
+			state: state,
+			progress: row["progress"]
+		)
+	}
+
 	func storeMediaItem(_ result: StoreItemTaskResult) throws {
 		writeLock.lock()
 		defer { writeLock.unlock() }
@@ -1152,5 +1245,25 @@ private extension OfflineMediaItem {
 			playbackMetadata: playbackMetadata,
 			artworkURL: try? OfflineStore.resolveBookmarkIfPresent(row, column: "artwork_bookmark", renewals: &renewals)
 		)
+	}
+}
+
+private extension OfflineDownloadQueueEntry.State {
+	init?(storageValue: String) {
+		switch storageValue {
+		case "queued": self = .queued
+		case "downloading": self = .downloading
+		case "failed_download": self = .failed(action: .download)
+		default: return nil
+		}
+	}
+
+	var storageValue: String {
+		switch self {
+		case .queued: "queued"
+		case .downloading: "downloading"
+		case .failed(.download): "failed_download"
+		case .failed(.remove): "failed_remove"
+		}
 	}
 }

--- a/Sources/Offliner/Internal/OfflineStore.swift
+++ b/Sources/Offliner/Internal/OfflineStore.swift
@@ -350,6 +350,24 @@ final class OfflineStore {
 		deleteFiles(for: bookmarksToDelete)
 	}
 
+	func invalidateMediaItem(resourceType: String, resourceId: String) throws {
+		writeLock.lock()
+		defer { writeLock.unlock() }
+		try ensureAcceptsWritesLocked()
+		var bookmarksToDelete: [Data] = []
+
+		try databaseQueue.inTransaction { database in
+			bookmarksToDelete = try collectBookmarks(resourceType: resourceType, resourceId: resourceId, database: database)
+			try database.execute(
+				sql: "DELETE FROM offline_item WHERE resource_type = ? AND resource_id = ?",
+				arguments: [resourceType, resourceId]
+			)
+			return .commit
+		}
+
+		deleteFiles(for: bookmarksToDelete)
+	}
+
 	func getCollection(collectionType: OfflineCollectionType, resourceId: String) async throws -> OfflineCollection? {
 		let row = try await databaseQueue.read { database in
 			try Row.fetchOne(

--- a/Sources/Offliner/Internal/OfflineStore.swift
+++ b/Sources/Offliner/Internal/OfflineStore.swift
@@ -27,6 +27,56 @@ final class OfflineStore {
 		self.databaseQueue = databaseQueue
 	}
 
+	func getResourceOperation(resourceType: String, resourceId: String) throws -> StoredResourceOperation? {
+		try databaseQueue.read { database in
+			try Row.fetchOne(
+				database,
+				sql: "SELECT action, state FROM offline_resource_operation WHERE resource_type = ? AND resource_id = ?",
+				arguments: [resourceType, resourceId]
+			).flatMap { row in
+				guard let action = InternalOfflineResourceAction(rawValue: row["action"]),
+					  let state = OfflineResourceState(storageValue: row["state"]) else { return nil }
+				return StoredResourceOperation(action: action, state: state)
+			}
+		}
+	}
+
+	func setResourceOperation(
+		resourceType: String,
+		resourceId: String,
+		action: InternalOfflineResourceAction,
+		state: OfflineResourceState
+	) throws {
+		writeLock.lock()
+		defer { writeLock.unlock() }
+		try ensureAcceptsWritesLocked()
+		try databaseQueue.write { database in
+			try database.execute(
+				sql: """
+					INSERT INTO offline_resource_operation (resource_type, resource_id, action, state)
+					VALUES (?, ?, ?, ?)
+					ON CONFLICT (resource_type, resource_id) DO UPDATE SET
+						action = excluded.action,
+						state = excluded.state,
+						updated_at = CURRENT_TIMESTAMP
+					""",
+				arguments: [resourceType, resourceId, action.rawValue, state.storageValue]
+			)
+		}
+	}
+
+	func deleteResourceOperation(resourceType: String, resourceId: String) throws {
+		writeLock.lock()
+		defer { writeLock.unlock() }
+		try ensureAcceptsWritesLocked()
+		try databaseQueue.write { database in
+			try database.execute(
+				sql: "DELETE FROM offline_resource_operation WHERE resource_type = ? AND resource_id = ?",
+				arguments: [resourceType, resourceId]
+			)
+		}
+	}
+
 	func storeMediaItem(_ result: StoreItemTaskResult) throws {
 		writeLock.lock()
 		defer { writeLock.unlock() }

--- a/Sources/Offliner/Internal/OfflineStore.swift
+++ b/Sources/Offliner/Internal/OfflineStore.swift
@@ -3,6 +3,8 @@ import GRDB
 
 final class OfflineStore {
 	private let databaseQueue: DatabaseQueue
+	private let writeLock = NSLock()
+	private var acceptsWrites = true
 
 	static func searchKey(_ value: String) -> String {
 		value.lowercased().folding(options: .diacriticInsensitive, locale: Locale(identifier: "en_US_POSIX"))
@@ -21,21 +23,14 @@ final class OfflineStore {
 		return try DatabaseQueue(path: path, configuration: configuration)
 	}
 
-	static func url() throws -> URL {
-		let appSupportURLs = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
-		guard let appSupportDirectory = appSupportURLs.first else {
-			throw FileStorageError.noApplicationSupportDirectory
-		}
-		let directory = appSupportDirectory.appendingPathComponent("Offliner", isDirectory: true)
-		try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-		return directory.appendingPathComponent("offline.sqlite")
-	}
-
 	init(_ databaseQueue: DatabaseQueue) {
 		self.databaseQueue = databaseQueue
 	}
 
 	func storeMediaItem(_ result: StoreItemTaskResult) throws {
+		writeLock.lock()
+		defer { writeLock.unlock() }
+		try ensureAcceptsWritesLocked()
 		let catalogMetadataJson = try result.catalogMetadata.serialize()
 		let playbackMetadataJson = try result.playbackMetadata?.serialize()
 
@@ -116,6 +111,9 @@ final class OfflineStore {
 	}
 
 	func storeCollection(_ result: StoreCollectionTaskResult) throws {
+		writeLock.lock()
+		defer { writeLock.unlock() }
+		try ensureAcceptsWritesLocked()
 		let catalogMetadataJson = try result.catalogMetadata.serialize()
 		let artworkBookmark = try result.artworkURL.map { try Self.makeBookmark(for: $0) }
 
@@ -143,6 +141,9 @@ final class OfflineStore {
 	}
 
 	func deleteCollection(resourceType: String, resourceId: String) throws {
+		writeLock.lock()
+		defer { writeLock.unlock() }
+		try ensureAcceptsWritesLocked()
 		var bookmarksToDelete: [Data] = []
 
 		try databaseQueue.inTransaction { database in
@@ -170,6 +171,9 @@ final class OfflineStore {
 		fromCollection collectionType: String,
 		collectionId: String
 	) throws {
+		writeLock.lock()
+		defer { writeLock.unlock() }
+		try ensureAcceptsWritesLocked()
 		var bookmarksToDelete: [Data] = []
 
 		try databaseQueue.inTransaction { database in
@@ -737,6 +741,31 @@ final class OfflineStore {
 		return ["media_bookmark", "license_bookmark", "artwork_bookmark"].compactMap { row?[$0] as Data? }
 	}
 
+	func invalidateWrites() {
+		writeLock.lock()
+		acceptsWrites = false
+		writeLock.unlock()
+	}
+
+	func allBookmarks() throws -> [Data] {
+		try databaseQueue.read { database in
+			let rows = try Row.fetchAll(database, sql: "SELECT media_bookmark, license_bookmark, artwork_bookmark FROM offline_item")
+			return rows.flatMap { row in
+				["media_bookmark", "license_bookmark", "artwork_bookmark"].compactMap { row[$0] as Data? }
+			}
+		}
+	}
+
+	private func ensureAcceptsWritesLocked() throws {
+		guard acceptsWrites else { throw OfflinerLifecycleError.reset }
+	}
+
+	private func ensureAcceptsWrites() throws {
+		writeLock.lock()
+		defer { writeLock.unlock() }
+		try ensureAcceptsWritesLocked()
+	}
+
 	private func deleteFiles(for bookmarks: [Data]) {
 		for bookmarkData in bookmarks {
 			try? FileStorage.delete(bookmark: bookmarkData)
@@ -1032,6 +1061,7 @@ extension OfflineStore {
 		guard !renewals.isEmpty else {
 			return
 		}
+		try ensureAcceptsWrites()
 
 		let chunkSize = 300
 

--- a/Sources/Offliner/Internal/OfflinerStorage.swift
+++ b/Sources/Offliner/Internal/OfflinerStorage.swift
@@ -1,0 +1,90 @@
+import CryptoKit
+import Foundation
+import GRDB
+
+final class OfflinerStorage {
+	private static let legacyResetLock = NSLock()
+	private static let rootName = "Offliner"
+	private static let accountsName = "Accounts"
+	private static let legacyMigrationMarker = ".account-scoped-storage-v1"
+
+	let rootDirectory: URL
+	let databaseQueue: DatabaseQueue
+	let offlineStore: OfflineStore
+	let fileStorage: FileStorage
+	let backgroundSessionIdentifier: String
+
+	init(installationId: String, baseDirectory: URL? = nil) throws {
+		let baseDirectory = try baseDirectory ?? Self.applicationSupportDirectory()
+		let offlinerRoot = baseDirectory.appendingPathComponent(Self.rootName, isDirectory: true)
+		let scope = Self.scope(for: installationId)
+		rootDirectory = offlinerRoot
+			.appendingPathComponent(Self.accountsName, isDirectory: true)
+			.appendingPathComponent(scope, isDirectory: true)
+		try FileManager.default.createDirectory(at: rootDirectory, withIntermediateDirectories: true)
+		try Self.migrateLegacyStorageIfNeeded(at: offlinerRoot, to: rootDirectory, scope: scope)
+
+		databaseQueue = try OfflineStore.makeDatabaseQueue(
+			path: rootDirectory.appendingPathComponent("offline.sqlite").path
+		)
+		try Migrations.run(databaseQueue)
+		offlineStore = OfflineStore(databaseQueue)
+		fileStorage = FileStorage(rootDirectory: rootDirectory.appendingPathComponent("Artifacts", isDirectory: true))
+		backgroundSessionIdentifier = "com.tidal.offliner.download.\(scope.prefix(32))"
+	}
+
+	func reset() throws {
+		let bookmarks = (try? offlineStore.allBookmarks()) ?? []
+		for bookmark in bookmarks {
+			try? FileStorage.delete(bookmark: bookmark)
+		}
+		try databaseQueue.close()
+		try? FileManager.default.removeItem(at: rootDirectory)
+	}
+
+	func invalidateWrites() {
+		offlineStore.invalidateWrites()
+		fileStorage.invalidateWrites()
+	}
+
+	private static func applicationSupportDirectory() throws -> URL {
+		guard let directory = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
+			throw FileStorageError.noApplicationSupportDirectory
+		}
+		return directory
+	}
+
+	private static func scope(for installationId: String) -> String {
+		SHA256.hash(data: Data(installationId.utf8)).map { String(format: "%02x", $0) }.joined()
+	}
+
+	private static func migrateLegacyStorageIfNeeded(at root: URL, to accountRoot: URL, scope: String) throws {
+		legacyResetLock.lock()
+		defer { legacyResetLock.unlock() }
+
+		try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+		let marker = root.appendingPathComponent(legacyMigrationMarker)
+		guard !FileManager.default.fileExists(atPath: marker.path) else { return }
+
+		for name in ["offline.sqlite", "offline.sqlite-shm", "offline.sqlite-wal"] {
+			let source = root.appendingPathComponent(name)
+			let destination = accountRoot.appendingPathComponent(name)
+			if FileManager.default.fileExists(atPath: source.path),
+			   !FileManager.default.fileExists(atPath: destination.path) {
+				try FileManager.default.moveItem(at: source, to: destination)
+			}
+		}
+
+		let artifactsRoot = accountRoot.appendingPathComponent("Artifacts", isDirectory: true)
+		try FileManager.default.createDirectory(at: artifactsRoot, withIntermediateDirectories: true)
+		for name in ["Artworks", "Licenses"] {
+			let source = root.appendingPathComponent(name, isDirectory: true)
+			let destination = artifactsRoot.appendingPathComponent(name, isDirectory: true)
+			if FileManager.default.fileExists(atPath: source.path),
+			   !FileManager.default.fileExists(atPath: destination.path) {
+				try FileManager.default.moveItem(at: source, to: destination)
+			}
+		}
+		try Data(scope.utf8).write(to: marker, options: .atomic)
+	}
+}

--- a/Sources/Offliner/Internal/ResourceStateTracker.swift
+++ b/Sources/Offliner/Internal/ResourceStateTracker.swift
@@ -45,6 +45,26 @@ struct OfflineResourceKey: Hashable, Sendable {
 			? ResourceId.me.stringValue
 			: resourceId
 	}
+
+	var publicResource: OfflineResource? {
+		if let type = OfflineMediaItemType(rawValue: resourceType) {
+			return .media(type: type, resourceId: resourceId)
+		}
+		return publicCollection
+	}
+
+	var publicCollection: OfflineResource? {
+		guard let type = OfflineCollectionType(rawValue: resourceType) else { return nil }
+		return .collection(type: type, resourceId: resourceId)
+	}
+}
+
+// MARK: - DownloadQueueTask
+
+struct DownloadQueueTask: Sendable {
+	let resource: OfflineResource
+	let parentCollection: OfflineResource?
+	let supportsProgress: Bool
 }
 
 // MARK: - ResourceStateTracker
@@ -56,11 +76,22 @@ actor ResourceStateTracker {
 		let resources: Set<OfflineResourceKey>
 	}
 
+	private struct QueueTaskState {
+		let root: OfflineResourceKey
+		let parentCollection: OfflineResource?
+		var state: OfflineResourceState
+		let supportsProgress: Bool
+		var progress: Double?
+	}
+
 	private let offlineStore: OfflineStore
 	private var taskStates: [String: TaskState] = [:]
+	private var queueTaskStates: [String: QueueTaskState] = [:]
 	private var transientStates: [OfflineResourceKey: (InternalOfflineResourceAction, OfflineResourceState)] = [:]
 	private var continuations: [OfflineResourceKey: [UUID: AsyncStream<OfflineResourceState>.Continuation]] = [:]
+	private var queueContinuations: [UUID: AsyncStream<[OfflineDownloadQueueEntry]>.Continuation] = [:]
 	private var lastEmittedStates: [OfflineResourceKey: OfflineResourceState] = [:]
+	private var lastEmittedQueue: [OfflineDownloadQueueEntry]?
 	private var isShutdown = false
 
 	init(offlineStore: OfflineStore) {
@@ -95,6 +126,25 @@ actor ResourceStateTracker {
 			}
 			continuation.onTermination = { [weak self] _ in
 				Task { await self?.removeContinuation(id, for: resource) }
+			}
+		}
+	}
+
+	func downloadQueueSnapshot() throws -> [OfflineDownloadQueueEntry] {
+		guard !isShutdown else { return [] }
+		return try offlineStore.getDownloadQueueEntries()
+	}
+
+	func observeDownloadQueue() throws -> AsyncStream<[OfflineDownloadQueueEntry]> {
+		guard !isShutdown else { return AsyncStream { $0.finish() } }
+		let initial = try downloadQueueSnapshot()
+		lastEmittedQueue = initial
+		return AsyncStream { continuation in
+			let id = UUID()
+			queueContinuations[id] = continuation
+			continuation.yield(initial)
+			continuation.onTermination = { [weak self] _ in
+				Task { await self?.removeQueueContinuation(id) }
 			}
 		}
 	}
@@ -142,16 +192,42 @@ actor ResourceStateTracker {
 				action: action,
 				state: state
 			)
+			if action == .store, let publicResource = resource.publicResource {
+				queueTaskStates = queueTaskStates.filter { $0.value.root != resource }
+				try offlineStore.setDownloadQueueEntry(OfflineDownloadQueueEntry(
+					resource: publicResource,
+					parentCollection: nil,
+					state: .queued,
+					progress: nil
+				))
+			} else if action == .remove {
+				queueTaskStates = queueTaskStates.filter { $0.value.root != resource }
+				try offlineStore.deleteDownloadQueueEntry(
+					resourceType: resource.resourceType,
+					resourceId: resource.resourceId
+				)
+			}
 		} catch {
 			transientStates.removeValue(forKey: resource)
+			try? offlineStore.deleteResourceOperation(resourceType: resource.resourceType, resourceId: resource.resourceId)
 			throw error
 		}
 		emitChanges(for: [resource])
+		emitDownloadQueueIfChanged()
 		return true
 	}
 
 	func registrationFailed(_ action: InternalOfflineResourceAction, for resource: OfflineResourceKey) {
 		setTransient(action: action, state: .failed(action: action.publicAction), for: resource, persist: true)
+		if action == .store, let publicResource = resource.publicResource {
+			try? offlineStore.setDownloadQueueEntry(OfflineDownloadQueueEntry(
+				resource: publicResource,
+				parentCollection: nil,
+				state: .failed(action: .download),
+				progress: nil
+			))
+			emitDownloadQueueIfChanged()
+		}
 	}
 
 	func resolve(_ resource: OfflineResourceKey, state: OfflineResourceState) {
@@ -160,15 +236,19 @@ actor ResourceStateTracker {
 		}
 		transientStates[resource] = (.store, state)
 		try? offlineStore.deleteResourceOperation(resourceType: resource.resourceType, resourceId: resource.resourceId)
+		try? offlineStore.deleteDownloadQueueEntry(resourceType: resource.resourceType, resourceId: resource.resourceId)
+		queueTaskStates = queueTaskStates.filter { $0.value.root != resource }
 		emitChanges(for: [resource])
+		emitDownloadQueueIfChanged()
 	}
 
 	func record(
 		taskId: String,
 		action: InternalOfflineResourceAction,
 		state: OfflineResourceState,
-		resources: Set<OfflineResourceKey>
-	) {
+		resources: Set<OfflineResourceKey>,
+		downloadQueueTask: DownloadQueueTask?
+	) throws {
 		guard !isShutdown else {
 			return
 		}
@@ -183,6 +263,9 @@ actor ResourceStateTracker {
 			}
 			persistEffectiveOperation(for: resource)
 		}
+		if action == .store, let downloadQueueTask {
+			try recordDownloadQueueTask(taskId: taskId, state: state, task: downloadQueueTask)
+		}
 		emitChanges(for: affected)
 	}
 
@@ -195,7 +278,19 @@ actor ResourceStateTracker {
 		for resource in task.resources {
 			persistEffectiveOperation(for: resource)
 		}
+		if var queueTask = queueTaskStates[taskId] {
+			queueTask.state = state
+			queueTaskStates[taskId] = queueTask
+			persistDownloadQueue(root: queueTask.root)
+		}
 		emitChanges(for: task.resources)
+	}
+
+	func updateProgress(taskId: String, progress: Double) {
+		guard !isShutdown, var task = queueTaskStates[taskId] else { return }
+		task.progress = min(max(progress, 0), 1)
+		queueTaskStates[taskId] = task
+		persistDownloadQueue(root: task.root)
 	}
 
 	func finish(taskId: String, succeeded: Bool) {
@@ -207,6 +302,11 @@ actor ResourceStateTracker {
 			taskStates[taskId] = task
 			for resource in task.resources {
 				persistEffectiveOperation(for: resource)
+			}
+			if var queueTask = queueTaskStates[taskId] {
+				queueTask.state = .failed(action: .download)
+				queueTaskStates[taskId] = queueTask
+				persistDownloadQueue(root: queueTask.root)
 			}
 			emitChanges(for: task.resources)
 			return
@@ -220,6 +320,12 @@ actor ResourceStateTracker {
 			}
 			persistEffectiveOperation(for: resource)
 		}
+		if var queueTask = queueTaskStates[taskId] {
+			queueTask.state = .downloaded
+			queueTask.progress = queueTask.supportsProgress ? 1 : nil
+			queueTaskStates[taskId] = queueTask
+			persistDownloadQueue(root: queueTask.root)
+		}
 		emitChanges(for: task.resources)
 	}
 
@@ -232,9 +338,15 @@ actor ResourceStateTracker {
 			continuation.finish()
 		}
 		continuations.removeAll()
+		for continuation in queueContinuations.values {
+			continuation.finish()
+		}
+		queueContinuations.removeAll()
 		taskStates.removeAll()
+		queueTaskStates.removeAll()
 		transientStates.removeAll()
 		lastEmittedStates.removeAll()
+		lastEmittedQueue = nil
 	}
 
 	private func setTransient(
@@ -278,6 +390,123 @@ actor ResourceStateTracker {
 		}
 	}
 
+	private func recordDownloadQueueTask(
+		taskId: String,
+		state: OfflineResourceState,
+		task: DownloadQueueTask
+	) throws {
+		let resource = OfflineResourceKey(task.resource)
+		let parent = task.parentCollection.map(OfflineResourceKey.init)
+		let root: OfflineResourceKey
+		let hasCollectionDownloadIntent = state == .queued
+			|| state == .downloading
+			|| state == .failed(action: .download)
+		if parent == nil, resource.publicCollection != nil, hasCollectionDownloadIntent {
+			root = resource
+			let storedMembers = try offlineStore.getDownloadQueueEntries().filter {
+				$0.parentCollection.map(OfflineResourceKey.init) == resource
+			}
+			for member in storedMembers {
+				let memberKey = OfflineResourceKey(member.resource)
+				try offlineStore.deleteDownloadQueueEntry(
+					resourceType: memberKey.resourceType,
+					resourceId: memberKey.resourceId
+				)
+			}
+			queueTaskStates = queueTaskStates.mapValues { existing in
+				guard existing.parentCollection.map(OfflineResourceKey.init) == resource else { return existing }
+				return QueueTaskState(
+					root: resource,
+					parentCollection: nil,
+					state: existing.state,
+					supportsProgress: existing.supportsProgress,
+					progress: existing.progress
+				)
+			}
+		} else if let parent,
+		   try offlineStore.getDownloadQueueEntry(resourceType: parent.resourceType, resourceId: parent.resourceId) != nil {
+			root = parent
+			if resource != parent {
+				try offlineStore.deleteDownloadQueueEntry(resourceType: resource.resourceType, resourceId: resource.resourceId)
+				queueTaskStates = queueTaskStates.mapValues { existing in
+					guard existing.root == resource else { return existing }
+					return QueueTaskState(
+						root: parent,
+						parentCollection: nil,
+						state: existing.state,
+						supportsProgress: existing.supportsProgress,
+						progress: existing.progress
+					)
+				}
+			}
+		} else if try offlineStore.getDownloadQueueEntry(
+			resourceType: resource.resourceType,
+			resourceId: resource.resourceId
+		) != nil {
+			root = resource
+		} else if let parent {
+			root = parent
+		} else {
+			root = resource
+		}
+
+		queueTaskStates[taskId] = QueueTaskState(
+			root: root,
+			parentCollection: root == resource ? task.parentCollection : nil,
+			state: state,
+			supportsProgress: task.supportsProgress,
+			progress: nil
+		)
+		try persistDownloadQueueThrowing(root: root)
+	}
+
+	private func persistDownloadQueue(root: OfflineResourceKey) {
+		try? persistDownloadQueueThrowing(root: root)
+	}
+
+	private func persistDownloadQueueThrowing(root: OfflineResourceKey) throws {
+		let tasks = queueTaskStates.values.filter { $0.root == root }
+		let failed = tasks.contains { $0.state == .failed(action: .download) }
+		let downloading = tasks.contains { $0.state == .downloading }
+		let queued = tasks.contains { $0.state == .queued }
+		guard failed || downloading || queued else {
+			try offlineStore.deleteDownloadQueueEntry(resourceType: root.resourceType, resourceId: root.resourceId)
+			queueTaskStates = queueTaskStates.filter { $0.value.root != root }
+			emitDownloadQueueIfChanged()
+			return
+		}
+
+		guard let resource = root.publicResource else { return }
+		let state: OfflineDownloadQueueEntry.State = if failed {
+			.failed(action: .download)
+		} else if downloading {
+			.downloading
+		} else {
+			.queued
+		}
+		let progressTasks = tasks.filter(\.supportsProgress)
+		let hasKnownProgress = progressTasks.contains { $0.progress != nil }
+		let progress = hasKnownProgress && !progressTasks.isEmpty
+			? progressTasks.reduce(0) { $0 + ($1.progress ?? 0) } / Double(progressTasks.count)
+			: nil
+		let parentCollection = tasks.lazy.compactMap(\.parentCollection).first
+		try offlineStore.setDownloadQueueEntry(OfflineDownloadQueueEntry(
+			resource: resource,
+			parentCollection: parentCollection,
+			state: state,
+			progress: progress
+		))
+		emitDownloadQueueIfChanged()
+	}
+
+	private func emitDownloadQueueIfChanged() {
+		guard let queue = try? offlineStore.getDownloadQueueEntries(), queue != lastEmittedQueue else { return }
+		lastEmittedQueue = queue
+		for continuation in queueContinuations.values {
+			continuation.yield(queue)
+		}
+	}
+
 	private func emitChanges(for resources: Set<OfflineResourceKey>) {
 		for resource in resources {
 			guard let state = effectiveState(for: resource), state != lastEmittedStates[resource] else {
@@ -295,6 +524,10 @@ actor ResourceStateTracker {
 		if continuations[resource]?.isEmpty == true {
 			continuations.removeValue(forKey: resource)
 		}
+	}
+
+	private func removeQueueContinuation(_ id: UUID) {
+		queueContinuations.removeValue(forKey: id)
 	}
 }
 

--- a/Sources/Offliner/Internal/ResourceStateTracker.swift
+++ b/Sources/Offliner/Internal/ResourceStateTracker.swift
@@ -1,0 +1,350 @@
+import Foundation
+
+// MARK: - InternalOfflineResourceAction
+
+enum InternalOfflineResourceAction: String, Sendable {
+	case store
+	case remove
+
+	var publicAction: OfflineResourceAction {
+		switch self {
+		case .store: .download
+		case .remove: .remove
+		}
+	}
+}
+
+// MARK: - StoredResourceOperation
+
+struct StoredResourceOperation: Sendable {
+	let action: InternalOfflineResourceAction
+	let state: OfflineResourceState
+}
+
+// MARK: - OfflineResourceKey
+
+struct OfflineResourceKey: Hashable, Sendable {
+	let resourceType: String
+	let resourceId: String
+
+	init(_ resource: OfflineResource) {
+		switch resource {
+		case let .media(type, resourceId):
+			self.init(resourceType: type.rawValue, resourceId: resourceId)
+		case let .collection(type, resourceId):
+			self.init(
+				resourceType: type.rawValue,
+				resourceId: type == .userCollectionTracks ? ResourceId.me.stringValue : resourceId
+			)
+		}
+	}
+
+	init(resourceType: String, resourceId: String) {
+		self.resourceType = resourceType
+		self.resourceId = resourceType == OfflineCollectionType.userCollectionTracks.rawValue
+			? ResourceId.me.stringValue
+			: resourceId
+	}
+}
+
+// MARK: - ResourceStateTracker
+
+actor ResourceStateTracker {
+	private struct TaskState {
+		let action: InternalOfflineResourceAction
+		var state: OfflineResourceState
+		let resources: Set<OfflineResourceKey>
+	}
+
+	private let offlineStore: OfflineStore
+	private var taskStates: [String: TaskState] = [:]
+	private var transientStates: [OfflineResourceKey: (InternalOfflineResourceAction, OfflineResourceState)] = [:]
+	private var continuations: [OfflineResourceKey: [UUID: AsyncStream<OfflineResourceState>.Continuation]] = [:]
+	private var lastEmittedStates: [OfflineResourceKey: OfflineResourceState] = [:]
+	private var isShutdown = false
+
+	init(offlineStore: OfflineStore) {
+		self.offlineStore = offlineStore
+	}
+
+	func state(for resource: OfflineResourceKey) throws -> OfflineResourceState? {
+		guard !isShutdown else {
+			return nil
+		}
+		if let state = effectiveState(for: resource) {
+			return state
+		}
+		return try offlineStore.getResourceOperation(
+			resourceType: resource.resourceType,
+			resourceId: resource.resourceId
+		)?.state
+	}
+
+	func observe(_ resource: OfflineResourceKey) -> AsyncStream<OfflineResourceState> {
+		guard !isShutdown else {
+			return AsyncStream { $0.finish() }
+		}
+		return AsyncStream { continuation in
+			let id = UUID()
+			continuations[resource, default: [:]][id] = continuation
+			if let state = effectiveState(for: resource) ?? (try? offlineStore.getResourceOperation(
+				resourceType: resource.resourceType,
+				resourceId: resource.resourceId
+			))?.state {
+				continuation.yield(state)
+			}
+			continuation.onTermination = { [weak self] _ in
+				Task { await self?.removeContinuation(id, for: resource) }
+			}
+		}
+	}
+
+	func begin(_ action: InternalOfflineResourceAction, for resource: OfflineResourceKey) throws -> Bool {
+		guard !isShutdown else {
+			return false
+		}
+		let activeTasks = taskStates.values.filter { $0.resources.contains(resource) && $0.state.isActiveOperation }
+		if let activeTask = activeTasks.max(by: { $0.state.priority < $1.state.priority }) {
+			if activeTask.action == action {
+				return false
+			}
+			throw OfflineResourceOperationError.conflictingOperationInProgress(currentState: activeTask.state)
+		}
+		let current: OfflineResourceState? = if let state = effectiveState(for: resource) {
+			state
+		} else {
+			try offlineStore.getResourceOperation(
+				resourceType: resource.resourceType,
+				resourceId: resource.resourceId
+			)?.state
+		}
+
+		if let current {
+			switch (action, current) {
+			case (.store, .queued), (.store, .downloading), (.remove, .removing):
+				return false
+			case (.store, .removing), (.remove, .queued), (.remove, .downloading):
+				throw OfflineResourceOperationError.conflictingOperationInProgress(currentState: current)
+			default:
+				break
+			}
+		}
+		taskStates = taskStates.filter { _, task in
+			!task.resources.contains(resource) || task.state.isActiveOperation
+		}
+
+		let state: OfflineResourceState = action == .store ? .queued : .removing
+		transientStates[resource] = (action, state)
+		do {
+			try offlineStore.setResourceOperation(
+				resourceType: resource.resourceType,
+				resourceId: resource.resourceId,
+				action: action,
+				state: state
+			)
+		} catch {
+			transientStates.removeValue(forKey: resource)
+			throw error
+		}
+		emitChanges(for: [resource])
+		return true
+	}
+
+	func registrationFailed(_ action: InternalOfflineResourceAction, for resource: OfflineResourceKey) {
+		setTransient(action: action, state: .failed(action: action.publicAction), for: resource, persist: true)
+	}
+
+	func resolve(_ resource: OfflineResourceKey, state: OfflineResourceState) {
+		guard !isShutdown else {
+			return
+		}
+		transientStates[resource] = (.store, state)
+		try? offlineStore.deleteResourceOperation(resourceType: resource.resourceType, resourceId: resource.resourceId)
+		emitChanges(for: [resource])
+	}
+
+	func record(
+		taskId: String,
+		action: InternalOfflineResourceAction,
+		state: OfflineResourceState,
+		resources: Set<OfflineResourceKey>
+	) {
+		guard !isShutdown else {
+			return
+		}
+		let affected = resources.union(taskStates[taskId]?.resources ?? [])
+		taskStates[taskId] = TaskState(action: action, state: state, resources: resources)
+		for resource in resources {
+			if let transientState = transientStates[resource],
+			   transientState.0 == action,
+			   !transientState.1.isFailure
+			{
+				transientStates.removeValue(forKey: resource)
+			}
+			persistEffectiveOperation(for: resource)
+		}
+		emitChanges(for: affected)
+	}
+
+	func update(taskId: String, state: OfflineResourceState) {
+		guard !isShutdown, var task = taskStates[taskId] else {
+			return
+		}
+		task.state = state
+		taskStates[taskId] = task
+		for resource in task.resources {
+			persistEffectiveOperation(for: resource)
+		}
+		emitChanges(for: task.resources)
+	}
+
+	func finish(taskId: String, succeeded: Bool) {
+		guard !isShutdown, var task = taskStates[taskId] else {
+			return
+		}
+		if !succeeded {
+			task.state = .failed(action: task.action.publicAction)
+			taskStates[taskId] = task
+			for resource in task.resources {
+				persistEffectiveOperation(for: resource)
+			}
+			emitChanges(for: task.resources)
+			return
+		}
+
+		taskStates.removeValue(forKey: taskId)
+		for resource in task.resources {
+			let finalState: OfflineResourceState = task.action == .store ? .downloaded : .notDownloaded
+			if transientStates[resource]?.1.isFailure != true {
+				transientStates[resource] = (task.action, finalState)
+			}
+			persistEffectiveOperation(for: resource)
+		}
+		emitChanges(for: task.resources)
+	}
+
+	func shutdown() {
+		guard !isShutdown else {
+			return
+		}
+		isShutdown = true
+		for continuation in continuations.values.flatMap(\.values) {
+			continuation.finish()
+		}
+		continuations.removeAll()
+		taskStates.removeAll()
+		transientStates.removeAll()
+		lastEmittedStates.removeAll()
+	}
+
+	private func setTransient(
+		action: InternalOfflineResourceAction,
+		state: OfflineResourceState,
+		for resource: OfflineResourceKey,
+		persist: Bool
+	) {
+		transientStates[resource] = (action, state)
+		if persist {
+			persistEffectiveOperation(for: resource)
+		}
+		emitChanges(for: [resource])
+	}
+
+	private func effectiveState(for resource: OfflineResourceKey) -> OfflineResourceState? {
+		let taskValues = taskStates.values.filter { $0.resources.contains(resource) }.map(\.state)
+		let values = taskValues + [transientStates[resource]?.1].compactMap { $0 }
+		return values.max { $0.priority < $1.priority }
+	}
+
+	private func persistEffectiveOperation(for resource: OfflineResourceKey) {
+		let taskOperations = taskStates.values
+			.filter { $0.resources.contains(resource) && ($0.state.isActiveOperation || $0.state.isFailure) }
+			.map { (action: $0.action, state: $0.state) }
+		let transientOperation = transientStates[resource].flatMap { operation in
+			operation.1.isActiveOperation || operation.1.isFailure ? operation : nil
+		}.map { (action: $0.0, state: $0.1) }
+		let operation = (taskOperations + [transientOperation].compactMap { $0 })
+			.max { $0.state.priority < $1.state.priority }
+
+		if let operation {
+			try? offlineStore.setResourceOperation(
+				resourceType: resource.resourceType,
+				resourceId: resource.resourceId,
+				action: operation.action,
+				state: operation.state
+			)
+		} else {
+			try? offlineStore.deleteResourceOperation(resourceType: resource.resourceType, resourceId: resource.resourceId)
+		}
+	}
+
+	private func emitChanges(for resources: Set<OfflineResourceKey>) {
+		for resource in resources {
+			guard let state = effectiveState(for: resource), state != lastEmittedStates[resource] else {
+				continue
+			}
+			lastEmittedStates[resource] = state
+			for continuation in continuations[resource]?.values ?? [:].values {
+				continuation.yield(state)
+			}
+		}
+	}
+
+	private func removeContinuation(_ id: UUID, for resource: OfflineResourceKey) {
+		continuations[resource]?.removeValue(forKey: id)
+		if continuations[resource]?.isEmpty == true {
+			continuations.removeValue(forKey: resource)
+		}
+	}
+}
+
+extension OfflineResourceState {
+	var isActiveOperation: Bool {
+		switch self {
+		case .queued, .downloading, .removing: true
+		case .notDownloaded, .downloaded, .failed: false
+		}
+	}
+
+	var isFailure: Bool {
+		if case .failed = self {
+			return true
+		}
+		return false
+	}
+
+	var priority: Int {
+		switch self {
+		case .failed: 6
+		case .removing: 5
+		case .downloading: 4
+		case .queued: 3
+		case .downloaded: 2
+		case .notDownloaded: 1
+		}
+	}
+
+	var storageValue: String {
+		switch self {
+		case .notDownloaded: "not_downloaded"
+		case .queued: "queued"
+		case .downloading: "downloading"
+		case .downloaded: "downloaded"
+		case .removing: "removing"
+		case let .failed(action): "failed_\(action.rawValue)"
+		}
+	}
+
+	init?(storageValue: String) {
+		switch storageValue {
+		case "not_downloaded": self = .notDownloaded
+		case "queued": self = .queued
+		case "downloading": self = .downloading
+		case "downloaded": self = .downloaded
+		case "removing": self = .removing
+		case "failed_download": self = .failed(action: .download)
+		case "failed_remove": self = .failed(action: .remove)
+		default: return nil
+		}
+	}
+}

--- a/Sources/Offliner/Internal/Resources/Migrations/V000003_offline_resource_operations.sql
+++ b/Sources/Offliner/Internal/Resources/Migrations/V000003_offline_resource_operations.sql
@@ -1,0 +1,10 @@
+CREATE TABLE offline_resource_operation
+(
+    resource_type TEXT NOT NULL,
+    resource_id   TEXT NOT NULL,
+    action        TEXT NOT NULL,
+    state         TEXT NOT NULL,
+    updated_at    TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (resource_type, resource_id)
+);

--- a/Sources/Offliner/Internal/Resources/Migrations/V000004_offline_download_queue.sql
+++ b/Sources/Offliner/Internal/Resources/Migrations/V000004_offline_download_queue.sql
@@ -1,0 +1,12 @@
+CREATE TABLE offline_download_queue
+(
+    resource_type          TEXT NOT NULL,
+    resource_id            TEXT NOT NULL,
+    parent_collection_type TEXT,
+    parent_collection_id   TEXT,
+    state                  TEXT NOT NULL,
+    progress               DOUBLE,
+    updated_at             TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (resource_type, resource_id)
+);

--- a/Sources/Offliner/Internal/TaskRunner.swift
+++ b/Sources/Offliner/Internal/TaskRunner.swift
@@ -64,14 +64,16 @@ actor TaskRunner {
 			artworkDownloader: artworkDownloader,
 			mediaDownloader: mediaDownloader,
 			manifestFetcher: trackManifestFetcher,
-			licenseDownloader: licenseDownloader
+			licenseDownloader: licenseDownloader,
+			resourceStateTracker: resourceStateTracker
 		)
 		self.storeVideoHandler = StoreVideoHandler(
 			offlineStore: offlineStore,
 			artworkDownloader: artworkDownloader,
 			mediaDownloader: mediaDownloader,
 			manifestFetcher: videoManifestFetcher,
-			licenseDownloader: licenseDownloader
+			licenseDownloader: licenseDownloader,
+			resourceStateTracker: resourceStateTracker
 		)
 		self.storeAlbumHandler = StoreAlbumHandler(
 			offlineStore: offlineStore,
@@ -111,6 +113,11 @@ actor TaskRunner {
 	func synchronizeState() async {
 		guard !isShutdown else { return }
 		try? await refresh()
+	}
+
+	func synchronizeDownloadQueue() async throws {
+		guard !isShutdown else { return }
+		try await refresh()
 	}
 
 	func setAllowDownloadsOnExpensiveNetworks(_ allowed: Bool) {
@@ -160,15 +167,17 @@ actor TaskRunner {
 			try Task.checkCancellation()
 			guard !isShutdown else { return }
 
-			for task in page.tasks where taskIds.insert(task.id).inserted {
-				taskActions[task.id] = task.action
+			for task in page.tasks where !taskIds.contains(task.id) {
 				let state = task.resourceState
-				await resourceStateTracker.record(
+				try await resourceStateTracker.record(
 					taskId: task.id,
 					action: task.action,
 					state: state,
-					resources: task.resourceKeys
+					resources: task.resourceKeys,
+					downloadQueueTask: task.downloadQueueTask
 				)
+				guard taskIds.insert(task.id).inserted else { continue }
+				taskActions[task.id] = task.action
 				guard task.state == .pending || task.state == .inProgress else { continue }
 				let pendingTask = handle(task)
 				pendingTasks.append(pendingTask)

--- a/Sources/Offliner/Internal/TaskRunner.swift
+++ b/Sources/Offliner/Internal/TaskRunner.swift
@@ -19,10 +19,12 @@ actor TaskRunner {
 	private let network: Network
 	private let mediaDownloader: MediaDownloaderProtocol
 	private let licenseDownloader: LicenseDownloader
+	private let resourceStateTracker: ResourceStateTracker
 
 	private var pendingTasks: [InternalTask] = []
 	private var runningTasks: [InternalTask] = []
 	private var taskIds: Set<String> = []
+	private var taskActions: [String: InternalOfflineResourceAction] = [:]
 
 	private var processTask: Task<Void, Never>?
 	private var rerunRequested = false
@@ -42,6 +44,7 @@ actor TaskRunner {
 		artworkDownloader: ArtworkDownloaderProtocol,
 		mediaDownloader: MediaDownloaderProtocol,
 		licenseDownloader: LicenseDownloader,
+		resourceStateTracker: ResourceStateTracker,
 		trackManifestFetcher: TrackManifestFetcherProtocol,
 		videoManifestFetcher: VideoManifestFetcherProtocol
 	) {
@@ -50,6 +53,7 @@ actor TaskRunner {
 		self.network = Network()
 		self.mediaDownloader = mediaDownloader
 		self.licenseDownloader = licenseDownloader
+		self.resourceStateTracker = resourceStateTracker
 
 		let (stream, continuation) = AsyncStream<Download>.makeStream()
 		self.newDownloads = stream
@@ -104,6 +108,11 @@ actor TaskRunner {
 		}
 	}
 
+	func synchronizeState() async {
+		guard !isShutdown else { return }
+		try? await refresh()
+	}
+
 	func setAllowDownloadsOnExpensiveNetworks(_ allowed: Bool) {
 		guard !isShutdown else { return }
 		allowDownloadsOnExpensiveNetworks = allowed
@@ -135,26 +144,41 @@ actor TaskRunner {
 		pendingTasks.removeAll()
 		runningTasks.removeAll()
 		taskIds.removeAll()
+		taskActions.removeAll()
 		currentDownloads.removeAll()
 		downloadsContinuation?.finish()
 		downloadsContinuation = nil
+		await resourceStateTracker.shutdown()
 	}
 
 	private func refresh() async throws {
 		try Task.checkCancellation()
 		guard !isShutdown else { return }
-		let (tasks, _) = try await offlineApiClient.getTasks(cursor: nil)
-		try Task.checkCancellation()
-		guard !isShutdown else { return }
+		var cursor: String?
+		repeat {
+			let page = try await offlineApiClient.getTasks(cursor: cursor)
+			try Task.checkCancellation()
+			guard !isShutdown else { return }
 
-		for task in tasks where taskIds.insert(task.id).inserted {
-			let pendingTask = handle(task)
-			pendingTasks.append(pendingTask)
-			if let download = pendingTask.download {
-				currentDownloads.append(download)
-				downloadsContinuation?.yield(download)
+			for task in page.tasks where taskIds.insert(task.id).inserted {
+				taskActions[task.id] = task.action
+				let state = task.resourceState
+				await resourceStateTracker.record(
+					taskId: task.id,
+					action: task.action,
+					state: state,
+					resources: task.resourceKeys
+				)
+				guard task.state == .pending || task.state == .inProgress else { continue }
+				let pendingTask = handle(task)
+				pendingTasks.append(pendingTask)
+				if let download = pendingTask.download {
+					currentDownloads.append(download)
+					downloadsContinuation?.yield(download)
+				}
 			}
-		}
+			cursor = page.cursor
+		} while cursor != nil
 	}
 
 	private func handle(_ offlineTask: OfflineTask) -> InternalTask {
@@ -166,6 +190,7 @@ actor TaskRunner {
 		case .storeUserCollectionTracks(let task): storeUserCollectionTracksHandler.handle(task)
 		case .removeItem(let task): removeItemHandler.handle(task)
 		case .removeCollection(let task): removeCollectionHandler.handle(task)
+		case .terminal: preconditionFailure("Terminal offline tasks are never executed")
 		}
 	}
 
@@ -200,9 +225,15 @@ actor TaskRunner {
 
 	private func getTask() -> InternalTask? {
 		guard !isShutdown, !Task.isCancelled else { return nil }
-		let runningKeys = Set(runningTasks.map(\.concurrencyKey))
-
-		guard let index = pendingTasks.firstIndex(where: { !runningKeys.contains($0.concurrencyKey) }) else {
+		guard let index = pendingTasks.firstIndex(where: { candidate in
+			runningTasks.allSatisfy { running in
+				guard candidate.concurrencyKey != running.concurrencyKey else { return false }
+				let actionsDiffer = taskActions[candidate.id] != taskActions[running.id]
+				guard actionsDiffer else { return true }
+				let includesCollectionWideOperation = candidate.isCollectionWide || running.isCollectionWide
+				return !includesCollectionWideOperation || candidate.resourceKeys.isDisjoint(with: running.resourceKeys)
+			}
+		}) else {
 			return nil
 		}
 
@@ -230,11 +261,14 @@ actor TaskRunner {
 		} catch {
 			Self.logger.error("Failed to mark task \(task.id, privacy: .public) as in progress, skipping it: \(error, privacy: .public)")
 			await task.download?.updateState(.failed)
+			await resourceStateTracker.finish(taskId: task.id, succeeded: false)
 			finish(task)
 			return
 		}
 
 		await task.download?.updateState(.inProgress)
+		let activeState: OfflineResourceState = taskActions[task.id] == .remove ? .removing : .downloading
+		await resourceStateTracker.update(taskId: task.id, state: activeState)
 
 		do {
 			try await task.run()
@@ -242,6 +276,7 @@ actor TaskRunner {
 			guard !isShutdown else { throw CancellationError() }
 			await task.download?.updateState(.completed)
 			try? await offlineApiClient.updateTask(taskId: task.id, state: .completed)
+			await resourceStateTracker.finish(taskId: task.id, succeeded: true)
 		} catch is CancellationError {
 			finish(task)
 			return
@@ -253,6 +288,7 @@ actor TaskRunner {
 			Self.logger.error("Task \(task.id, privacy: .public) failed: \(error, privacy: .public)")
 			await task.download?.updateState(.failed)
 			try? await offlineApiClient.updateTask(taskId: task.id, state: .failed)
+			await resourceStateTracker.finish(taskId: task.id, succeeded: false)
 		}
 
 		finish(task)
@@ -261,6 +297,7 @@ actor TaskRunner {
 	private func finish(_ task: InternalTask) {
 		runningTasks.removeAll { $0 === task }
 		taskIds.remove(task.id)
+		taskActions.removeValue(forKey: task.id)
 		if let download = task.download {
 			currentDownloads.removeAll { $0 === download }
 		}
@@ -311,6 +348,7 @@ protocol InternalTask: AnyObject {
 	var id: String { get }
 	var download: Download? { get }
 	var concurrencyKey: OfflineTaskConcurrencyKey { get }
+	var resourceKeys: Set<OfflineResourceKey> { get }
 	func isDownloadTask(for collection: OfflineCollectionReference) -> Bool
 	func run() async throws
 }
@@ -320,5 +358,34 @@ extension InternalTask {
 
 	func isDownloadTask(for collection: OfflineCollectionReference) -> Bool {
 		download?.relatedCollection == collection
+	}
+
+	var resourceKeys: Set<OfflineResourceKey> {
+		var keys = Set([OfflineResourceKey(
+			resourceType: concurrencyKey.resourceType,
+			resourceId: concurrencyKey.resourceId
+		)])
+		if let collectionType = concurrencyKey.collectionType, let collectionId = concurrencyKey.collectionId {
+			keys.insert(OfflineResourceKey(resourceType: collectionType, resourceId: collectionId))
+		}
+		return keys
+	}
+
+	var isCollectionWide: Bool {
+		OfflineCollectionType(rawValue: concurrencyKey.resourceType) != nil
+	}
+}
+
+private extension OfflineTask {
+	var resourceState: OfflineResourceState {
+		switch (action, state) {
+		case (.store, .pending): .queued
+		case (.store, .inProgress): .downloading
+		case (.store, .failed): .failed(action: .download)
+		case (.store, .completed): .downloaded
+		case (.remove, .pending), (.remove, .inProgress): .removing
+		case (.remove, .failed): .failed(action: .remove)
+		case (.remove, .completed): .notDownloaded
+		}
 	}
 }

--- a/Sources/Offliner/Internal/TaskRunner.swift
+++ b/Sources/Offliner/Internal/TaskRunner.swift
@@ -17,6 +17,8 @@ actor TaskRunner {
 
 	private let offlineApiClient: OfflineApiClientProtocol
 	private let network: Network
+	private let mediaDownloader: MediaDownloaderProtocol
+	private let licenseDownloader: LicenseDownloader
 
 	private var pendingTasks: [InternalTask] = []
 	private var runningTasks: [InternalTask] = []
@@ -24,6 +26,7 @@ actor TaskRunner {
 
 	private var processTask: Task<Void, Never>?
 	private var rerunRequested = false
+	private var isShutdown = false
 
 	private(set) var currentDownloads: [Download] = []
 	private var downloadsContinuation: AsyncStream<Download>.Continuation?
@@ -45,6 +48,8 @@ actor TaskRunner {
 		self.offlineApiClient = offlineApiClient
 		self.allowDownloadsOnExpensiveNetworks = configuration.allowDownloadsOnExpensiveNetworks
 		self.network = Network()
+		self.mediaDownloader = mediaDownloader
+		self.licenseDownloader = licenseDownloader
 
 		let (stream, continuation) = AsyncStream<Download>.makeStream()
 		self.newDownloads = stream
@@ -84,6 +89,7 @@ actor TaskRunner {
 	}
 
 	func run() {
+		guard !isShutdown else { return }
 		guard processTask == nil else {
 			rerunRequested = true
 			return
@@ -99,6 +105,7 @@ actor TaskRunner {
 	}
 
 	func setAllowDownloadsOnExpensiveNetworks(_ allowed: Bool) {
+		guard !isShutdown else { return }
 		allowDownloadsOnExpensiveNetworks = allowed
 		if allowed {
 			run()
@@ -106,13 +113,39 @@ actor TaskRunner {
 	}
 
 	func hasCurrentDownload(relatedTo collectionType: OfflineCollectionType, resourceId: ResourceId) -> Bool {
+		guard !isShutdown else { return false }
 		let collection = OfflineCollectionReference(collectionType: collectionType, resourceId: resourceId)
 		return pendingTasks.contains { $0.isDownloadTask(for: collection) } ||
 			runningTasks.contains { $0.isDownloadTask(for: collection) }
 	}
 
+	func shutdown() async {
+		guard !isShutdown else {
+			if let processTask { await processTask.value }
+			return
+		}
+
+		isShutdown = true
+		rerunRequested = false
+		let task = processTask
+		task?.cancel()
+		await mediaDownloader.cancelAll()
+		await licenseDownloader.cancelAll()
+		await task?.value
+		pendingTasks.removeAll()
+		runningTasks.removeAll()
+		taskIds.removeAll()
+		currentDownloads.removeAll()
+		downloadsContinuation?.finish()
+		downloadsContinuation = nil
+	}
+
 	private func refresh() async throws {
+		try Task.checkCancellation()
+		guard !isShutdown else { return }
 		let (tasks, _) = try await offlineApiClient.getTasks(cursor: nil)
+		try Task.checkCancellation()
+		guard !isShutdown else { return }
 
 		for task in tasks where taskIds.insert(task.id).inserted {
 			let pendingTask = handle(task)
@@ -137,18 +170,23 @@ actor TaskRunner {
 	}
 
 	private func process() async {
+		guard !isShutdown, !Task.isCancelled else { return }
 		if pendingTasks.count < Self.refreshThreshold {
 			try? await refresh()
 		}
 
 		await withTaskGroup(of: Void.self) { group in
-			for _ in 0 ..< Self.maxConcurrentTasks {
+			for _ in 0 ..< Self.maxConcurrentTasks where !Task.isCancelled && !isShutdown {
 				if let task = getTask() {
 					group.addTask { await self.start(task) }
 				}
 			}
 
 			for await _ in group {
+				guard !Task.isCancelled, !isShutdown else {
+					group.cancelAll()
+					continue
+				}
 				if pendingTasks.count < Self.refreshThreshold {
 					try? await refresh()
 				}
@@ -161,6 +199,7 @@ actor TaskRunner {
 	}
 
 	private func getTask() -> InternalTask? {
+		guard !isShutdown, !Task.isCancelled else { return nil }
 		let runningKeys = Set(runningTasks.map(\.concurrencyKey))
 
 		guard let index = pendingTasks.firstIndex(where: { !runningKeys.contains($0.concurrencyKey) }) else {
@@ -173,8 +212,17 @@ actor TaskRunner {
 	}
 
 	private func start(_ task: InternalTask) async {
+		guard !isShutdown, !Task.isCancelled else {
+			finish(task)
+			return
+		}
 		while !allowDownloadsOnExpensiveNetworks, !(await network.isInexpensive) {
-			try? await Task.sleep(nanoseconds: 1_000_000_000)
+			do {
+				try await Task.sleep(nanoseconds: 1_000_000_000)
+			} catch {
+				finish(task)
+				return
+			}
 		}
 
 		do {
@@ -190,9 +238,18 @@ actor TaskRunner {
 
 		do {
 			try await task.run()
+			try Task.checkCancellation()
+			guard !isShutdown else { throw CancellationError() }
 			await task.download?.updateState(.completed)
 			try? await offlineApiClient.updateTask(taskId: task.id, state: .completed)
+		} catch is CancellationError {
+			finish(task)
+			return
 		} catch {
+			guard !isShutdown, !Task.isCancelled else {
+				finish(task)
+				return
+			}
 			Self.logger.error("Task \(task.id, privacy: .public) failed: \(error, privacy: .public)")
 			await task.download?.updateState(.failed)
 			try? await offlineApiClient.updateTask(taskId: task.id, state: .failed)

--- a/Sources/Offliner/Mocks/Download+Mock.swift
+++ b/Sources/Offliner/Mocks/Download+Mock.swift
@@ -11,7 +11,9 @@ public extension Download {
 		Download(
 			title: title,
 			artists: artists,
-			imageURL: imageURL
+			imageURL: imageURL,
+			taskId: "mock-task",
+			resource: .media(type: .tracks, resourceId: "mock-track")
 		)
 	}
 }

--- a/Sources/Offliner/OfflinePlaybackAVAsset.swift
+++ b/Sources/Offliner/OfflinePlaybackAVAsset.swift
@@ -1,0 +1,102 @@
+import AVFoundation
+import Foundation
+
+/// An error encountered while preparing a stored asset for AVFoundation playback.
+public enum OfflinePlaybackAVAssetError: Error, Equatable {
+	case storedLicenseNotFound(URL)
+	case storedLicenseUnreadable(URL)
+}
+
+/// An AVFoundation asset prepared for offline playback.
+///
+/// This object owns the URL asset and, for protected media, the FairPlay content-key session, delegate, delegate queue,
+/// and stored license data. Retain this object for as long as any `AVPlayerItem` created from `urlAsset` is queued or
+/// playing. `AVPlayerItem` does not retain this playback preparation context for you.
+public final class OfflinePlaybackAVAsset {
+	public let urlAsset: AVURLAsset
+
+	private let contentKeySession: AVContentKeySession?
+	private let contentKeySessionDelegate: StoredOfflineLicenseDelegate?
+	private let contentKeyDelegateQueue: DispatchQueue?
+
+	var usesStoredLicense: Bool {
+		contentKeySession != nil
+	}
+
+	public init(playbackAsset: OfflinePlaybackAsset) throws {
+		let urlAsset = AVURLAsset(url: playbackAsset.mediaURL)
+		guard let licenseURL = playbackAsset.licenseURL else {
+			self.urlAsset = urlAsset
+			contentKeySession = nil
+			contentKeySessionDelegate = nil
+			contentKeyDelegateQueue = nil
+			return
+		}
+
+		var isDirectory: ObjCBool = false
+		guard FileManager.default.fileExists(atPath: licenseURL.path, isDirectory: &isDirectory) else {
+			throw OfflinePlaybackAVAssetError.storedLicenseNotFound(licenseURL)
+		}
+		guard !isDirectory.boolValue else {
+			throw OfflinePlaybackAVAssetError.storedLicenseUnreadable(licenseURL)
+		}
+
+		let license: Data
+		do {
+			license = try Data(contentsOf: licenseURL)
+		} catch {
+			throw OfflinePlaybackAVAssetError.storedLicenseUnreadable(licenseURL)
+		}
+		guard !license.isEmpty else {
+			throw OfflinePlaybackAVAssetError.storedLicenseUnreadable(licenseURL)
+		}
+
+		let delegate = StoredOfflineLicenseDelegate(license: license)
+		let delegateQueue = DispatchQueue(label: "com.tidal.offliner.stored-license")
+		let session = AVContentKeySession(keySystem: .fairPlayStreaming)
+		session.setDelegate(delegate, queue: delegateQueue)
+		session.addContentKeyRecipient(urlAsset)
+
+		self.urlAsset = urlAsset
+		contentKeySession = session
+		contentKeySessionDelegate = delegate
+		contentKeyDelegateQueue = delegateQueue
+	}
+}
+
+private final class StoredOfflineLicenseDelegate: NSObject, AVContentKeySessionDelegate {
+	private let license: Data
+
+	init(license: Data) {
+		self.license = license
+	}
+
+	func contentKeySession(
+		_ session: AVContentKeySession,
+		didProvide keyRequest: AVContentKeyRequest
+	) {
+		do {
+			#if os(iOS)
+				try keyRequest.respondByRequestingPersistableContentKeyRequestAndReturnError()
+			#else
+				try keyRequest.respondByRequestingPersistableContentKeyRequest()
+			#endif
+		} catch {
+			keyRequest.processContentKeyResponseError(error)
+		}
+	}
+
+	func contentKeySession(
+		_ session: AVContentKeySession,
+		didProvide keyRequest: AVPersistableContentKeyRequest
+	) {
+		let response = AVContentKeyResponse(fairPlayStreamingKeyResponseData: license)
+		keyRequest.processContentKeyResponse(response)
+	}
+
+	func contentKeySession(
+		_ session: AVContentKeySession,
+		contentKeyRequest keyRequest: AVContentKeyRequest,
+		didFailWithError error: Error
+	) {}
+}

--- a/Sources/Offliner/Offliner.swift
+++ b/Sources/Offliner/Offliner.swift
@@ -1,11 +1,10 @@
 import Foundation
 import GRDB
-import Player
 
 // MARK: - Offliner
 
 public final class Offliner {
-	static let defaultCollectionDownloadStatePollInterval: UInt64 = 1_000_000_000
+	static let defaultCollectionPollInterval: UInt64 = 1_000_000_000
 
 	private let offlineApiClient: OfflineApiClientProtocol
 	private let offlineStore: OfflineStore
@@ -53,7 +52,7 @@ public final class Offliner {
 		self.offlineApiClient = offlineApiClient
 		self.offlineStore = offlineStore
 		self.mediaDownloader = mediaDownloader
-		self.collectionDownloadStatePollInterval = Self.defaultCollectionDownloadStatePollInterval
+		self.collectionDownloadStatePollInterval = Self.defaultCollectionPollInterval
 		self.trackManifestFetcher = trackManifestFetcher
 		self.audioFormats = configuration.audioFormats
 		self.taskRunner = TaskRunner(
@@ -85,7 +84,7 @@ public final class Offliner {
 		licenseDownloader: LicenseDownloader = LicenseDownloader(),
 		trackManifestFetcher: TrackManifestFetcherProtocol,
 		videoManifestFetcher: VideoManifestFetcherProtocol,
-		collectionDownloadStatePollInterval: UInt64 = Offliner.defaultCollectionDownloadStatePollInterval
+		collectionDownloadStatePollInterval: UInt64 = Offliner.defaultCollectionPollInterval
 	) {
 		self.offlineApiClient = offlineApiClient
 		self.offlineStore = offlineStore
@@ -127,6 +126,22 @@ public final class Offliner {
 		}
 
 		return items
+	}
+
+	/// Returns the locally playable asset for an offlined track or video.
+	///
+	/// File bookmarks are resolved only for playback so enumerating offline content remains fast. If a stored file can no
+	/// longer be resolved, the item is scheduled for download again and this method returns `nil`.
+	public func getOfflinePlaybackAsset(
+		mediaType: OfflineMediaItemType,
+		resourceId: ResourceId
+	) async -> OfflinePlaybackAsset? {
+		do {
+			return try await offlineStore.getPlaybackAsset(mediaType: mediaType, resourceId: resourceId.stringValue)
+		} catch {
+			Task { try? await download(mediaType: mediaType, resourceId: resourceId) }
+			return nil
+		}
 	}
 
 	public func getOfflineCollection(
@@ -405,28 +420,6 @@ public final class Offliner {
 	}
 }
 
-// MARK: - OfflineItemProvider
-
-extension Offliner: OfflineItemProvider {
-	public func get(productType: ProductType, productId: String) async -> OfflinePlaybackItem? {
-		let mediaType: OfflineMediaItemType
-		switch productType {
-		case .TRACK: mediaType = .tracks
-		case .VIDEO: mediaType = .videos
-		case .UC: return nil
-		}
-
-		do {
-			return try await offlineStore.getPlayableMediaItem(mediaType: mediaType, resourceId: productId)
-				.map { OfflinePlaybackItem($0, productType: productType) }
-		} catch {
-			Task { try? await download(mediaType: mediaType, resourceId: .identifier(productId)) }
-		}
-
-		return nil
-	}
-}
-
 // MARK: - Internal Mappings
 
 extension OfflineMediaItemType {
@@ -445,20 +438,5 @@ extension OfflineCollectionType {
 		case .playlists: return .playlist
 		case .userCollectionTracks: return .userCollectionTracks
 		}
-	}
-}
-
-// MARK: - OfflinePlaybackItem from PlayableOfflineMediaItem
-
-private extension OfflinePlaybackItem {
-	init(_ item: PlayableOfflineMediaItem, productType: ProductType) {
-		self.init(
-			mediaURL: item.mediaURL,
-			licenseURL: item.licenseURL,
-			format: item.playbackMetadata?.format.rawValue,
-			albumReplayGain: item.playbackMetadata?.albumNormalizationData?.replayGain,
-			albumPeakAmplitude: item.playbackMetadata?.albumNormalizationData?.peakAmplitude,
-			productType: productType
-		)
 	}
 }

--- a/Sources/Offliner/Offliner.swift
+++ b/Sources/Offliner/Offliner.swift
@@ -8,10 +8,14 @@ public final class Offliner {
 
 	private let offlineApiClient: OfflineApiClientProtocol
 	private let offlineStore: OfflineStore
+	private let storage: OfflinerStorage
 	private let taskRunner: TaskRunner
 	private let mediaDownloader: MediaDownloaderProtocol
 	private let collectionDownloadStatePollInterval: UInt64
 	private var trackManifestFetcher: TrackManifestFetcherProtocol
+	private let lifecycleLock = NSLock()
+	private var isReset = false
+	private var resetTask: Task<Void, Error>?
 
 	public var audioFormats: [AudioFormat] {
 		didSet {
@@ -20,6 +24,7 @@ public final class Offliner {
 	}
 
 	public func setAllowDownloadsOnExpensiveNetworks(_ allowed: Bool) async {
+		guard isActive else { return }
 		await taskRunner.setAllowDownloadsOnExpensiveNetworks(allowed)
 	}
 
@@ -34,23 +39,26 @@ public final class Offliner {
 	}
 
 	public func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void) {
+		guard isActive else { return }
 		mediaDownloader.handleBackgroundURLSessionEvents(identifier: identifier, completionHandler: completionHandler)
 	}
 
 	public init(installationId: String, configuration: Configuration) throws {
-		let databaseQueue = try OfflineStore.makeDatabaseQueue(path: OfflineStore.url().path)
-		try Migrations.run(databaseQueue)
-
-		let offlineStore = OfflineStore(databaseQueue)
+		let storage = try OfflinerStorage(installationId: installationId)
+		let offlineStore = storage.offlineStore
 		let offlineApiClient = OfflineApiClient(installationId: installationId)
-		let artworkDownloader = ArtworkDownloader()
-		let mediaDownloader = MediaDownloader(configuration: configuration)
-		let licenseDownloader = LicenseDownloader()
+		let artworkDownloader = ArtworkDownloader(fileStorage: storage.fileStorage)
+		let mediaDownloader = MediaDownloader(
+			configuration: configuration,
+			backgroundSessionIdentifier: storage.backgroundSessionIdentifier
+		)
+		let licenseDownloader = LicenseDownloader(fileStorage: storage.fileStorage)
 		let trackManifestFetcher = TrackManifestFetcher(audioFormats: configuration.audioFormats)
 		let videoManifestFetcher = VideoManifestFetcher()
 
 		self.offlineApiClient = offlineApiClient
 		self.offlineStore = offlineStore
+		self.storage = storage
 		self.mediaDownloader = mediaDownloader
 		self.collectionDownloadStatePollInterval = Self.defaultCollectionPollInterval
 		self.trackManifestFetcher = trackManifestFetcher
@@ -67,9 +75,11 @@ public final class Offliner {
 		)
 
 		mediaDownloader.orphanedTaskHandler = { [weak self] taskId in
-			guard let self, let taskId else { return }
+			guard let self, self.isActive, let taskId else { return }
 			Task {
+				guard self.isActive else { return }
 				try? await self.offlineApiClient.updateTask(taskId: taskId, state: .failed)
+				guard self.isActive else { return }
 				await self.run()
 			}
 		}
@@ -77,17 +87,20 @@ public final class Offliner {
 
 	init(
 		configuration: Configuration = Configuration(),
+		storage: OfflinerStorage,
 		offlineApiClient: OfflineApiClientProtocol,
-		offlineStore: OfflineStore,
 		artworkDownloader: ArtworkDownloaderProtocol,
 		mediaDownloader: MediaDownloaderProtocol,
-		licenseDownloader: LicenseDownloader = LicenseDownloader(),
+		licenseDownloader: LicenseDownloader? = nil,
 		trackManifestFetcher: TrackManifestFetcherProtocol,
 		videoManifestFetcher: VideoManifestFetcherProtocol,
 		collectionDownloadStatePollInterval: UInt64 = Offliner.defaultCollectionPollInterval
 	) {
+		let offlineStore = storage.offlineStore
+		let licenseDownloader = licenseDownloader ?? LicenseDownloader(fileStorage: storage.fileStorage)
 		self.offlineApiClient = offlineApiClient
 		self.offlineStore = offlineStore
+		self.storage = storage
 		self.mediaDownloader = mediaDownloader
 		self.collectionDownloadStatePollInterval = collectionDownloadStatePollInterval
 		self.trackManifestFetcher = trackManifestFetcher
@@ -105,16 +118,44 @@ public final class Offliner {
 	}
 
 	public func run() async {
+		guard isActive else { return }
 		await taskRunner.run()
+	}
+
+	/// Permanently invalidates this instance and removes only its installation-scoped local offline data.
+	///
+	/// This operation does not enqueue backend removals. Create a new `Offliner` after reset, including when signing in again
+	/// with the same installation identifier.
+	public func reset() async throws {
+		try await resetOperation().value
+	}
+
+	private func resetOperation() -> Task<Void, Error> {
+		lifecycleLock.lock()
+		defer { lifecycleLock.unlock() }
+		if let resetTask {
+			return resetTask
+		}
+
+		isReset = true
+		storage.invalidateWrites()
+		let task = Task { [taskRunner, storage] in
+			await taskRunner.shutdown()
+			try storage.reset()
+		}
+		resetTask = task
+		return task
 	}
 
 	// MARK: - Offline Content
 
 	public func getOfflineMediaItem(mediaType: OfflineMediaItemType, resourceId: ResourceId) async throws -> OfflineMediaItem? {
-		try await offlineStore.getMediaItem(mediaType: mediaType, resourceId: resourceId.stringValue)
+		try ensureActive()
+		return try await offlineStore.getMediaItem(mediaType: mediaType, resourceId: resourceId.stringValue)
 	}
 
 	public func getOfflineMediaItems(mediaType: OfflineMediaItemType) async throws -> [OfflineMediaItem] {
+		try ensureActive()
 		let (items, failures) = try await offlineStore.getMediaItems(mediaType: mediaType)
 
 		if !failures.isEmpty {
@@ -136,6 +177,7 @@ public final class Offliner {
 		mediaType: OfflineMediaItemType,
 		resourceId: ResourceId
 	) async -> OfflinePlaybackAsset? {
+		guard isActive else { return nil }
 		do {
 			return try await offlineStore.getPlaybackAsset(mediaType: mediaType, resourceId: resourceId.stringValue)
 		} catch {
@@ -148,7 +190,8 @@ public final class Offliner {
 		collectionType: OfflineCollectionType,
 		resourceId: ResourceId
 	) -> AsyncStream<OfflineCollection?> {
-		AsyncStream { continuation in
+		guard isActive else { return AsyncStream { $0.finish() } }
+		return AsyncStream { continuation in
 			let task = Task {
 				let local = try? await offlineStore.getCollection(
 					collectionType: collectionType,
@@ -173,7 +216,8 @@ public final class Offliner {
 		collectionType: OfflineCollectionType,
 		cursor: String? = nil
 	) -> AsyncStream<Set<OfflineCollection>> {
-		AsyncStream { continuation in
+		guard isActive else { return AsyncStream { $0.finish() } }
+		return AsyncStream { continuation in
 			let task = Task {
 				let local = (try? await offlineStore.getCollections(collectionType: collectionType)) ?? []
 				var collections = Set(local)
@@ -202,6 +246,16 @@ public final class Offliner {
 		}
 	}
 
+	/// Returns a finite, error-preserving snapshot of locally stored collections.
+	///
+	/// This method does not access the network, so stored content remains available while offline.
+	public func getStoredOfflineCollections(
+		collectionType: OfflineCollectionType
+	) async throws -> Set<OfflineCollection> {
+		try ensureActive()
+		return Set(try await offlineStore.getCollections(collectionType: collectionType))
+	}
+
 	/// Streams collection-level offline availability.
 	///
 	/// The stream emits a fast initial value from local storage and active in-memory downloads, then continues polling for
@@ -213,7 +267,8 @@ public final class Offliner {
 		collectionType: OfflineCollectionType,
 		resourceId: ResourceId
 	) -> AsyncStream<OfflineCollectionDownloadState> {
-		AsyncStream { continuation in
+		guard isActive else { return AsyncStream { $0.finish() } }
+		return AsyncStream { continuation in
 			let task = Task {
 				var lastState: OfflineCollectionDownloadState?
 				var consecutiveDownloadedObservations = 0
@@ -266,7 +321,8 @@ public final class Offliner {
 		collectionType: OfflineCollectionType,
 		resourceId: ResourceId
 	) async throws -> Int {
-		try await offlineStore.countCollectionItems(collectionType: collectionType, resourceId: resourceId.stringValue)
+		try ensureActive()
+		return try await offlineStore.countCollectionItems(collectionType: collectionType, resourceId: resourceId.stringValue)
 	}
 
 	public func getOfflineCollectionItems(
@@ -276,6 +332,7 @@ public final class Offliner {
 		sort: OfflineCollectionItemSort? = nil,
 		after cursor: String? = nil
 	) async throws -> OfflineCollectionItemsPage {
+		try ensureActive()
 		let resourceId = resourceId.stringValue
 
 		let (page, failures): (OfflineCollectionItemsPage, [FailedOfflineItem])
@@ -333,6 +390,7 @@ public final class Offliner {
 		limit: Int = 20,
 		after cursor: String? = nil
 	) async throws -> OfflineCollectionSearchPage {
+		try ensureActive()
 		let (page, failures) = try await offlineStore.searchCollectionItems(
 			collectionType: collectionType,
 			resourceId: resourceId.stringValue,
@@ -359,34 +417,40 @@ public final class Offliner {
 		collectionType: OfflineCollectionType,
 		resourceId: ResourceId
 	) async throws -> AudioFormat? {
-		try await offlineStore.getAudioFormatOfCollection(collectionType: collectionType, resourceId: resourceId.stringValue)
+		try ensureActive()
+		return try await offlineStore.getAudioFormatOfCollection(collectionType: collectionType, resourceId: resourceId.stringValue)
 	}
 
 	public func getCollectionDuration(
 		collectionType: OfflineCollectionType,
 		resourceId: ResourceId
 	) async throws -> Int {
-		try await offlineStore.getCollectionDuration(collectionType: collectionType, resourceId: resourceId.stringValue)
+		try ensureActive()
+		return try await offlineStore.getCollectionDuration(collectionType: collectionType, resourceId: resourceId.stringValue)
 	}
 
 	// MARK: - Download/Remove
 
 	public func download(mediaType: OfflineMediaItemType, resourceId: ResourceId) async throws {
+		try ensureActive()
 		try await offlineApiClient.addItem(type: mediaType.toResourceType, id: resourceId.stringValue)
 		await taskRunner.run()
 	}
 
 	public func download(collectionType: OfflineCollectionType, resourceId: ResourceId) async throws {
+		try ensureActive()
 		try await offlineApiClient.addItem(type: collectionType.toResourceType, id: resourceId.stringValue)
 		await taskRunner.run()
 	}
 
 	public func remove(mediaType: OfflineMediaItemType, resourceId: ResourceId) async throws {
+		try ensureActive()
 		try await offlineApiClient.removeItem(type: mediaType.toResourceType, id: resourceId.stringValue)
 		await taskRunner.run()
 	}
 
 	public func remove(collectionType: OfflineCollectionType, resourceId: ResourceId) async throws {
+		try ensureActive()
 		try await offlineApiClient.removeItem(type: collectionType.toResourceType, id: resourceId.stringValue)
 		// Optimistically update local availability; the remove task performs the same idempotent cleanup.
 		try? offlineStore.deleteCollection(
@@ -417,6 +481,16 @@ public final class Offliner {
 		resourceId: ResourceId
 	) -> String {
 		collectionType == .userCollectionTracks ? ResourceId.me.stringValue : resourceId.stringValue
+	}
+
+	private var isActive: Bool {
+		lifecycleLock.lock()
+		defer { lifecycleLock.unlock() }
+		return !isReset
+	}
+
+	private func ensureActive() throws {
+		guard isActive else { throw OfflinerLifecycleError.reset }
 	}
 }
 

--- a/Sources/Offliner/Offliner.swift
+++ b/Sources/Offliner/Offliner.swift
@@ -4,14 +4,12 @@ import GRDB
 // MARK: - Offliner
 
 public final class Offliner {
-	static let defaultCollectionPollInterval: UInt64 = 1_000_000_000
-
 	private let offlineApiClient: OfflineApiClientProtocol
 	private let offlineStore: OfflineStore
 	private let storage: OfflinerStorage
 	private let taskRunner: TaskRunner
 	private let mediaDownloader: MediaDownloaderProtocol
-	private let collectionDownloadStatePollInterval: UInt64
+	private let resourceStateTracker: ResourceStateTracker
 	private var trackManifestFetcher: TrackManifestFetcherProtocol
 	private let lifecycleLock = NSLock()
 	private var isReset = false
@@ -53,6 +51,7 @@ public final class Offliner {
 			backgroundSessionIdentifier: storage.backgroundSessionIdentifier
 		)
 		let licenseDownloader = LicenseDownloader(fileStorage: storage.fileStorage)
+		let resourceStateTracker = ResourceStateTracker(offlineStore: offlineStore)
 		let trackManifestFetcher = TrackManifestFetcher(audioFormats: configuration.audioFormats)
 		let videoManifestFetcher = VideoManifestFetcher()
 
@@ -60,7 +59,7 @@ public final class Offliner {
 		self.offlineStore = offlineStore
 		self.storage = storage
 		self.mediaDownloader = mediaDownloader
-		self.collectionDownloadStatePollInterval = Self.defaultCollectionPollInterval
+		self.resourceStateTracker = resourceStateTracker
 		self.trackManifestFetcher = trackManifestFetcher
 		self.audioFormats = configuration.audioFormats
 		self.taskRunner = TaskRunner(
@@ -70,6 +69,7 @@ public final class Offliner {
 			artworkDownloader: artworkDownloader,
 			mediaDownloader: mediaDownloader,
 			licenseDownloader: licenseDownloader,
+			resourceStateTracker: resourceStateTracker,
 			trackManifestFetcher: trackManifestFetcher,
 			videoManifestFetcher: videoManifestFetcher
 		)
@@ -93,16 +93,16 @@ public final class Offliner {
 		mediaDownloader: MediaDownloaderProtocol,
 		licenseDownloader: LicenseDownloader? = nil,
 		trackManifestFetcher: TrackManifestFetcherProtocol,
-		videoManifestFetcher: VideoManifestFetcherProtocol,
-		collectionDownloadStatePollInterval: UInt64 = Offliner.defaultCollectionPollInterval
+		videoManifestFetcher: VideoManifestFetcherProtocol
 	) {
 		let offlineStore = storage.offlineStore
 		let licenseDownloader = licenseDownloader ?? LicenseDownloader(fileStorage: storage.fileStorage)
+		let resourceStateTracker = ResourceStateTracker(offlineStore: offlineStore)
 		self.offlineApiClient = offlineApiClient
 		self.offlineStore = offlineStore
 		self.storage = storage
 		self.mediaDownloader = mediaDownloader
-		self.collectionDownloadStatePollInterval = collectionDownloadStatePollInterval
+		self.resourceStateTracker = resourceStateTracker
 		self.trackManifestFetcher = trackManifestFetcher
 		self.audioFormats = configuration.audioFormats
 		self.taskRunner = TaskRunner(
@@ -112,6 +112,7 @@ public final class Offliner {
 			artworkDownloader: artworkDownloader,
 			mediaDownloader: mediaDownloader,
 			licenseDownloader: licenseDownloader,
+			resourceStateTracker: resourceStateTracker,
 			trackManifestFetcher: trackManifestFetcher,
 			videoManifestFetcher: videoManifestFetcher
 		)
@@ -256,61 +257,62 @@ public final class Offliner {
 		return Set(try await offlineStore.getCollections(collectionType: collectionType))
 	}
 
+	/// Returns the latest operation or local availability state for a media item or collection.
+	///
+	/// Locally persisted queued, removing, and failed operations survive Offliner recreation. A backend refresh is scheduled
+	/// to recover task progress, but a temporary network failure does not hide the locally known state.
+	public func getOfflineResourceState(for resource: OfflineResource) async throws -> OfflineResourceState {
+		try ensureActive()
+		await taskRunner.synchronizeState()
+		if let state = try await resourceStateTracker.state(for: OfflineResourceKey(resource)) {
+			return state
+		}
+		return try await localResourceState(for: resource)
+	}
+
+	/// Observes distinct state changes for one media item or collection until reset or cancellation.
+	public func observeOfflineResourceState(for resource: OfflineResource) -> AsyncStream<OfflineResourceState> {
+		guard isActive else { return AsyncStream { $0.finish() } }
+		let key = OfflineResourceKey(resource)
+		return AsyncStream { continuation in
+			let task = Task {
+				do {
+					var lastState = try await getOfflineResourceState(for: resource)
+					continuation.yield(lastState)
+					for await state in await resourceStateTracker.observe(key) where state != lastState {
+						continuation.yield(state)
+						lastState = state
+					}
+				} catch {
+					// Observation is nonthrowing for source compatibility; registration and snapshot calls preserve errors.
+				}
+				continuation.finish()
+			}
+			continuation.onTermination = { _ in task.cancel() }
+		}
+	}
+
 	/// Streams collection-level offline availability.
 	///
-	/// The stream emits a fast initial value from local storage and active in-memory downloads, then continues polling for
-	/// later local changes.
-	///
-	/// The stream does not poll backend task inventory. Removal is represented as `.notDownloaded`; `.downloading` is
-	/// reserved for active download/acquisition work already known by this SDK instance.
+	/// This compatibility stream maps the resource-scoped operation state into the original three availability states.
+	/// Removal and failed downloads map to `.notDownloaded`; a failed removal preserves the collection's local availability.
 	public func getOfflineCollectionDownloadState(
 		collectionType: OfflineCollectionType,
 		resourceId: ResourceId
 	) -> AsyncStream<OfflineCollectionDownloadState> {
-		guard isActive else { return AsyncStream { $0.finish() } }
+		let resource = OfflineResource.collection(type: collectionType, resourceId: resourceId.stringValue)
 		return AsyncStream { continuation in
 			let task = Task {
-				var lastState: OfflineCollectionDownloadState?
-				var consecutiveDownloadedObservations = 0
-
-				func yieldState(_ state: OfflineCollectionDownloadState) {
-					let shouldYield: Bool
-
-					// A second downloaded observation avoids transient completion between collection metadata and
-					// collection item tasks.
-					if state == .downloaded {
-						consecutiveDownloadedObservations += 1
-						shouldYield = lastState == .downloaded || consecutiveDownloadedObservations >= 2
-					} else {
-						consecutiveDownloadedObservations = 0
-						shouldYield = true
+				for await state in observeOfflineResourceState(for: resource) {
+					let legacyState: OfflineCollectionDownloadState = switch state {
+					case .queued, .downloading: .downloading
+					case .downloaded: .downloaded
+					case .notDownloaded, .removing, .failed(action: .download): .notDownloaded
+					case .failed(action: .remove):
+						(try? await localResourceState(for: resource)) == .downloaded ? .downloaded : .notDownloaded
 					}
-
-					if shouldYield, state != lastState {
-						continuation.yield(state)
-						lastState = state
-					}
+					continuation.yield(legacyState)
 				}
-
-				let initialState = await offlineCollectionDownloadState(
-					collectionType: collectionType,
-					resourceId: resourceId
-				)
-				continuation.yield(initialState)
-				lastState = initialState
-
-				while !Task.isCancelled {
-					try? await Task.sleep(nanoseconds: collectionDownloadStatePollInterval)
-					guard !Task.isCancelled else { break }
-
-					let state = await offlineCollectionDownloadState(
-						collectionType: collectionType,
-						resourceId: resourceId
-					)
-
-					yieldState(state)
-				}
-
 				continuation.finish()
 			}
 			continuation.onTermination = { _ in task.cancel() }
@@ -432,48 +434,90 @@ public final class Offliner {
 	// MARK: - Download/Remove
 
 	public func download(mediaType: OfflineMediaItemType, resourceId: ResourceId) async throws {
-		try ensureActive()
-		try await offlineApiClient.addItem(type: mediaType.toResourceType, id: resourceId.stringValue)
-		await taskRunner.run()
+		try await perform(
+			action: .store,
+			resource: .media(type: mediaType, resourceId: resourceId.stringValue),
+			resourceType: mediaType.toResourceType
+		)
 	}
 
 	public func download(collectionType: OfflineCollectionType, resourceId: ResourceId) async throws {
-		try ensureActive()
-		try await offlineApiClient.addItem(type: collectionType.toResourceType, id: resourceId.stringValue)
-		await taskRunner.run()
+		try await perform(
+			action: .store,
+			resource: .collection(type: collectionType, resourceId: resourceId.stringValue),
+			resourceType: collectionType.toResourceType
+		)
 	}
 
 	public func remove(mediaType: OfflineMediaItemType, resourceId: ResourceId) async throws {
-		try ensureActive()
-		try await offlineApiClient.removeItem(type: mediaType.toResourceType, id: resourceId.stringValue)
-		await taskRunner.run()
+		try await perform(
+			action: .remove,
+			resource: .media(type: mediaType, resourceId: resourceId.stringValue),
+			resourceType: mediaType.toResourceType
+		)
 	}
 
 	public func remove(collectionType: OfflineCollectionType, resourceId: ResourceId) async throws {
-		try ensureActive()
-		try await offlineApiClient.removeItem(type: collectionType.toResourceType, id: resourceId.stringValue)
-		// Optimistically update local availability; the remove task performs the same idempotent cleanup.
-		try? offlineStore.deleteCollection(
-			resourceType: collectionType.rawValue,
-			resourceId: collectionLocalResourceId(collectionType: collectionType, resourceId: resourceId)
+		try await perform(
+			action: .remove,
+			resource: .collection(type: collectionType, resourceId: resourceId.stringValue),
+			resourceType: collectionType.toResourceType
 		)
+	}
+
+	private func perform(
+		action: InternalOfflineResourceAction,
+		resource: OfflineResource,
+		resourceType: ResourceType
+	) async throws {
+		try ensureActive()
+		let key = OfflineResourceKey(resource)
+		let localState = try await localResourceState(for: resource)
+		if let knownState = try await resourceStateTracker.state(for: key) {
+			if action == .store, localState == .downloaded,
+			   knownState == .downloaded || knownState == .failed(action: .remove) {
+				await resourceStateTracker.resolve(key, state: .downloaded)
+				return
+			}
+			if action == .remove, localState == .notDownloaded,
+			   knownState == .notDownloaded || knownState == .failed(action: .download) {
+				await resourceStateTracker.resolve(key, state: .notDownloaded)
+				return
+			}
+			guard try await resourceStateTracker.begin(action, for: key) else { return }
+		} else {
+			if action == .store, localState == .downloaded { return }
+			guard try await resourceStateTracker.begin(action, for: key) else { return }
+		}
+		do {
+			switch action {
+			case .store:
+				try await offlineApiClient.addItem(type: resourceType, id: key.resourceId)
+			case .remove:
+				try await offlineApiClient.removeItem(type: resourceType, id: key.resourceId)
+			}
+		} catch {
+			await resourceStateTracker.registrationFailed(action, for: key)
+			throw error
+		}
 		await taskRunner.run()
 	}
 
-	private func offlineCollectionDownloadState(
-		collectionType: OfflineCollectionType,
-		resourceId: ResourceId
-	) async -> OfflineCollectionDownloadState {
-		if await taskRunner.hasCurrentDownload(relatedTo: collectionType, resourceId: resourceId) {
-			return .downloading
+	private func localResourceState(for resource: OfflineResource) async throws -> OfflineResourceState {
+		switch resource {
+		case .media(let mediaType, let resourceId):
+			return try await offlineStore.getMediaItem(mediaType: mediaType, resourceId: resourceId) == nil
+				? .notDownloaded
+				: .downloaded
+		case .collection(let collectionType, let resourceId):
+			return try await offlineStore.getCollection(
+				collectionType: collectionType,
+				resourceId: collectionLocalResourceId(
+					collectionType: collectionType,
+					resourceId: .identifier(resourceId)
+				)
+			) == nil ? .notDownloaded : .downloaded
 		}
-
-		let localCollection = try? await offlineStore.getCollection(
-			collectionType: collectionType,
-			resourceId: collectionLocalResourceId(collectionType: collectionType, resourceId: resourceId)
-		)
-
-		return localCollection == nil ? .notDownloaded : .downloaded
 	}
 
 	private func collectionLocalResourceId(

--- a/Sources/Offliner/Offliner.swift
+++ b/Sources/Offliner/Offliner.swift
@@ -12,8 +12,10 @@ public final class Offliner {
 	private let resourceStateTracker: ResourceStateTracker
 	private var trackManifestFetcher: TrackManifestFetcherProtocol
 	private let lifecycleLock = NSLock()
+	private let playbackReplacementLock = NSLock()
 	private var isReset = false
 	private var resetTask: Task<Void, Error>?
+	private var playbackReplacementResources: Set<OfflineResourceKey> = []
 
 	public var audioFormats: [AudioFormat] {
 		didSet {
@@ -182,9 +184,53 @@ public final class Offliner {
 		do {
 			return try await offlineStore.getPlaybackAsset(mediaType: mediaType, resourceId: resourceId.stringValue)
 		} catch {
-			Task { try? await download(mediaType: mediaType, resourceId: resourceId) }
+			schedulePlaybackAssetReplacement(mediaType: mediaType, resourceId: resourceId)
 			return nil
 		}
+	}
+
+	/// Returns an AVFoundation asset prepared for unprotected or stored-license playback.
+	///
+	/// Retain the returned object for the entire lifetime of every `AVPlayerItem` made from its `urlAsset`, including while
+	/// queued. If stored playback files or license preparation cannot be resolved, this returns `nil` and schedules one
+	/// idempotent replacement download.
+	public func getOfflinePlaybackAVAsset(
+		mediaType: OfflineMediaItemType,
+		resourceId: ResourceId
+	) async -> OfflinePlaybackAVAsset? {
+		guard let playbackAsset = await getOfflinePlaybackAsset(mediaType: mediaType, resourceId: resourceId) else {
+			return nil
+		}
+		do {
+			return try OfflinePlaybackAVAsset(playbackAsset: playbackAsset)
+		} catch {
+			schedulePlaybackAssetReplacement(mediaType: mediaType, resourceId: resourceId)
+			return nil
+		}
+	}
+
+	private func schedulePlaybackAssetReplacement(mediaType: OfflineMediaItemType, resourceId: ResourceId) {
+		let resource = OfflineResourceKey(resourceType: mediaType.rawValue, resourceId: resourceId.stringValue)
+		playbackReplacementLock.lock()
+		let inserted = playbackReplacementResources.insert(resource).inserted
+		playbackReplacementLock.unlock()
+		guard inserted else { return }
+
+		Task {
+			defer { finishPlaybackAssetReplacement(resource) }
+			do {
+				try offlineStore.invalidateMediaItem(resourceType: mediaType.rawValue, resourceId: resourceId.stringValue)
+				try await download(mediaType: mediaType, resourceId: resourceId)
+			} catch {
+				// Playback lookup remains nonthrowing. Resource state exposes a failed replacement registration.
+			}
+		}
+	}
+
+	private func finishPlaybackAssetReplacement(_ resource: OfflineResourceKey) {
+		playbackReplacementLock.lock()
+		playbackReplacementResources.remove(resource)
+		playbackReplacementLock.unlock()
 	}
 
 	public func getOfflineCollection(

--- a/Sources/Offliner/Offliner.swift
+++ b/Sources/Offliner/Offliner.swift
@@ -24,7 +24,9 @@ public final class Offliner {
 	}
 
 	public func setAllowDownloadsOnExpensiveNetworks(_ allowed: Bool) async {
-		guard isActive else { return }
+		guard isActive else {
+			return
+		}
 		await taskRunner.setAllowDownloadsOnExpensiveNetworks(allowed)
 	}
 
@@ -40,7 +42,9 @@ public final class Offliner {
 
 	@discardableResult
 	public func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void) -> Bool {
-		guard isActive else { return false }
+		guard isActive else {
+			return false
+		}
 		return mediaDownloader.handleBackgroundURLSessionEvents(
 			identifier: identifier,
 			completionHandler: completionHandler
@@ -54,7 +58,8 @@ public final class Offliner {
 		let artworkDownloader = ArtworkDownloader(fileStorage: storage.fileStorage)
 		let mediaDownloader = MediaDownloader(
 			configuration: configuration,
-			backgroundSessionIdentifier: storage.backgroundSessionIdentifier
+			backgroundSessionIdentifier: storage.backgroundSessionIdentifier,
+			fileStorage: storage.fileStorage
 		)
 		let licenseDownloader = LicenseDownloader(fileStorage: storage.fileStorage)
 		let resourceStateTracker = ResourceStateTracker(offlineStore: offlineStore)
@@ -67,8 +72,8 @@ public final class Offliner {
 		self.mediaDownloader = mediaDownloader
 		self.resourceStateTracker = resourceStateTracker
 		self.trackManifestFetcher = trackManifestFetcher
-		self.audioFormats = configuration.audioFormats
-		self.taskRunner = TaskRunner(
+		audioFormats = configuration.audioFormats
+		taskRunner = TaskRunner(
 			configuration: configuration,
 			offlineApiClient: offlineApiClient,
 			offlineStore: offlineStore,
@@ -81,11 +86,17 @@ public final class Offliner {
 		)
 
 		mediaDownloader.orphanedTaskHandler = { [weak self] taskId in
-			guard let self, self.isActive, let taskId else { return }
+			guard let self, isActive, let taskId else {
+				return
+			}
 			Task {
-				guard self.isActive else { return }
+				guard self.isActive else {
+					return
+				}
 				try? await self.offlineApiClient.updateTask(taskId: taskId, state: .failed)
-				guard self.isActive else { return }
+				guard self.isActive else {
+					return
+				}
 				await self.run()
 			}
 		}
@@ -110,8 +121,8 @@ public final class Offliner {
 		self.mediaDownloader = mediaDownloader
 		self.resourceStateTracker = resourceStateTracker
 		self.trackManifestFetcher = trackManifestFetcher
-		self.audioFormats = configuration.audioFormats
-		self.taskRunner = TaskRunner(
+		audioFormats = configuration.audioFormats
+		taskRunner = TaskRunner(
 			configuration: configuration,
 			offlineApiClient: offlineApiClient,
 			offlineStore: offlineStore,
@@ -125,7 +136,9 @@ public final class Offliner {
 	}
 
 	public func run() async {
-		guard isActive else { return }
+		guard isActive else {
+			return
+		}
 		await taskRunner.run()
 	}
 
@@ -184,7 +197,9 @@ public final class Offliner {
 		mediaType: OfflineMediaItemType,
 		resourceId: ResourceId
 	) async -> OfflinePlaybackAsset? {
-		guard isActive else { return nil }
+		guard isActive else {
+			return nil
+		}
 		do {
 			return try await offlineStore.getPlaybackAsset(mediaType: mediaType, resourceId: resourceId.stringValue)
 		} catch {
@@ -218,7 +233,9 @@ public final class Offliner {
 		playbackReplacementLock.lock()
 		let inserted = playbackReplacementResources.insert(resource).inserted
 		playbackReplacementLock.unlock()
-		guard inserted else { return }
+		guard inserted else {
+			return
+		}
 
 		Task {
 			defer { finishPlaybackAssetReplacement(resource) }
@@ -241,7 +258,9 @@ public final class Offliner {
 		collectionType: OfflineCollectionType,
 		resourceId: ResourceId
 	) -> AsyncStream<OfflineCollection?> {
-		guard isActive else { return AsyncStream { $0.finish() } }
+		guard isActive else {
+			return AsyncStream { $0.finish() }
+		}
 		return AsyncStream { continuation in
 			let task = Task {
 				let local = try? await offlineStore.getCollection(
@@ -267,10 +286,12 @@ public final class Offliner {
 		collectionType: OfflineCollectionType,
 		cursor: String? = nil
 	) -> AsyncStream<Set<OfflineCollection>> {
-		guard isActive else { return AsyncStream { $0.finish() } }
+		guard isActive else {
+			return AsyncStream { $0.finish() }
+		}
 		return AsyncStream { continuation in
 			let task = Task {
-				let local = (try? await offlineStore.getCollections(collectionType: collectionType)) ?? []
+				let local = await (try? offlineStore.getCollections(collectionType: collectionType)) ?? []
 				var collections = Set(local)
 				continuation.yield(collections)
 
@@ -304,7 +325,7 @@ public final class Offliner {
 		collectionType: OfflineCollectionType
 	) async throws -> Set<OfflineCollection> {
 		try ensureActive()
-		return Set(try await offlineStore.getCollections(collectionType: collectionType))
+		return try await Set(offlineStore.getCollections(collectionType: collectionType))
 	}
 
 	/// Returns the latest operation or local availability state for a media item or collection.
@@ -322,7 +343,9 @@ public final class Offliner {
 
 	/// Observes distinct state changes for one media item or collection until reset or cancellation.
 	public func observeOfflineResourceState(for resource: OfflineResource) -> AsyncStream<OfflineResourceState> {
-		guard isActive else { return AsyncStream { $0.finish() } }
+		guard isActive else {
+			return AsyncStream { $0.finish() }
+		}
 		let key = OfflineResourceKey(resource)
 		return AsyncStream { continuation in
 			let task = Task {
@@ -394,7 +417,7 @@ public final class Offliner {
 					case .downloaded: .downloaded
 					case .notDownloaded, .removing, .failed(action: .download): .notDownloaded
 					case .failed(action: .remove):
-						(try? await localResourceState(for: resource)) == .downloaded ? .downloaded : .notDownloaded
+						await (try? localResourceState(for: resource)) == .downloaded ? .downloaded : .notDownloaded
 					}
 					continuation.yield(legacyState)
 				}
@@ -431,7 +454,7 @@ public final class Offliner {
 				limit: limit,
 				after: cursor
 			)
-		case .title(let direction):
+		case let .title(direction):
 			(page, failures) = try await offlineStore.getCollectionItemsOrderByTitle(
 				collectionType: collectionType,
 				resourceId: resourceId,
@@ -439,7 +462,7 @@ public final class Offliner {
 				limit: limit,
 				after: cursor
 			)
-		case .album(let direction):
+		case let .album(direction):
 			(page, failures) = try await offlineStore.getCollectionItemsOrderByAlbum(
 				collectionType: collectionType,
 				resourceId: resourceId,
@@ -447,7 +470,7 @@ public final class Offliner {
 				limit: limit,
 				after: cursor
 			)
-		case .artist(let direction):
+		case let .artist(direction):
 			(page, failures) = try await offlineStore.getCollectionItemsOrderByArtist(
 				collectionType: collectionType,
 				resourceId: resourceId,
@@ -455,7 +478,7 @@ public final class Offliner {
 				limit: limit,
 				after: cursor
 			)
-		case .dateAdded(let direction):
+		case let .dateAdded(direction):
 			(page, failures) = try await offlineStore.getCollectionItemsOrderByDateAdded(
 				collectionType: collectionType,
 				resourceId: resourceId,
@@ -492,7 +515,9 @@ public final class Offliner {
 	}
 
 	private func scheduleRedownload(for failures: [FailedOfflineItem]) {
-		guard !failures.isEmpty else { return }
+		guard !failures.isEmpty else {
+			return
+		}
 		Task {
 			for failure in failures {
 				try? await download(mediaType: failure.mediaType, resourceId: .identifier(failure.resourceId))
@@ -560,19 +585,27 @@ public final class Offliner {
 		let localState = try await localResourceState(for: resource)
 		if let knownState = try await resourceStateTracker.state(for: key) {
 			if action == .store, localState == .downloaded,
-			   knownState == .downloaded || knownState == .failed(action: .remove) {
+			   knownState == .downloaded || knownState == .failed(action: .remove)
+			{
 				await resourceStateTracker.resolve(key, state: .downloaded)
 				return
 			}
 			if action == .remove, localState == .notDownloaded,
-			   knownState == .notDownloaded || knownState == .failed(action: .download) {
+			   knownState == .notDownloaded || knownState == .failed(action: .download)
+			{
 				await resourceStateTracker.resolve(key, state: .notDownloaded)
 				return
 			}
-			guard try await resourceStateTracker.begin(action, for: key) else { return }
+			guard try await resourceStateTracker.begin(action, for: key) else {
+				return
+			}
 		} else {
-			if action == .store, localState == .downloaded { return }
-			guard try await resourceStateTracker.begin(action, for: key) else { return }
+			if action == .store, localState == .downloaded {
+				return
+			}
+			guard try await resourceStateTracker.begin(action, for: key) else {
+				return
+			}
 		}
 		do {
 			switch action {
@@ -590,12 +623,12 @@ public final class Offliner {
 
 	private func localResourceState(for resource: OfflineResource) async throws -> OfflineResourceState {
 		switch resource {
-		case .media(let mediaType, let resourceId):
-			return try await offlineStore.getMediaItem(mediaType: mediaType, resourceId: resourceId) == nil
+		case let .media(mediaType, resourceId):
+			try await offlineStore.getMediaItem(mediaType: mediaType, resourceId: resourceId) == nil
 				? .notDownloaded
 				: .downloaded
-		case .collection(let collectionType, let resourceId):
-			return try await offlineStore.getCollection(
+		case let .collection(collectionType, resourceId):
+			try await offlineStore.getCollection(
 				collectionType: collectionType,
 				resourceId: collectionLocalResourceId(
 					collectionType: collectionType,
@@ -619,7 +652,9 @@ public final class Offliner {
 	}
 
 	private func ensureActive() throws {
-		guard isActive else { throw OfflinerLifecycleError.reset }
+		guard isActive else {
+			throw OfflinerLifecycleError.reset
+		}
 	}
 }
 
@@ -628,8 +663,8 @@ public final class Offliner {
 extension OfflineMediaItemType {
 	var toResourceType: ResourceType {
 		switch self {
-		case .tracks: return .track
-		case .videos: return .video
+		case .tracks: .track
+		case .videos: .video
 		}
 	}
 }
@@ -637,9 +672,9 @@ extension OfflineMediaItemType {
 extension OfflineCollectionType {
 	var toResourceType: ResourceType {
 		switch self {
-		case .albums: return .album
-		case .playlists: return .playlist
-		case .userCollectionTracks: return .userCollectionTracks
+		case .albums: .album
+		case .playlists: .playlist
+		case .userCollectionTracks: .userCollectionTracks
 		}
 	}
 }

--- a/Sources/Offliner/Offliner.swift
+++ b/Sources/Offliner/Offliner.swift
@@ -38,9 +38,13 @@ public final class Offliner {
 		}
 	}
 
-	public func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void) {
-		guard isActive else { return }
-		mediaDownloader.handleBackgroundURLSessionEvents(identifier: identifier, completionHandler: completionHandler)
+	@discardableResult
+	public func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void) -> Bool {
+		guard isActive else { return false }
+		return mediaDownloader.handleBackgroundURLSessionEvents(
+			identifier: identifier,
+			completionHandler: completionHandler
+		)
 	}
 
 	public init(installationId: String, configuration: Configuration) throws {

--- a/Sources/Offliner/Offliner.swift
+++ b/Sources/Offliner/Offliner.swift
@@ -292,6 +292,41 @@ public final class Offliner {
 		}
 	}
 
+	/// Returns the active aggregate download queue after backend task synchronization completes.
+	///
+	/// Collection metadata and member tasks count as one collection entry. Direct media downloads remain separate entries.
+	/// Successful operations disappear; failed downloads remain until explicitly retried, removed, or reset.
+	public func getOfflineDownloadQueue() async throws -> [OfflineDownloadQueueEntry] {
+		try ensureActive()
+		try await taskRunner.synchronizeDownloadQueue()
+		return try await resourceStateTracker.downloadQueueSnapshot()
+	}
+
+	/// Observes distinct aggregate download queue snapshots until cancellation or reset.
+	///
+	/// Every subscriber receives its own synchronized initial snapshot and all subsequent broadcasts. An initial backend or
+	/// local persistence failure terminates only that subscriber with the original error.
+	public func observeOfflineDownloadQueue() -> AsyncThrowingStream<[OfflineDownloadQueueEntry], Error> {
+		guard isActive else {
+			return AsyncThrowingStream { $0.finish(throwing: OfflinerLifecycleError.reset) }
+		}
+		return AsyncThrowingStream { continuation in
+			let task = Task {
+				do {
+					try await taskRunner.synchronizeDownloadQueue()
+					for await snapshot in try await resourceStateTracker.observeDownloadQueue() {
+						try Task.checkCancellation()
+						continuation.yield(snapshot)
+					}
+					continuation.finish()
+				} catch {
+					continuation.finish(throwing: error)
+				}
+			}
+			continuation.onTermination = { _ in task.cancel() }
+		}
+	}
+
 	/// Streams collection-level offline availability.
 	///
 	/// This compatibility stream maps the resource-scoped operation state into the original three availability states.

--- a/Sources/Offliner/README.md
+++ b/Sources/Offliner/README.md
@@ -90,7 +90,7 @@ Subscribe to new downloads as they're picked up for processing:
 
 ```swift
 for await download in offliner.newDownloads {
-    print("Started downloading: \(download.title) by \(download.artists)")
+    print("Task \(download.taskId) started \(download.resource)")
 }
 ```
 
@@ -104,8 +104,7 @@ let downloads = await offliner.currentDownloads
 
 #### Collection Download State
 
-Subscribe to collection download-state changes for albums, playlists, and user collection tracks. The stream emits an
-initial local state from local storage and active in-memory SDK work, then continues polling for local changes:
+The compatibility collection stream remains available for its original three-state UI:
 
 ```swift
 for await state in offliner.getOfflineCollectionDownloadState(
@@ -116,9 +115,6 @@ for await state in offliner.getOfflineCollectionDownloadState(
 }
 ```
 
-The stream is optimized for view entry and does not poll backend task inventory. Backend-provided per-collection
-activity metadata would be required for authoritative task state after a cold start.
-
 | State | Meaning |
 | --- | --- |
 | `.notDownloaded` | The collection is not locally available, or it is being removed. |
@@ -127,6 +123,30 @@ activity metadata would be required for authoritative task state after a cold st
 
 Removal tasks are not surfaced as `.downloading`; callers can map this state directly to a download button label:
 `Download`, `Downloading...`, and `Downloaded`.
+
+For resource-scoped media and collection state, use the normalized snapshot and observation APIs:
+
+```swift
+let resource = OfflineResource.collection(type: .albums, resourceId: "album-id")
+let state = try await offliner.getOfflineResourceState(for: resource)
+
+for await state in offliner.observeOfflineResourceState(for: resource) {
+    switch state {
+    case .notDownloaded, .queued, .downloading, .downloaded, .removing:
+        break
+    case .failed(let action):
+        // `action` is `.download` or `.remove` and is the stable retry direction.
+        break
+    }
+}
+```
+
+Queued, removing, and failed operation state is stored in the installation-scoped Offliner database and recovered on a
+new `Offliner` instance. Backend task inventory refreshes queued versus active transfer state when connectivity permits;
+a refresh failure does not hide locally stored content or discard the last known operation. Streams finish when the
+instance is reset. Repeating the same active request is idempotent. An opposite request while work is queued, downloading,
+or removing throws `OfflineResourceOperationError.conflictingOperationInProgress` so collection removal cannot race its
+member stores.
 
 #### Tracking Individual Download Progress
 

--- a/Sources/Offliner/README.md
+++ b/Sources/Offliner/README.md
@@ -189,6 +189,32 @@ let allAlbums = try await offliner.getOfflineCollections(collectionType: .albums
 let allPlaylists = try await offliner.getOfflineCollections(collectionType: .playlists)
 ```
 
+For a finite, local-only snapshot that preserves database errors and works without a network connection, use:
+
+```swift
+let storedAlbums = try await offliner.getStoredOfflineCollections(collectionType: .albums)
+let storedPlaylists = try await offliner.getStoredOfflineCollections(collectionType: .playlists)
+```
+
+The existing streams continue to combine local state with pending backend inventory for compatibility.
+
+### Logout and Installation Changes
+
+Offline databases, artwork, licenses, media bookmarks, and background download sessions are isolated by the
+`installationId` passed to `Offliner`. Before discarding an instance during logout or an installation/account change,
+reset it and await completion:
+
+```swift
+try await offliner.reset()
+```
+
+Reset is local-only: it cancels and awaits ongoing work, removes that installation's local data and artifacts, and does
+not enqueue backend removals. A reset instance is permanently invalid; create a new `Offliner` for the next session.
+
+When upgrading from an SDK version that used the original unscoped store, the first installation initialized after the
+upgrade claims and migrates that existing database and its artwork/license directories into installation-scoped
+storage. Its persisted bookmarks are retained and renewed when needed.
+
 ### Collection Items (Paginated)
 
 Get items within a collection using cursor-based pagination:

--- a/Sources/Offliner/README.md
+++ b/Sources/Offliner/README.md
@@ -161,7 +161,7 @@ Retrieve a specific offline media item:
 
 ```swift
 if let track = try await offliner.getOfflineMediaItem(mediaType: .tracks, resourceId: "track-id") {
-    // Access mediaURL, licenseURL, artworkURL, catalogMetadata, and playbackMetadata
+    // Access artworkURL, catalogMetadata, and playbackMetadata without resolving playback files
 }
 ```
 
@@ -322,12 +322,53 @@ Removal requests are registered with the backend and task processing is triggere
 
 ## Offline Playback
 
-Offliner conforms to `OfflineItemProvider` (from the Player module), so it can be used directly as the offline content source for the Player:
+Offliner exposes a Player-independent playback asset lookup. The lookup resolves the stored media and license file bookmarks only when playback is requested:
 
 ```swift
-let item = await offliner.get(productType: .TRACK, productId: "track-id")
-// Returns an OfflinePlaybackItem with mediaURL, licenseURL, format, and normalization data
+let asset = await offliner.getOfflinePlaybackAsset(
+    mediaType: .tracks,
+    resourceId: .identifier("track-id")
+)
+// Returns mediaURL, licenseURL, and playback metadata, or nil when no playable asset is stored.
 ```
+
+Offliner has no dependency on the Player module because Player does not support watchOS. Consumers that use Player can declare the `OfflineItemProvider` conformance in a target that links both products:
+
+```swift
+import Offliner
+import Player
+
+extension Offliner: @retroactive OfflineItemProvider {
+    public func get(productType: ProductType, productId: String) async -> OfflinePlaybackItem? {
+        let mediaType: OfflineMediaItemType
+        switch productType {
+        case .TRACK: mediaType = .tracks
+        case .VIDEO: mediaType = .videos
+        case .UC: return nil
+        }
+
+        guard let asset = await getOfflinePlaybackAsset(
+            mediaType: mediaType,
+            resourceId: .identifier(productId)
+        ) else {
+            return nil
+        }
+
+        return OfflinePlaybackItem(
+            mediaURL: asset.mediaURL,
+            licenseURL: asset.licenseURL,
+            format: asset.playbackMetadata?.format.rawValue,
+            albumReplayGain: asset.playbackMetadata?.albumNormalizationData?.replayGain,
+            albumPeakAmplitude: asset.playbackMetadata?.albumNormalizationData?.peakAmplitude,
+            productType: productType
+        )
+    }
+}
+```
+
+## Platform Support
+
+Offliner supports iOS 15+, macOS 12+, and watchOS 10+. Its shared download pipeline uses `AVAssetDownloadConfiguration`, KVO progress observation, and the platform-appropriate asset location delegate callback.
 
 ---
 

--- a/Sources/Offliner/README.md
+++ b/Sources/Offliner/README.md
@@ -403,6 +403,45 @@ let asset = await offliner.getOfflinePlaybackAsset(
 // Returns mediaURL, licenseURL, and playback metadata, or nil when no playable asset is stored.
 ```
 
+On watchOS, do not create a plain `AVURLAsset` from `mediaURL` when `licenseURL` is present. Prepare the asset through
+Offliner so protected downloads receive their persisted FairPlay license:
+
+```swift
+import AVFoundation
+import Offliner
+
+final class QueuedOfflinePlayback {
+    // Retain this wrapper for the entire lifetime of playerItem, including while it is queued.
+    let preparedAsset: OfflinePlaybackAVAsset
+    let playerItem: AVPlayerItem
+
+    init(preparedAsset: OfflinePlaybackAVAsset) {
+        self.preparedAsset = preparedAsset
+        playerItem = AVPlayerItem(asset: preparedAsset.urlAsset)
+    }
+}
+
+guard let preparedAsset = await offliner.getOfflinePlaybackAVAsset(
+    mediaType: .tracks,
+    resourceId: .identifier("track-id")
+) else {
+    // The item is unavailable; Offliner schedules an idempotent replacement download when stored files are corrupt.
+    return
+}
+
+let queuedPlayback = QueuedOfflinePlayback(preparedAsset: preparedAsset)
+player.insert(queuedPlayback.playerItem, after: nil)
+// Keep queuedPlayback alive until its playerItem has been removed from the queue.
+```
+
+`getOfflinePlaybackAVAsset` is the supported watchOS lookup. `OfflinePlaybackAVAsset` creates no content-key session for
+unprotected media. For protected media it loads the stored
+license, creates an `AVContentKeySession(.fairPlayStreaming)`, installs the stored-license delegate, and registers its
+`urlAsset` as the content-key recipient. If preparation fails, the lookup returns `nil`, invalidates the corrupt local item,
+and schedules one idempotent replacement download without enqueueing a backend removal. The public throwing initializer is
+also available when a consumer needs the exact missing/unreadable stored-license error for diagnostics.
+Real FairPlay playback remains part of TM-1574 device validation.
+
 Offliner has no dependency on the Player module because Player does not support watchOS. Consumers that use Player can declare the `OfflineItemProvider` conformance in a target that links both products:
 
 ```swift

--- a/Sources/Offliner/README.md
+++ b/Sources/Offliner/README.md
@@ -84,6 +84,31 @@ These methods register the download request with the backend and automatically t
 
 ### Monitoring Downloads
 
+#### Aggregate Download Queue
+
+Use the aggregate queue when the UI needs a relaunch-safe list of queued, active, and failed download operations. The
+finite snapshot waits for backend task synchronization and preserves synchronization or local persistence errors:
+
+```swift
+let queue = try await offliner.getOfflineDownloadQueue()
+
+for try await queue in offliner.observeOfflineDownloadQueue() {
+    for entry in queue {
+        print("\(entry.resource): \(entry.state), progress: \(String(describing: entry.progress))")
+    }
+}
+```
+
+Every observer receives the same synchronized initial snapshot and subsequent distinct snapshots. Collection metadata
+and member tasks are counted once under the top-level collection when their relationship is known. A directly requested
+track or video remains a media entry and may expose its `parentCollection`. `progress` is optional because metadata tasks
+and restored backend tasks may not expose transfer progress.
+
+Queue state is limited to `.queued`, `.downloading`, and `.failed(action: .download)`. A successful operation disappears
+from the active queue. A terminal failure remains available after relaunch until retry, removal, or reset; pass
+`entry.resource` back to the matching media or collection `download(...)` overload to retry. Queue observers are
+independent broadcasts and finish when the Offliner instance is reset.
+
 #### New Downloads Stream
 
 Subscribe to new downloads as they're picked up for processing:

--- a/Sources/Offliner/Types.swift
+++ b/Sources/Offliner/Types.swift
@@ -2,14 +2,14 @@ import Foundation
 
 // MARK: - OfflineMediaItemType
 
-public enum OfflineMediaItemType: String, Sendable {
+public enum OfflineMediaItemType: String, Sendable, Hashable {
 	case tracks
 	case videos
 }
 
 // MARK: - OfflineCollectionType
 
-public enum OfflineCollectionType: String, Sendable {
+public enum OfflineCollectionType: String, Sendable, Hashable {
 	case albums
 	case playlists
 	case userCollectionTracks
@@ -17,7 +17,7 @@ public enum OfflineCollectionType: String, Sendable {
 
 // MARK: - ResourceId
 
-public enum ResourceId: Sendable {
+public enum ResourceId: Sendable, Hashable {
 	case identifier(String)
 	case me
 
@@ -27,6 +27,40 @@ public enum ResourceId: Sendable {
 		case .me: "me"
 		}
 	}
+}
+
+// MARK: - OfflineResource
+
+/// A stable identity for a resource managed by Offliner.
+public enum OfflineResource: Sendable, Hashable {
+	case media(type: OfflineMediaItemType, resourceId: String)
+	case collection(type: OfflineCollectionType, resourceId: String)
+}
+
+/// The operation requested for an offline resource.
+public enum OfflineResourceAction: String, Sendable, Hashable {
+	case download
+	case remove
+}
+
+// MARK: - OfflineResourceState
+
+/// The normalized local operation and availability state of an offline resource.
+public enum OfflineResourceState: Sendable, Hashable {
+	case notDownloaded
+	case queued
+	case downloading
+	case downloaded
+	case removing
+	/// The operation failed. The associated action is the stable retry direction.
+	case failed(action: OfflineResourceAction)
+}
+
+// MARK: - OfflineResourceOperationError
+
+public enum OfflineResourceOperationError: Error, Sendable, Equatable {
+	/// The requested action conflicts with an operation already in progress for this resource.
+	case conflictingOperationInProgress(currentState: OfflineResourceState)
 }
 
 // MARK: - OfflineMediaItem
@@ -105,19 +139,17 @@ public enum OfflineCollectionState: Hashable {
 
 // MARK: - OfflineCollectionDownloadState
 
-/// Collection-level offline availability for albums, playlists, and user collection tracks.
+/// Compatibility collection availability for albums, playlists, and user collection tracks.
 ///
-/// This state describes whether collection media is available offline or known by this SDK instance to be acquired. It
-/// does not model generic offliner task activity: collection removal is represented as `notDownloaded`, not
-/// `downloading`.
+/// Use `OfflineResourceState` when queued, removal, and failure states are needed.
 public enum OfflineCollectionDownloadState: Sendable, Hashable {
-	/// The collection is not locally downloaded, or it is being removed.
+	/// The collection is not locally downloaded, is being removed, or its download failed.
 	case notDownloaded
 
 	/// The collection or one of its members has active download/acquisition work known by this SDK instance.
 	case downloading
 
-	/// The collection is locally stored and there is no locally known pending download/acquisition work.
+	/// The collection is locally stored, including after a failed removal.
 	case downloaded
 }
 

--- a/Sources/Offliner/Types.swift
+++ b/Sources/Offliner/Types.swift
@@ -217,6 +217,11 @@ public enum OfflineCollectionItemSort: Hashable {
 	case dateAdded(direction: SortDirection)
 }
 
+/// An error produced when an operation is attempted on an Offliner instance after it has been reset.
+public enum OfflinerLifecycleError: Error {
+	case reset
+}
+
 // MARK: - OfflineCollectionItem
 
 public struct OfflineCollectionItem {

--- a/Sources/Offliner/Types.swift
+++ b/Sources/Offliner/Types.swift
@@ -63,6 +63,41 @@ public enum OfflineResourceOperationError: Error, Sendable, Equatable {
 	case conflictingOperationInProgress(currentState: OfflineResourceState)
 }
 
+// MARK: - OfflineDownloadQueueEntry
+
+/// One top-level download operation in the active Offliner queue.
+///
+/// Collection metadata and member tasks are aggregated into one collection entry when their relationship is known.
+/// A directly requested media item remains a media entry and exposes its related collection separately.
+public struct OfflineDownloadQueueEntry: Sendable, Hashable {
+	public enum State: Sendable, Hashable {
+		case queued
+		case downloading
+		/// A terminal failure. Download queues only expose the `.download` action.
+		case failed(action: OfflineResourceAction)
+	}
+
+	/// The stable top-level resource identity to pass back to `download(...)` when retrying.
+	public let resource: OfflineResource
+	/// The related collection for a directly requested media item, when supplied by the backend task.
+	public let parentCollection: OfflineResource?
+	public let state: State
+	/// Aggregate transfer progress in `0 ... 1`, or `nil` until progress is known.
+	public let progress: Double?
+
+	public init(
+		resource: OfflineResource,
+		parentCollection: OfflineResource?,
+		state: State,
+		progress: Double?
+	) {
+		self.resource = resource
+		self.parentCollection = parentCollection
+		self.state = state
+		self.progress = progress
+	}
+}
+
 // MARK: - OfflineMediaItem
 
 public struct OfflineMediaItem {

--- a/Sources/Offliner/Types.swift
+++ b/Sources/Offliner/Types.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Player
 
 // MARK: - OfflineMediaItemType
 
@@ -79,12 +78,22 @@ public struct OfflineMediaItem {
 	public let artworkURL: URL?
 }
 
-// MARK: - PlayableOfflineMediaItem
+// MARK: - OfflinePlaybackAsset
 
-struct PlayableOfflineMediaItem {
-	let playbackMetadata: OfflineMediaItem.PlaybackMetadata?
-	let mediaURL: URL
-	let licenseURL: URL?
+public struct OfflinePlaybackAsset {
+	public let playbackMetadata: OfflineMediaItem.PlaybackMetadata?
+	public let mediaURL: URL
+	public let licenseURL: URL?
+
+	public init(
+		playbackMetadata: OfflineMediaItem.PlaybackMetadata?,
+		mediaURL: URL,
+		licenseURL: URL?
+	) {
+		self.playbackMetadata = playbackMetadata
+		self.mediaURL = mediaURL
+		self.licenseURL = licenseURL
+	}
 }
 
 // MARK: - OfflineCollectionState

--- a/Sources/TidalAPI/Utils/TidalAPIError.swift
+++ b/Sources/TidalAPI/Utils/TidalAPIError.swift
@@ -35,9 +35,12 @@ public struct TidalAPIError: LocalizedError, Equatable {
 		self.underlyingError = underlyingError
 	}
 
-	public var errorDescription: String {
+	/// Must be `String?` to witness `LocalizedError.errorDescription`; a non-optional declaration is ignored and
+	/// `localizedDescription` falls back to the generic "The operation couldn't be completed" NSError text.
+	public var errorDescription: String? {
 		"""
 		API Error: \(String(describing: statusCode))
+		Message: \(message)
 		URL: \(url)
 		SubStatus: \(String(describing: subStatus))
 		"""

--- a/Tests/OfflinerTests/CollectionDownloadTests.swift
+++ b/Tests/OfflinerTests/CollectionDownloadTests.swift
@@ -155,7 +155,7 @@ final class CollectionDownloadTests: OfflinerTestCase {
 		XCTAssertEqual(state, .notDownloaded)
 	}
 
-	func testRedownloadAlbumDeletesOldArtworkAndStoresNewOne() async throws {
+	func testRepeatedDownloadAlbumIsIdempotentAfterCompletion() async throws {
 		let backend = StubOfflineApiClient()
 		let offliner = createOffliner(
 			offlineApiClient: backend,
@@ -180,9 +180,10 @@ final class CollectionDownloadTests: OfflinerTestCase {
 		let secondCollection = try XCTUnwrap(secondCollectionOptional)
 		let secondArtworkURL = try XCTUnwrap(secondCollection.artworkURL)
 
-		XCTAssertFalse(FileManager.default.fileExists(atPath: firstArtworkURL.path))
+		XCTAssertTrue(FileManager.default.fileExists(atPath: firstArtworkURL.path))
 		XCTAssertTrue(FileManager.default.fileExists(atPath: secondArtworkURL.path))
-		XCTAssertNotEqual(firstArtworkURL, secondArtworkURL)
+		XCTAssertEqual(firstArtworkURL, secondArtworkURL)
+		XCTAssertEqual(backend.addedItems.count, 1)
 	}
 
 	func testDownloadAlbumFailsWhenArtworkDownloadFails() async throws {

--- a/Tests/OfflinerTests/CollectionItemsTests.swift
+++ b/Tests/OfflinerTests/CollectionItemsTests.swift
@@ -124,7 +124,10 @@ final class CollectionItemsTests: OfflinerTestCase {
 		backend.enqueueTasks(tasks)
 		try await runAllTasks(offliner, backend: backend, expectedDownloads: 3)
 
-		let storedPlayableItem = await offliner.get(productType: .TRACK, productId: "track-2")
+		let storedPlayableItem = await offliner.getOfflinePlaybackAsset(
+			mediaType: .tracks,
+			resourceId: .identifier("track-2")
+		)
 		let mediaURL = try XCTUnwrap(storedPlayableItem?.mediaURL)
 		try FileManager.default.removeItem(at: mediaURL)
 
@@ -135,7 +138,10 @@ final class CollectionItemsTests: OfflinerTestCase {
 		)
 
 		XCTAssertEqual(page.items.map(\.item.catalogMetadata.id), ["track-1", "track-2", "track-3"])
-		let playableItem = await offliner.get(productType: .TRACK, productId: "track-2")
+		let playableItem = await offliner.getOfflinePlaybackAsset(
+			mediaType: .tracks,
+			resourceId: .identifier("track-2")
+		)
 		XCTAssertNil(playableItem)
 	}
 

--- a/Tests/OfflinerTests/DownloadQueueTests.swift
+++ b/Tests/OfflinerTests/DownloadQueueTests.swift
@@ -1,0 +1,375 @@
+@testable import Offliner
+import TidalAPI
+import XCTest
+
+// MARK: - DownloadQueueTests
+
+final class DownloadQueueTests: OfflinerTestCase {
+	func testSnapshotWaitsForBackendSynchronization() async throws {
+		let backend = BlockingGetTasksOfflineApiClient()
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+		let snapshotTask = Task { try await offliner.getOfflineDownloadQueue() }
+
+		await backend.waitUntilRequested()
+		XCTAssertFalse(snapshotTask.isCancelled)
+		await backend.resume(with: [.storeAlbum(storeAlbumTask(id: "album-task"))])
+
+		let snapshot = try await snapshotTask.value
+		XCTAssertEqual(snapshot, [OfflineDownloadQueueEntry(
+			resource: .collection(type: .albums, resourceId: "album-1"),
+			parentCollection: nil,
+			state: .queued,
+			progress: nil
+		)])
+	}
+
+	func testSnapshotPreservesSynchronizationError() async {
+		let offliner = createOffliner(
+			offlineApiClient: FailOnGetTasksOfflineApiClient(),
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+
+		await XCTAssertThrowsErrorAsync {
+			_ = try await offliner.getOfflineDownloadQueue()
+		}
+	}
+
+	func testObservationBroadcastsDistinctProgressAndCompletionToEverySubscriber() async throws {
+		let backend = StubOfflineApiClient()
+		let media = SucceedingMediaDownloader()
+		media.progressValues = [0.25, 0.25, 0.75]
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: media
+		)
+		var first = offliner.observeOfflineDownloadQueue().makeAsyncIterator()
+		var second = offliner.observeOfflineDownloadQueue().makeAsyncIterator()
+		let firstInitial = try await first.next()
+		let secondInitial = try await second.next()
+		XCTAssertEqual(firstInitial, [])
+		XCTAssertEqual(secondInitial, [])
+
+		try await offliner.download(mediaType: .tracks, resourceId: .identifier("track-1"))
+		let firstQueued = try await first.next()
+		let secondQueued = try await second.next()
+		XCTAssertEqual(firstQueued, secondQueued)
+		XCTAssertEqual(firstQueued?.first?.state, .queued)
+
+		await offliner.run()
+		await backend.waitForTasksToComplete()
+		let firstUpdates = try await collectUntilEmpty(&first)
+		let secondUpdates = try await collectUntilEmpty(&second)
+
+		XCTAssertEqual(firstUpdates, secondUpdates)
+		XCTAssertTrue(firstUpdates.contains { $0.first?.state == .downloading })
+		XCTAssertEqual(firstUpdates.filter { $0.first?.progress == 0.25 }.count, 1)
+		XCTAssertTrue(firstUpdates.contains { $0.first?.progress == 0.75 })
+		XCTAssertEqual(firstUpdates.last, [])
+	}
+
+	func testObservationFinishesOnReset() async throws {
+		let offliner = createOffliner(
+			offlineApiClient: HoldingOfflineApiClient(),
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+		var iterator = offliner.observeOfflineDownloadQueue().makeAsyncIterator()
+		let initial = try await iterator.next()
+		XCTAssertEqual(initial, [])
+
+		try await offliner.reset()
+
+		let afterReset = try await iterator.next()
+		XCTAssertNil(afterReset)
+	}
+
+	func testCancelledObservationFinishesOnlyThatSubscriber() async throws {
+		let backend = HoldingOfflineApiClient()
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+		let started = expectation(description: "subscriber started")
+		let cancelledConsumer = Task {
+			do {
+				for try await _ in offliner.observeOfflineDownloadQueue() {
+					started.fulfill()
+				}
+			} catch is CancellationError {
+				// Expected.
+			}
+		}
+		await fulfillment(of: [started])
+		cancelledConsumer.cancel()
+		try await cancelledConsumer.value
+
+		var remaining = offliner.observeOfflineDownloadQueue().makeAsyncIterator()
+		let initial = try await remaining.next()
+		XCTAssertEqual(initial, [])
+		try await offliner.download(mediaType: .videos, resourceId: .identifier("video-1"))
+		let queued = try await remaining.next()
+		XCTAssertEqual(queued?.first?.resource, .media(type: .videos, resourceId: "video-1"))
+	}
+
+	func testCollectionMetadataAndMembersAggregateAsOneEntry() async throws {
+		let backend = StubOfflineApiClient()
+		backend.enqueueTasks([
+			.storeTrack(storeTrackTask(id: "track-1", trackId: "track-1", position: 1)),
+			.storeTrack(storeTrackTask(id: "track-2", trackId: "track-2", position: 2)),
+			.storeAlbum(storeAlbumTask(id: "album-metadata")),
+		])
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+
+		let snapshot = try await offliner.getOfflineDownloadQueue()
+
+		XCTAssertEqual(snapshot.count, 1)
+		XCTAssertEqual(snapshot.first?.resource, .collection(type: .albums, resourceId: "album-1"))
+		XCTAssertNil(snapshot.first?.parentCollection)
+		XCTAssertEqual(snapshot.first?.state, .queued)
+	}
+
+	func testTerminalCollectionMetadataDoesNotAbsorbStandaloneMedia() async throws {
+		let backend = StubOfflineApiClient()
+		let media = SuspendingMediaDownloader()
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: media
+		)
+		try await offliner.download(mediaType: .tracks, resourceId: .identifier("track-1"))
+		backend.enqueueTasks([.terminal(TerminalOfflineTask(
+			id: "historical-album-metadata",
+			state: .completed,
+			action: .store,
+			resourceType: "albums",
+			resourceId: "stub-album",
+			collectionResourceType: nil,
+			collectionResourceId: nil
+		))])
+		await media.waitUntilStarted()
+
+		let snapshot = try await offliner.getOfflineDownloadQueue()
+
+		XCTAssertEqual(snapshot.count, 1)
+		XCTAssertEqual(snapshot.first?.resource, .media(type: .tracks, resourceId: "track-1"))
+		XCTAssertEqual(snapshot.first?.parentCollection, .collection(type: .albums, resourceId: "stub-album"))
+		XCTAssertEqual(snapshot.first?.state, .downloading)
+	}
+
+	func testCollectionMetadataFailureRemainsInQueue() async throws {
+		let backend = StubOfflineApiClient()
+		backend.enqueueTasks([.storeAlbum(storeAlbumTask(id: "album-metadata"))])
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: FailingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+
+		await offliner.run()
+		await backend.waitForTasksToComplete()
+		let snapshot = try await offliner.getOfflineDownloadQueue()
+
+		XCTAssertEqual(snapshot.count, 1)
+		XCTAssertEqual(snapshot.first?.resource, .collection(type: .albums, resourceId: "album-1"))
+		XCTAssertEqual(snapshot.first?.state, .failed(action: .download))
+	}
+
+	func testFailedCollectionMemberSurvivesLaterSiblingCompletion() async throws {
+		let backend = StubOfflineApiClient()
+		let media = SelectiveSuspendingMediaDownloader(failingTaskIds: ["failing-track"])
+		backend.enqueueTasks([
+			.storeTrack(storeTrackTask(id: "failing-track", trackId: "track-1", position: 1)),
+			.storeTrack(storeTrackTask(id: "succeeding-track", trackId: "track-2", position: 2)),
+		])
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: media
+		)
+
+		await offliner.run()
+		await media.waitUntilStarted(count: 2)
+		await media.complete(taskId: "succeeding-track")
+		await backend.waitForTasksToComplete()
+		let snapshot = try await offliner.getOfflineDownloadQueue()
+
+		XCTAssertEqual(snapshot.count, 1)
+		XCTAssertEqual(snapshot.first?.resource, .collection(type: .albums, resourceId: "album-1"))
+		XCTAssertEqual(snapshot.first?.state, .failed(action: .download))
+	}
+
+	func testStandaloneMediaFailurePersistsAcrossRecreationWithRetryIdentity() async throws {
+		let installationId = "failed-media-queue"
+		let backend = StubOfflineApiClient()
+		var first: Offliner? = Offliner(
+			storage: try OfflinerStorage(installationId: installationId, baseDirectory: tempDir),
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: FailingMediaDownloader(),
+			trackManifestFetcher: SucceedingTrackManifestFetcher(),
+			videoManifestFetcher: SucceedingVideoManifestFetcher()
+		)
+		try await first?.download(mediaType: .tracks, resourceId: .identifier("track-1"))
+		await first?.run()
+		await backend.waitForTasksToComplete()
+		first = nil
+
+		let second = createOffliner(
+			installationId: installationId,
+			offlineApiClient: HoldingOfflineApiClient(),
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+		let snapshot = try await second.getOfflineDownloadQueue()
+
+		XCTAssertEqual(snapshot.count, 1)
+		XCTAssertEqual(snapshot.first?.resource, .media(type: .tracks, resourceId: "track-1"))
+		XCTAssertEqual(snapshot.first?.parentCollection, .collection(type: .albums, resourceId: "stub-album"))
+		XCTAssertEqual(snapshot.first?.state, .failed(action: .download))
+	}
+
+	func testSuccessfulDownloadDisappearsFromQueue() async throws {
+		let backend = StubOfflineApiClient()
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+		try await offliner.download(mediaType: .tracks, resourceId: .identifier("track-1"))
+
+		await offliner.run()
+		await backend.waitForTasksToComplete()
+
+		let snapshot = try await offliner.getOfflineDownloadQueue()
+		XCTAssertEqual(snapshot, [])
+	}
+
+	func testFailedEntryResourceCanBeUsedToRetry() async throws {
+		let backend = FailOnceAddOfflineApiClient()
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+		await XCTAssertThrowsErrorAsync {
+			try await offliner.download(collectionType: .playlists, resourceId: .identifier("playlist-1"))
+		}
+		let failedSnapshot = try await offliner.getOfflineDownloadQueue()
+		let failed = try XCTUnwrap(failedSnapshot.first)
+
+		try await retry(failed.resource, with: offliner)
+
+		let retrySnapshot = try await offliner.getOfflineDownloadQueue()
+		let retried = try XCTUnwrap(retrySnapshot.first)
+		XCTAssertEqual(retried.resource, failed.resource)
+		XCTAssertEqual(retried.state, .queued)
+		let addCallCount = await backend.addCallCount
+		XCTAssertEqual(addCallCount, 2)
+	}
+
+	private func collectUntilEmpty(
+		_ iterator: inout AsyncThrowingStream<[OfflineDownloadQueueEntry], Error>.Iterator
+	) async throws -> [[OfflineDownloadQueueEntry]] {
+		var updates: [[OfflineDownloadQueueEntry]] = []
+		while let snapshot = try await iterator.next() {
+			updates.append(snapshot)
+			if snapshot.isEmpty { return updates }
+		}
+		return updates
+	}
+
+	private func retry(_ resource: OfflineResource, with offliner: Offliner) async throws {
+		switch resource {
+		case .media(let type, let resourceId):
+			try await offliner.download(mediaType: type, resourceId: .identifier(resourceId))
+		case .collection(let type, let resourceId):
+			try await offliner.download(collectionType: type, resourceId: .identifier(resourceId))
+		}
+	}
+
+	private func storeAlbumTask(id: String) -> StoreAlbumTask {
+		StoreAlbumTask(
+			id: id,
+			album: AlbumsResourceObject(id: "album-1", type: "albums"),
+			artists: [],
+			artwork: nil
+		)
+	}
+
+	private func storeTrackTask(id: String, trackId: String, position: Int) -> StoreTrackTask {
+		StoreTrackTask(
+			id: id,
+			track: TracksResourceObject(id: trackId, type: "tracks"),
+			artists: [],
+			artwork: nil,
+			collectionResourceType: "albums",
+			collectionResourceId: "album-1",
+			volume: 1,
+			position: position
+		)
+	}
+}
+
+private actor BlockingGetTasksOfflineApiClient: OfflineApiClientProtocol {
+	private var requested = false
+	private var requestedContinuation: CheckedContinuation<Void, Never>?
+	private var responseContinuation: CheckedContinuation<(tasks: [OfflineTask], cursor: String?), Never>?
+
+	func addItem(type: ResourceType, id: String) async throws {}
+	func removeItem(type: ResourceType, id: String) async throws {}
+	func updateTask(taskId: String, state: Download.State) async throws {}
+
+	func getTasks(cursor: String?) async throws -> (tasks: [OfflineTask], cursor: String?) {
+		requested = true
+		requestedContinuation?.resume()
+		requestedContinuation = nil
+		return await withCheckedContinuation { responseContinuation = $0 }
+	}
+
+	func waitUntilRequested() async {
+		if requested { return }
+		await withCheckedContinuation { requestedContinuation = $0 }
+	}
+
+	func resume(with tasks: [OfflineTask]) {
+		responseContinuation?.resume(returning: (tasks, nil))
+		responseContinuation = nil
+	}
+}
+
+private actor FailOnceAddOfflineApiClient: OfflineApiClientProtocol {
+	private(set) var addCallCount = 0
+
+	func addItem(type: ResourceType, id: String) async throws {
+		addCallCount += 1
+		if addCallCount == 1 { throw FakeError.backendFailed }
+	}
+
+	func removeItem(type: ResourceType, id: String) async throws {}
+	func getTasks(cursor: String?) async throws -> (tasks: [OfflineTask], cursor: String?) { ([], nil) }
+	func updateTask(taskId: String, state: Download.State) async throws {}
+}
+
+private func XCTAssertThrowsErrorAsync(
+	_ expression: () async throws -> Void,
+	file: StaticString = #filePath,
+	line: UInt = #line
+) async {
+	do {
+		try await expression()
+		XCTFail("Expected error", file: file, line: line)
+	} catch {
+		// Expected.
+	}
+}

--- a/Tests/OfflinerTests/GetCollectionsStreamTests.swift
+++ b/Tests/OfflinerTests/GetCollectionsStreamTests.swift
@@ -2,6 +2,25 @@
 import XCTest
 
 final class GetCollectionsStreamTests: OfflinerTestCase {
+	func testStoredCollectionsSnapshotIsLocalOnlyAndPreservesDatabaseErrors() async throws {
+		let offliner = createOffliner(
+			offlineApiClient: FailingOfflineApiClient(),
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+
+		let collections = try await offliner.getStoredOfflineCollections(collectionType: .albums)
+		XCTAssertTrue(collections.isEmpty)
+		try await lastDatabaseQueue.write { database in
+			try database.drop(table: "offline_item")
+		}
+
+		do {
+			_ = try await offliner.getStoredOfflineCollections(collectionType: .albums)
+			XCTFail("Expected the local database error to be preserved")
+		} catch {}
+	}
+
 	func testGetOfflineCollectionEmitsLocalThenBackendPending() async throws {
 		let backend = StubOfflineApiClient()
 		let offliner = createOffliner(

--- a/Tests/OfflinerTests/ManifestFetcherTests.swift
+++ b/Tests/OfflinerTests/ManifestFetcherTests.swift
@@ -1,0 +1,17 @@
+@testable import Offliner
+import TidalAPI
+import XCTest
+
+final class ManifestFetcherTests: XCTestCase {
+	func testFullTrackPresentationIsAccepted() throws {
+		XCTAssertNoThrow(try validateFullTrackPresentation(.full))
+	}
+
+	func testPreviewTrackPresentationIsRejected() {
+		XCTAssertThrowsError(try validateFullTrackPresentation(.preview))
+	}
+
+	func testMissingTrackPresentationIsRejected() {
+		XCTAssertThrowsError(try validateFullTrackPresentation(nil))
+	}
+}

--- a/Tests/OfflinerTests/MediaItemDownloadTests.swift
+++ b/Tests/OfflinerTests/MediaItemDownloadTests.swift
@@ -132,7 +132,10 @@ final class MediaItemDownloadTests: OfflinerTestCase {
 
 		let firstItem = try await offliner.getOfflineMediaItem(mediaType: .tracks, resourceId: .identifier("track-123"))
 		let firstItemUnwrapped = try XCTUnwrap(firstItem)
-		let firstPlayableItem = await offliner.get(productType: .TRACK, productId: "track-123")
+		let firstPlayableItem = await offliner.getOfflinePlaybackAsset(
+			mediaType: .tracks,
+			resourceId: .identifier("track-123")
+		)
 		let firstMediaURL = try XCTUnwrap(firstPlayableItem?.mediaURL)
 		let firstArtworkURL = try XCTUnwrap(firstItemUnwrapped.artworkURL)
 		XCTAssertTrue(FileManager.default.fileExists(atPath: firstMediaURL.path))
@@ -143,7 +146,10 @@ final class MediaItemDownloadTests: OfflinerTestCase {
 
 		let secondItem = try await offliner.getOfflineMediaItem(mediaType: .tracks, resourceId: .identifier("track-123"))
 		let secondItemUnwrapped = try XCTUnwrap(secondItem)
-		let secondPlayableItem = await offliner.get(productType: .TRACK, productId: "track-123")
+		let secondPlayableItem = await offliner.getOfflinePlaybackAsset(
+			mediaType: .tracks,
+			resourceId: .identifier("track-123")
+		)
 		let secondMediaURL = try XCTUnwrap(secondPlayableItem?.mediaURL)
 		let secondArtworkURL = try XCTUnwrap(secondItemUnwrapped.artworkURL)
 

--- a/Tests/OfflinerTests/MediaItemDownloadTests.swift
+++ b/Tests/OfflinerTests/MediaItemDownloadTests.swift
@@ -120,9 +120,10 @@ final class MediaItemDownloadTests: OfflinerTestCase {
 		XCTAssertEqual(URL(fileURLWithPath: embeddedPath).standardizedFileURL.path, movedURL.standardizedFileURL.path)
 	}
 
-	func testRedownloadTrackDeletesOldFilesAndStoresNewOnes() async throws {
+	func testRepeatedDownloadTrackIsIdempotentAfterCompletion() async throws {
+		let backend = StubOfflineApiClient()
 		let offliner = createOffliner(
-			offlineApiClient: StubOfflineApiClient(),
+			offlineApiClient: backend,
 			artworkDownloader: SucceedingArtworkDownloader(),
 			mediaDownloader: SucceedingMediaDownloader()
 		)
@@ -142,7 +143,6 @@ final class MediaItemDownloadTests: OfflinerTestCase {
 		XCTAssertTrue(FileManager.default.fileExists(atPath: firstArtworkURL.path))
 
 		try await offliner.download(mediaType: .tracks, resourceId: .identifier("track-123"))
-		try await downloadAndWaitForCompletion(offliner)
 
 		let secondItem = try await offliner.getOfflineMediaItem(mediaType: .tracks, resourceId: .identifier("track-123"))
 		let secondItemUnwrapped = try XCTUnwrap(secondItem)
@@ -153,14 +153,15 @@ final class MediaItemDownloadTests: OfflinerTestCase {
 		let secondMediaURL = try XCTUnwrap(secondPlayableItem?.mediaURL)
 		let secondArtworkURL = try XCTUnwrap(secondItemUnwrapped.artworkURL)
 
-		XCTAssertFalse(FileManager.default.fileExists(atPath: firstMediaURL.path))
-		XCTAssertFalse(FileManager.default.fileExists(atPath: firstArtworkURL.path))
+		XCTAssertTrue(FileManager.default.fileExists(atPath: firstMediaURL.path))
+		XCTAssertTrue(FileManager.default.fileExists(atPath: firstArtworkURL.path))
 
 		XCTAssertTrue(FileManager.default.fileExists(atPath: secondMediaURL.path))
 		XCTAssertTrue(FileManager.default.fileExists(atPath: secondArtworkURL.path))
 
-		XCTAssertNotEqual(firstMediaURL, secondMediaURL)
-		XCTAssertNotEqual(firstArtworkURL, secondArtworkURL)
+		XCTAssertEqual(firstMediaURL, secondMediaURL)
+		XCTAssertEqual(firstArtworkURL, secondArtworkURL)
+		XCTAssertEqual(backend.addedItems.count, 1)
 	}
 
 	func testDownloadTrackFailsWhenMediaDownloadFails() async throws {

--- a/Tests/OfflinerTests/OfflinePlaybackAVAssetTests.swift
+++ b/Tests/OfflinerTests/OfflinePlaybackAVAssetTests.swift
@@ -1,0 +1,126 @@
+@testable import Offliner
+import AVFoundation
+import Foundation
+import XCTest
+
+final class OfflinePlaybackAVAssetTests: OfflinerTestCase {
+
+	func testUnprotectedAssetUsesPlainURLAsset() throws {
+		let mediaURL = tempDir.appendingPathComponent("media.movpkg")
+		let preparedAsset = try OfflinePlaybackAVAsset(playbackAsset: playbackAsset(
+			mediaURL: mediaURL,
+			licenseURL: nil
+		))
+
+		XCTAssertEqual(preparedAsset.urlAsset.url, mediaURL)
+		XCTAssertFalse(preparedAsset.usesStoredLicense)
+	}
+
+	func testProtectedAssetRetainsStoredLicenseContext() throws {
+		#if targetEnvironment(simulator)
+			throw XCTSkip("AVContentKeySession FairPlay construction is unavailable on simulators")
+		#else
+			let mediaURL = tempDir.appendingPathComponent("media.movpkg")
+			let licenseURL = tempDir.appendingPathComponent("license.key")
+			try Data([0x01, 0x02, 0x03]).write(to: licenseURL)
+
+			let preparedAsset = try OfflinePlaybackAVAsset(playbackAsset: playbackAsset(
+				mediaURL: mediaURL,
+				licenseURL: licenseURL
+			))
+
+			XCTAssertEqual(preparedAsset.urlAsset.url, mediaURL)
+			XCTAssertTrue(preparedAsset.usesStoredLicense)
+		#endif
+	}
+
+	func testProtectedAssetRejectsMissingStoredLicense() {
+		let licenseURL = tempDir.appendingPathComponent("missing.key")
+
+		XCTAssertThrowsError(try OfflinePlaybackAVAsset(playbackAsset: playbackAsset(
+			mediaURL: tempDir.appendingPathComponent("media.movpkg"),
+			licenseURL: licenseURL
+		))) { error in
+			XCTAssertEqual(error as? OfflinePlaybackAVAssetError, .storedLicenseNotFound(licenseURL))
+		}
+	}
+
+	func testProtectedAssetRejectsUnreadableStoredLicense() throws {
+		let licenseURL = tempDir.appendingPathComponent("license.key", isDirectory: true)
+		try FileManager.default.createDirectory(at: licenseURL, withIntermediateDirectories: true)
+
+		XCTAssertThrowsError(try OfflinePlaybackAVAsset(playbackAsset: playbackAsset(
+			mediaURL: tempDir.appendingPathComponent("media.movpkg"),
+			licenseURL: licenseURL
+		))) { error in
+			XCTAssertEqual(error as? OfflinePlaybackAVAssetError, .storedLicenseUnreadable(licenseURL))
+		}
+	}
+
+	func testProtectedAssetRejectsEmptyStoredLicense() throws {
+		let licenseURL = tempDir.appendingPathComponent("license.key")
+		try Data().write(to: licenseURL)
+
+		XCTAssertThrowsError(try OfflinePlaybackAVAsset(playbackAsset: playbackAsset(
+			mediaURL: tempDir.appendingPathComponent("media.movpkg"),
+			licenseURL: licenseURL
+		))) { error in
+			XCTAssertEqual(error as? OfflinePlaybackAVAssetError, .storedLicenseUnreadable(licenseURL))
+		}
+	}
+
+	func testPreparedLookupInvalidatesCorruptLicenseAndSchedulesOneReplacement() async throws {
+		let backend = StubOfflineApiClient()
+		let mediaDownloader = SuspendingMediaDownloader()
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: mediaDownloader
+		)
+		let mediaURL = tempDir.appendingPathComponent("track.movpkg")
+		let licenseURL = tempDir.appendingPathComponent("track.key")
+		try Data("media".utf8).write(to: mediaURL)
+		try Data().write(to: licenseURL)
+		let store = OfflineStore(lastDatabaseQueue)
+		try store.storeMediaItem(StoreItemTaskResult(
+			resourceType: OfflineMediaItemType.tracks.rawValue,
+			resourceId: "track-id",
+			catalogMetadata: .track(.mock(id: "track-id")),
+			playbackMetadata: nil,
+			collectionResourceType: OfflineCollectionType.albums.rawValue,
+			collectionResourceId: "album-id",
+			volume: 1,
+			position: 1,
+			addedAt: nil,
+			mediaURL: mediaURL,
+			licenseURL: licenseURL,
+			artworkURL: nil
+		))
+
+		let firstAsset = await offliner.getOfflinePlaybackAVAsset(
+			mediaType: .tracks,
+			resourceId: .identifier("track-id")
+		)
+		let secondAsset = await offliner.getOfflinePlaybackAVAsset(
+			mediaType: .tracks,
+			resourceId: .identifier("track-id")
+		)
+		for _ in 0 ..< 100 where backend.addedItems.isEmpty {
+			try await Task.sleep(nanoseconds: 10_000_000)
+		}
+
+		XCTAssertNil(firstAsset)
+		XCTAssertNil(secondAsset)
+		XCTAssertEqual(backend.addedItems.map(\.id), ["track-id"])
+		let storedItem = try await store.getMediaItem(mediaType: .tracks, resourceId: "track-id")
+		XCTAssertNil(storedItem)
+	}
+
+	private func playbackAsset(mediaURL: URL, licenseURL: URL?) -> OfflinePlaybackAsset {
+		OfflinePlaybackAsset(
+			playbackMetadata: nil,
+			mediaURL: mediaURL,
+			licenseURL: licenseURL
+		)
+	}
+}

--- a/Tests/OfflinerTests/OfflinerLifecycleTests.swift
+++ b/Tests/OfflinerTests/OfflinerLifecycleTests.swift
@@ -1,0 +1,154 @@
+@testable import Offliner
+import XCTest
+
+final class OfflinerLifecycleTests: OfflinerTestCase {
+	func testInstallationIdsHaveIsolatedCollectionsAndBackgroundSessions() async throws {
+		let firstBackend = StubOfflineApiClient()
+		let first = createOffliner(
+			installationId: "installation-a",
+			offlineApiClient: firstBackend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+		try await first.download(collectionType: .albums, resourceId: .identifier("album-a"))
+		await firstBackend.waitForTasksToComplete()
+
+		let second = createOffliner(
+			installationId: "installation-b",
+			offlineApiClient: FailingOfflineApiClient(),
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+
+		let firstCollections = try await first.getStoredOfflineCollections(collectionType: .albums)
+		let secondCollections = try await second.getStoredOfflineCollections(collectionType: .albums)
+		XCTAssertEqual(firstCollections.count, 1)
+		XCTAssertTrue(secondCollections.isEmpty)
+
+		let firstStorage = try OfflinerStorage(installationId: "installation-a", baseDirectory: tempDir)
+		let secondStorage = try OfflinerStorage(installationId: "installation-b", baseDirectory: tempDir)
+		XCTAssertNotEqual(firstStorage.rootDirectory, secondStorage.rootDirectory)
+		XCTAssertNotEqual(firstStorage.backgroundSessionIdentifier, secondStorage.backgroundSessionIdentifier)
+		XCTAssertLessThanOrEqual(firstStorage.backgroundSessionIdentifier.count, 64)
+	}
+
+	func testResetIsLocalOnlyRemovesArtifactsAndPermanentlyInvalidatesInstance() async throws {
+		let backend = StubOfflineApiClient()
+		let offliner = createOffliner(
+			installationId: "installation-a",
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+		try await offliner.download(mediaType: .tracks, resourceId: .identifier("track-a"))
+		await backend.waitForTasksToComplete()
+		let playbackAsset = await offliner.getOfflinePlaybackAsset(mediaType: .tracks, resourceId: .identifier("track-a"))
+		let asset = try XCTUnwrap(playbackAsset)
+		XCTAssertTrue(FileManager.default.fileExists(atPath: asset.mediaURL.path))
+		let removedItemCount = backend.removedItems.count
+
+		try await offliner.reset()
+
+		XCTAssertFalse(FileManager.default.fileExists(atPath: asset.mediaURL.path))
+		XCTAssertEqual(backend.removedItems.count, removedItemCount)
+		do {
+			_ = try await offliner.getStoredOfflineCollections(collectionType: .albums)
+			XCTFail("Expected reset instance to reject reads")
+		} catch OfflinerLifecycleError.reset {}
+
+		let replacement = createOffliner(
+			installationId: "installation-a",
+			offlineApiClient: FailingOfflineApiClient(),
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+		let collections = try await replacement.getStoredOfflineCollections(collectionType: .albums)
+		let mediaItem = try await replacement.getOfflineMediaItem(mediaType: .tracks, resourceId: .identifier("track-a"))
+		XCTAssertTrue(collections.isEmpty)
+		XCTAssertNil(mediaItem)
+	}
+
+	func testStaleInFlightDownloadCannotRepopulateAfterResetStarts() async throws {
+		let backend = StubOfflineApiClient()
+		let mediaDownloader = SuspendingMediaDownloader(resumesOnCancel: false)
+		let offliner = createOffliner(
+			installationId: "installation-a",
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: mediaDownloader
+		)
+
+		try await offliner.download(mediaType: .tracks, resourceId: .identifier("track-a"))
+		await mediaDownloader.waitUntilStarted()
+		let reset = Task { try await offliner.reset() }
+		await mediaDownloader.waitUntilCancelled()
+		await mediaDownloader.complete()
+		try await reset.value
+
+		let replacement = createOffliner(
+			installationId: "installation-a",
+			offlineApiClient: FailingOfflineApiClient(),
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+		let mediaItem = try await replacement.getOfflineMediaItem(mediaType: .tracks, resourceId: .identifier("track-a"))
+		XCTAssertNil(mediaItem)
+	}
+
+	func testLegacyStorageMigratesToFirstInstallation() async throws {
+		let legacyRoot = tempDir.appendingPathComponent("Offliner", isDirectory: true)
+		try FileManager.default.createDirectory(at: legacyRoot, withIntermediateDirectories: true)
+		let legacyArtworkDirectory = legacyRoot.appendingPathComponent("Artworks", isDirectory: true)
+		try FileManager.default.createDirectory(at: legacyArtworkDirectory, withIntermediateDirectories: true)
+		let artworkURL = legacyArtworkDirectory.appendingPathComponent("album.jpg")
+		try Data("artwork".utf8).write(to: artworkURL)
+		let legacyLicenseDirectory = legacyRoot.appendingPathComponent("Licenses", isDirectory: true)
+		try FileManager.default.createDirectory(at: legacyLicenseDirectory, withIntermediateDirectories: true)
+		let licenseURL = legacyLicenseDirectory.appendingPathComponent("track.key")
+		try Data("license".utf8).write(to: licenseURL)
+		let mediaURL = tempDir.appendingPathComponent("track.movpkg")
+		try Data("media".utf8).write(to: mediaURL)
+
+		let legacyDatabase = try OfflineStore.makeDatabaseQueue(path: legacyRoot.appendingPathComponent("offline.sqlite").path)
+		try Migrations.run(legacyDatabase)
+		let legacyStore = OfflineStore(legacyDatabase)
+		try legacyStore.storeCollection(StoreCollectionTaskResult(
+			resourceType: .albums,
+			resourceId: "album-a",
+			catalogMetadata: .album(.mock(id: "album-a")),
+			artworkURL: artworkURL
+		))
+		try legacyStore.storeMediaItem(StoreItemTaskResult(
+			resourceType: OfflineMediaItemType.tracks.rawValue,
+			resourceId: "track-a",
+			catalogMetadata: .track(.mock(id: "track-a")),
+			playbackMetadata: .mock(),
+			collectionResourceType: OfflineCollectionType.albums.rawValue,
+			collectionResourceId: "album-a",
+			volume: 1,
+			position: 1,
+			addedAt: nil,
+			mediaURL: mediaURL,
+			licenseURL: licenseURL,
+			artworkURL: artworkURL
+		))
+		try legacyDatabase.close()
+
+		let storage = try OfflinerStorage(installationId: "installation-a", baseDirectory: tempDir)
+		let collections = try await storage.offlineStore.getCollections(collectionType: .albums)
+		let migratedCollection = try XCTUnwrap(collections.first)
+		let migratedArtworkURL = try XCTUnwrap(migratedCollection.artworkURL)
+		let storedPlaybackAsset = try await storage.offlineStore.getPlaybackAsset(mediaType: .tracks, resourceId: "track-a")
+		let playbackAsset = try XCTUnwrap(storedPlaybackAsset)
+		let migratedLicenseURL = try XCTUnwrap(playbackAsset.licenseURL)
+
+		XCTAssertEqual(collections.map(\.catalogMetadata.id), ["album-a"])
+		XCTAssertTrue(FileManager.default.fileExists(atPath: migratedArtworkURL.path))
+		XCTAssertTrue(FileManager.default.fileExists(atPath: playbackAsset.mediaURL.path))
+		XCTAssertTrue(FileManager.default.fileExists(atPath: migratedLicenseURL.path))
+		XCTAssertFalse(FileManager.default.fileExists(atPath: legacyRoot.appendingPathComponent("offline.sqlite").path))
+		XCTAssertTrue(FileManager.default.fileExists(atPath: storage.rootDirectory.appendingPathComponent("offline.sqlite").path))
+		XCTAssertTrue(FileManager.default.fileExists(atPath: storage.rootDirectory
+			.appendingPathComponent("Artifacts/Artworks/album.jpg").path))
+	}
+}

--- a/Tests/OfflinerTests/OfflinerLifecycleTests.swift
+++ b/Tests/OfflinerTests/OfflinerLifecycleTests.swift
@@ -2,6 +2,37 @@
 import XCTest
 
 final class OfflinerLifecycleTests: OfflinerTestCase {
+	func testBackgroundSessionEventHandlingReturnsDownloaderDecision() {
+		let mediaDownloader = SucceedingMediaDownloader()
+		mediaDownloader.handlesBackgroundSessionEvents = true
+		let offliner = createOffliner(
+			offlineApiClient: FailingOfflineApiClient(),
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: mediaDownloader
+		)
+
+		let handled = offliner.handleBackgroundURLSessionEvents(identifier: "matching-session") {}
+
+		XCTAssertTrue(handled)
+		XCTAssertEqual(mediaDownloader.backgroundSessionIdentifiers, ["matching-session"])
+	}
+
+	func testBackgroundSessionEventHandlingRejectsResetInstance() async throws {
+		let mediaDownloader = SucceedingMediaDownloader()
+		mediaDownloader.handlesBackgroundSessionEvents = true
+		let offliner = createOffliner(
+			offlineApiClient: FailingOfflineApiClient(),
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: mediaDownloader
+		)
+		try await offliner.reset()
+
+		let handled = offliner.handleBackgroundURLSessionEvents(identifier: "matching-session") {}
+
+		XCTAssertFalse(handled)
+		XCTAssertTrue(mediaDownloader.backgroundSessionIdentifiers.isEmpty)
+	}
+
 	func testInstallationIdsHaveIsolatedCollectionsAndBackgroundSessions() async throws {
 		let firstBackend = StubOfflineApiClient()
 		let first = createOffliner(

--- a/Tests/OfflinerTests/OfflinerTestCase.swift
+++ b/Tests/OfflinerTests/OfflinerTestCase.swift
@@ -5,6 +5,7 @@ import XCTest
 class OfflinerTestCase: XCTestCase {
 	var tempDir: URL!
 	var lastDatabaseQueue: DatabaseQueue!
+	private var offliners: [Offliner] = []
 
 	override func setUp() {
 		super.setUp()
@@ -12,11 +13,15 @@ class OfflinerTestCase: XCTestCase {
 		try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
 	}
 
-	override func tearDown() {
+	override func tearDown() async throws {
+		for offliner in offliners {
+			try? await offliner.reset()
+		}
+		offliners.removeAll()
 		if let tempDir {
 			try? FileManager.default.removeItem(at: tempDir)
 		}
-		super.tearDown()
+		try await super.tearDown()
 	}
 
 	func createOffliner(
@@ -25,22 +30,22 @@ class OfflinerTestCase: XCTestCase {
 		artworkDownloader: ArtworkDownloaderProtocol,
 		mediaDownloader: MediaDownloaderProtocol,
 		trackManifestFetcher: TrackManifestFetcherProtocol = SucceedingTrackManifestFetcher(),
-		videoManifestFetcher: VideoManifestFetcherProtocol = SucceedingVideoManifestFetcher(),
-		collectionDownloadStatePollInterval: UInt64 = 1_000_000_000
+		videoManifestFetcher: VideoManifestFetcherProtocol = SucceedingVideoManifestFetcher()
 	) -> Offliner {
 		// swiftlint:disable:next force_try
 		let storage = try! OfflinerStorage(installationId: installationId, baseDirectory: tempDir)
 		lastDatabaseQueue = storage.databaseQueue
 
-		return Offliner(
+		let offliner = Offliner(
 			storage: storage,
 			offlineApiClient: offlineApiClient,
 			artworkDownloader: artworkDownloader,
 			mediaDownloader: mediaDownloader,
 			trackManifestFetcher: trackManifestFetcher,
-			videoManifestFetcher: videoManifestFetcher,
-			collectionDownloadStatePollInterval: collectionDownloadStatePollInterval
+			videoManifestFetcher: videoManifestFetcher
 		)
+		offliners.append(offliner)
+		return offliner
 	}
 
 	func downloadAndWaitForCompletion(_ offliner: Offliner) async throws {

--- a/Tests/OfflinerTests/OfflinerTestCase.swift
+++ b/Tests/OfflinerTests/OfflinerTestCase.swift
@@ -20,6 +20,7 @@ class OfflinerTestCase: XCTestCase {
 	}
 
 	func createOffliner(
+		installationId: String = UUID().uuidString,
 		offlineApiClient: OfflineApiClientProtocol,
 		artworkDownloader: ArtworkDownloaderProtocol,
 		mediaDownloader: MediaDownloaderProtocol,
@@ -27,17 +28,13 @@ class OfflinerTestCase: XCTestCase {
 		videoManifestFetcher: VideoManifestFetcherProtocol = SucceedingVideoManifestFetcher(),
 		collectionDownloadStatePollInterval: UInt64 = 1_000_000_000
 	) -> Offliner {
-		let dbPath = tempDir.appendingPathComponent("test-\(UUID().uuidString).sqlite").path
 		// swiftlint:disable:next force_try
-		let databaseQueue = try! OfflineStore.makeDatabaseQueue(path: dbPath)
-		// swiftlint:disable:next force_try
-		try! Migrations.run(databaseQueue)
-		lastDatabaseQueue = databaseQueue
-		let offlineStore = OfflineStore(databaseQueue)
+		let storage = try! OfflinerStorage(installationId: installationId, baseDirectory: tempDir)
+		lastDatabaseQueue = storage.databaseQueue
 
 		return Offliner(
+			storage: storage,
 			offlineApiClient: offlineApiClient,
-			offlineStore: offlineStore,
 			artworkDownloader: artworkDownloader,
 			mediaDownloader: mediaDownloader,
 			trackManifestFetcher: trackManifestFetcher,

--- a/Tests/OfflinerTests/RemoveTests.swift
+++ b/Tests/OfflinerTests/RemoveTests.swift
@@ -40,7 +40,10 @@ final class RemoveTests: OfflinerTestCase {
 
 		let storedItemOptional = try await offliner.getOfflineMediaItem(mediaType: .tracks, resourceId: .identifier("track-123"))
 		let storedItem = try XCTUnwrap(storedItemOptional)
-		let playableItem = await offliner.get(productType: .TRACK, productId: "track-123")
+		let playableItem = await offliner.getOfflinePlaybackAsset(
+			mediaType: .tracks,
+			resourceId: .identifier("track-123")
+		)
 		let mediaURL = try XCTUnwrap(playableItem?.mediaURL)
 		let artworkURL = try XCTUnwrap(storedItem.artworkURL)
 		XCTAssertTrue(FileManager.default.fileExists(atPath: mediaURL.path))

--- a/Tests/OfflinerTests/ResourceStateTests.swift
+++ b/Tests/OfflinerTests/ResourceStateTests.swift
@@ -1,0 +1,346 @@
+import GRDB
+@testable import Offliner
+import TidalAPI
+import XCTest
+
+// MARK: - ResourceStateTests
+
+final class ResourceStateTests: OfflinerTestCase {
+	func testRegistrationFailurePreservesDownloadRetryDirection() async throws {
+		let offliner = createOffliner(
+			offlineApiClient: FailingOfflineApiClient(),
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+		let resource = OfflineResource.media(type: .tracks, resourceId: "track-1")
+
+		await XCTAssertThrowsErrorAsync {
+			try await offliner.download(mediaType: .tracks, resourceId: .identifier("track-1"))
+		}
+
+		let state = try await offliner.getOfflineResourceState(for: resource)
+		XCTAssertEqual(state, .failed(action: .download))
+	}
+
+	func testLegacyCollectionStateMapsFailedDownloadToNotDownloaded() async throws {
+		let offliner = createOffliner(
+			offlineApiClient: FailingOfflineApiClient(),
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+		await XCTAssertThrowsErrorAsync {
+			try await offliner.download(collectionType: .albums, resourceId: .identifier("album-1"))
+		}
+
+		let state = await offliner.getOfflineCollectionDownloadState(
+			collectionType: .albums,
+			resourceId: .identifier("album-1")
+		).first()
+		XCTAssertEqual(state, .notDownloaded)
+	}
+
+	func testLegacyCollectionStateMapsFailedRemoveToDownloaded() async throws {
+		let storage = try OfflinerStorage(installationId: "failed-remove", baseDirectory: tempDir)
+		try storage.offlineStore.storeCollection(StoreCollectionTaskResult(
+			resourceType: .albums,
+			resourceId: "album-1",
+			catalogMetadata: .album(.mock(id: "album-1")),
+			artworkURL: nil
+		))
+		let offliner = Offliner(
+			storage: storage,
+			offlineApiClient: FailingOfflineApiClient(),
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader(),
+			trackManifestFetcher: SucceedingTrackManifestFetcher(),
+			videoManifestFetcher: SucceedingVideoManifestFetcher()
+		)
+		await XCTAssertThrowsErrorAsync {
+			try await offliner.remove(collectionType: .albums, resourceId: .identifier("album-1"))
+		}
+		let exactState = try await offliner.getOfflineResourceState(
+			for: .collection(type: .albums, resourceId: "album-1")
+		)
+		XCTAssertEqual(exactState, .failed(action: .remove))
+
+		let state = await offliner.getOfflineCollectionDownloadState(
+			collectionType: .albums,
+			resourceId: .identifier("album-1")
+		).first()
+		XCTAssertEqual(state, .downloaded)
+	}
+
+	func testRepeatedDownloadWhileQueuedRegistersOnlyOnce() async throws {
+		let backend = HoldingOfflineApiClient()
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+
+		try await offliner.download(mediaType: .tracks, resourceId: .identifier("track-1"))
+		try await offliner.download(mediaType: .tracks, resourceId: .identifier("track-1"))
+
+		XCTAssertEqual(backend.addedItems.count, 1)
+		let state = try await offliner.getOfflineResourceState(for: .media(type: .tracks, resourceId: "track-1"))
+		XCTAssertEqual(state, .queued)
+	}
+
+	func testRepeatedRemoveWhileRemovingRegistersOnlyOnce() async throws {
+		let backend = HoldingOfflineApiClient()
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+
+		try await offliner.remove(mediaType: .videos, resourceId: .identifier("video-1"))
+		try await offliner.remove(mediaType: .videos, resourceId: .identifier("video-1"))
+
+		XCTAssertEqual(backend.removedItems.count, 1)
+		let state = try await offliner.getOfflineResourceState(for: .media(type: .videos, resourceId: "video-1"))
+		XCTAssertEqual(state, .removing)
+	}
+
+	func testOppositeOperationsAreRejectedInBothDirections() async throws {
+		let backend = HoldingOfflineApiClient()
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+
+		try await offliner.download(mediaType: .tracks, resourceId: .identifier("track-1"))
+		do {
+			try await offliner.remove(mediaType: .tracks, resourceId: .identifier("track-1"))
+			XCTFail("Expected the queued download to reject removal")
+		} catch let error as OfflineResourceOperationError {
+			XCTAssertEqual(error, .conflictingOperationInProgress(currentState: .queued))
+		}
+
+		try await offliner.remove(mediaType: .videos, resourceId: .identifier("video-1"))
+		do {
+			try await offliner.download(mediaType: .videos, resourceId: .identifier("video-1"))
+			XCTFail("Expected the active removal to reject download")
+		} catch let error as OfflineResourceOperationError {
+			XCTAssertEqual(error, .conflictingOperationInProgress(currentState: .removing))
+		}
+
+		XCTAssertTrue(backend.removedItems.allSatisfy { $0.id != "track-1" })
+		XCTAssertTrue(backend.addedItems.allSatisfy { $0.id != "video-1" })
+	}
+
+	func testQueuedStateRecoversOfflineAfterOfflinerRecreation() async throws {
+		let installationId = "relaunch-installation"
+		let firstBackend = HoldingOfflineApiClient()
+		let first = createOffliner(
+			installationId: installationId,
+			offlineApiClient: firstBackend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+		try await first.download(collectionType: .albums, resourceId: .identifier("album-1"))
+		let persistedState = try await lastDatabaseQueue.read { database in
+			try String.fetchOne(database, sql: "SELECT state FROM offline_resource_operation WHERE resource_id = 'album-1'")
+		}
+		XCTAssertEqual(persistedState, "queued")
+
+		let second = createOffliner(
+			installationId: installationId,
+			offlineApiClient: FailOnGetTasksOfflineApiClient(),
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+
+		let state = try await second.getOfflineResourceState(for: .collection(type: .albums, resourceId: "album-1"))
+		XCTAssertEqual(state, .queued)
+	}
+
+	func testFailedBackendTaskRecoversOnNewOfflinerInstance() async throws {
+		let backend = StubOfflineApiClient()
+		backend.enqueueTasks([.storeAlbum(StoreAlbumTask(
+			id: "failed-album",
+			state: .failed,
+			album: AlbumsResourceObject(id: "album-1", type: "albums"),
+			artists: [],
+			artwork: nil
+		))])
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+
+		await offliner.run()
+		let state = try await offliner.getOfflineResourceState(
+			for: .collection(type: .albums, resourceId: "album-1")
+		)
+		XCTAssertEqual(state, .failed(action: .download))
+	}
+
+	func testExplicitRetrySupersedesFailureGeneration() async throws {
+		let storage = try OfflinerStorage(installationId: "retry-state", baseDirectory: tempDir)
+		let tracker = ResourceStateTracker(offlineStore: storage.offlineStore)
+		let resource = OfflineResourceKey(.media(type: .tracks, resourceId: "track-1"))
+		_ = try await tracker.begin(.store, for: resource)
+		await tracker.registrationFailed(.store, for: resource)
+
+		let retried = try await tracker.begin(.store, for: resource)
+		let state = try await tracker.state(for: resource)
+
+		XCTAssertTrue(retried)
+		XCTAssertEqual(state, .queued)
+	}
+
+	func testResourceStateStreamFinishesOnReset() async throws {
+		let offliner = createOffliner(
+			offlineApiClient: HoldingOfflineApiClient(),
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+		let stream = offliner.observeOfflineResourceState(for: .media(type: .tracks, resourceId: "track-1"))
+		var iterator = stream.makeAsyncIterator()
+		let initialState = await iterator.next()
+		XCTAssertEqual(initialState, .notDownloaded)
+
+		try await offliner.reset()
+
+		let finalState = await iterator.next()
+		XCTAssertNil(finalState)
+	}
+
+	func testCollectionStorePublishesDownloadingRatherThanRemoving() async throws {
+		let backend = StubOfflineApiClient()
+		let artwork = SuspendingArtworkDownloader()
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: artwork,
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+
+		try await offliner.download(collectionType: .albums, resourceId: .identifier("album-1"))
+		await artwork.waitUntilStarted()
+
+		let state = try await offliner.getOfflineResourceState(for: .collection(type: .albums, resourceId: "album-1"))
+		XCTAssertEqual(state, .downloading)
+		await artwork.complete()
+		await backend.waitForTasksToComplete()
+	}
+
+	func testMediaStateTransitionsToDownloadedAndExposesCorrelation() async throws {
+		let backend = StubOfflineApiClient()
+		let media = SuspendingMediaDownloader()
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: media
+		)
+		let downloads = offliner.newDownloads
+
+		try await offliner.download(mediaType: .tracks, resourceId: .identifier("track-1"))
+		var iterator = downloads.makeAsyncIterator()
+		let download = await iterator.next()
+		await media.waitUntilStarted()
+
+		XCTAssertEqual(download?.taskId, "task-0")
+		XCTAssertEqual(download?.resource, .media(type: .tracks, resourceId: "track-1"))
+		let state = try await offliner.getOfflineResourceState(for: .media(type: .tracks, resourceId: "track-1"))
+		XCTAssertEqual(state, .downloading)
+
+		await media.complete()
+		await backend.waitForTasksToComplete()
+		await assertEventuallyResourceState(
+			offliner,
+			resource: .media(type: .tracks, resourceId: "track-1"),
+			expected: .downloaded
+		)
+	}
+
+	func testCollectionFailureSurvivesLaterSiblingSuccess() async throws {
+		let installationId = "sibling-failure"
+		let backend = StubOfflineApiClient()
+		let media = SelectiveSuspendingMediaDownloader(failingTaskIds: ["failing-track"])
+		let offliner = createOffliner(
+			installationId: installationId,
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: media
+		)
+		backend.enqueueTasks([
+			.storeTrack(storeTrackTask(id: "failing-track", trackId: "track-1", position: 1)),
+			.storeTrack(storeTrackTask(id: "succeeding-track", trackId: "track-2", position: 2)),
+		])
+
+		await offliner.run()
+		await media.waitUntilStarted(count: 2)
+		await assertEventuallyResourceState(
+			offliner,
+			resource: .collection(type: .albums, resourceId: "album-1"),
+			expected: .failed(action: .download)
+		)
+
+		await media.complete(taskId: "succeeding-track")
+		await backend.waitForTasksToComplete()
+		let finalState = try await offliner.getOfflineResourceState(
+			for: .collection(type: .albums, resourceId: "album-1")
+		)
+		XCTAssertEqual(finalState, .failed(action: .download))
+		let persistedState = try await lastDatabaseQueue.read { database in
+			try String.fetchOne(database, sql: "SELECT state FROM offline_resource_operation WHERE resource_id = 'album-1'")
+		}
+		XCTAssertEqual(persistedState, "failed_download")
+
+		let recreated = createOffliner(
+			installationId: installationId,
+			offlineApiClient: FailOnGetTasksOfflineApiClient(),
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+		let recoveredState = try await recreated.getOfflineResourceState(
+			for: .collection(type: .albums, resourceId: "album-1")
+		)
+		XCTAssertEqual(recoveredState, .failed(action: .download))
+	}
+
+	private func storeTrackTask(id: String, trackId: String, position: Int) -> StoreTrackTask {
+		StoreTrackTask(
+			id: id,
+			track: TracksResourceObject(id: trackId, type: "tracks"),
+			artists: [],
+			artwork: nil,
+			collectionResourceType: "albums",
+			collectionResourceId: "album-1",
+			volume: 1,
+			position: position
+		)
+	}
+
+	private func assertEventuallyResourceState(
+		_ offliner: Offliner,
+		resource: OfflineResource,
+		expected: OfflineResourceState,
+		file: StaticString = #filePath,
+		line: UInt = #line
+	) async {
+		for _ in 0 ..< 100 {
+			if let state = try? await offliner.getOfflineResourceState(for: resource), state == expected {
+				return
+			}
+			try? await Task.sleep(nanoseconds: 10_000_000)
+		}
+		XCTFail("Timed out waiting for \(expected)", file: file, line: line)
+	}
+}
+
+private func XCTAssertThrowsErrorAsync(
+	_ expression: () async throws -> Void,
+	file: StaticString = #filePath,
+	line: UInt = #line
+) async {
+	do {
+		try await expression()
+		XCTFail("Expected error", file: file, line: line)
+	} catch {
+		// Expected.
+	}
+}

--- a/Tests/OfflinerTests/TaskConflictTests.swift
+++ b/Tests/OfflinerTests/TaskConflictTests.swift
@@ -60,7 +60,35 @@ final class TaskConflictTests: OfflinerTestCase {
 		await runTask
 	}
 
-	private func storeTrackTask(id: String, trackId: String) -> StoreTrackTask {
+	func testAlbumMemberStoresRunConcurrentlyWhileCollectionRemoveWaits() async throws {
+		let backend = StubOfflineApiClient()
+		let media = SelectiveSuspendingMediaDownloader()
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: media
+		)
+
+		backend.enqueueTasks([
+			.storeTrack(storeTrackTask(id: "store-1", trackId: "track-1", position: 1)),
+			.storeTrack(storeTrackTask(id: "store-2", trackId: "track-2", position: 2)),
+			.removeCollection(RemoveCollectionTask(id: "remove-album", resourceType: "albums", resourceId: "album-1")),
+		])
+
+		await offliner.run()
+		await media.waitUntilStarted(count: 2)
+		try await Task.sleep(nanoseconds: 100_000_000)
+		XCTAssertFalse(backend.completedTaskIds.contains("remove-album"))
+
+		await media.complete(taskId: "store-1")
+		await media.complete(taskId: "store-2")
+		await backend.waitForTasksToComplete()
+
+		XCTAssertEqual(Set(backend.completedTaskIds.prefix(2)), Set(["store-1", "store-2"]))
+		XCTAssertEqual(backend.completedTaskIds.last, "remove-album")
+	}
+
+	private func storeTrackTask(id: String, trackId: String, position: Int = 1) -> StoreTrackTask {
 		StoreTrackTask(
 			id: id,
 			track: TracksResourceObject(id: trackId, type: "tracks"),
@@ -69,7 +97,7 @@ final class TaskConflictTests: OfflinerTestCase {
 			collectionResourceType: "albums",
 			collectionResourceId: "album-1",
 			volume: 1,
-			position: 1
+			position: position
 		)
 	}
 

--- a/Tests/OfflinerTests/TestFakes.swift
+++ b/Tests/OfflinerTests/TestFakes.swift
@@ -316,6 +316,7 @@ final class SucceedingMediaDownloader: MediaDownloaderProtocol {
 	var progressValues: [Double] = []
 
 	func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void) {}
+	func cancelAll() async {}
 
 	func download(
 		taskId: String,
@@ -341,6 +342,7 @@ final class SucceedingMediaDownloader: MediaDownloaderProtocol {
 
 final class FailingMediaDownloader: MediaDownloaderProtocol {
 	func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void) {}
+	func cancelAll() async {}
 
 	func download(
 		taskId: String,
@@ -355,10 +357,37 @@ final class FailingMediaDownloader: MediaDownloaderProtocol {
 
 actor SuspendingMediaDownloader: MediaDownloaderProtocol {
 	private var startedContinuation: CheckedContinuation<Void, Never>?
+	private var cancelledContinuation: CheckedContinuation<Void, Never>?
 	private var resultContinuation: CheckedContinuation<MediaDownloadResult, Error>?
 	private var started = false
+	private var cancelled = false
+	private let resumesOnCancel: Bool
+
+	init(resumesOnCancel: Bool = true) {
+		self.resumesOnCancel = resumesOnCancel
+	}
 
 	nonisolated func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void) {}
+
+	func cancelAll() {
+		cancelled = true
+		cancelledContinuation?.resume()
+		cancelledContinuation = nil
+		guard resumesOnCancel else { return }
+		let continuation = resultContinuation
+		resultContinuation = nil
+		continuation?.resume(throwing: CancellationError())
+	}
+
+	func waitUntilCancelled() async {
+		if cancelled {
+			return
+		}
+
+		await withCheckedContinuation { continuation in
+			cancelledContinuation = continuation
+		}
+	}
 
 	func waitUntilStarted() async {
 		if started {

--- a/Tests/OfflinerTests/TestFakes.swift
+++ b/Tests/OfflinerTests/TestFakes.swift
@@ -256,6 +256,34 @@ final class FailOnGetTasksOfflineApiClient: OfflineApiClientProtocol {
 	func updateTask(taskId: String, state: Download.State) async throws {}
 }
 
+final class HoldingOfflineApiClient: OfflineApiClientProtocol {
+	private let lock = NSLock()
+	private var addedItemsStorage: [StubOfflineApiClient.RecordedItem] = []
+	private var removedItemsStorage: [StubOfflineApiClient.RecordedItem] = []
+
+	var addedItems: [StubOfflineApiClient.RecordedItem] {
+		lock.withLock { addedItemsStorage }
+	}
+
+	var removedItems: [StubOfflineApiClient.RecordedItem] {
+		lock.withLock { removedItemsStorage }
+	}
+
+	func addItem(type: ResourceType, id: String) async throws {
+		lock.withLock { addedItemsStorage.append(.init(type: type, id: id)) }
+	}
+
+	func removeItem(type: ResourceType, id: String) async throws {
+		lock.withLock { removedItemsStorage.append(.init(type: type, id: id)) }
+	}
+
+	func getTasks(cursor: String?) async throws -> (tasks: [OfflineTask], cursor: String?) {
+		([], nil)
+	}
+
+	func updateTask(taskId: String, state: Download.State) async throws {}
+}
+
 // MARK: - Artwork Downloader Fakes
 
 final class SucceedingArtworkDownloader: ArtworkDownloaderProtocol {
@@ -424,6 +452,53 @@ actor SuspendingMediaDownloader: MediaDownloaderProtocol {
 			self.startedContinuation = nil
 
 			startedContinuation?.resume()
+		}
+	}
+}
+
+actor SelectiveSuspendingMediaDownloader: MediaDownloaderProtocol {
+	private var startedTaskIds: Set<String> = []
+	private var continuations: [String: CheckedContinuation<MediaDownloadResult, Error>] = [:]
+	private let failingTaskIds: Set<String>
+
+	init(failingTaskIds: Set<String> = []) {
+		self.failingTaskIds = failingTaskIds
+	}
+
+	nonisolated func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void) {}
+
+	func cancelAll() {
+		for continuation in continuations.values {
+			continuation.resume(throwing: CancellationError())
+		}
+		continuations.removeAll()
+	}
+
+	func waitUntilStarted(count: Int) async {
+		while startedTaskIds.count < count {
+			await Task.yield()
+		}
+	}
+
+	func complete(taskId: String) {
+		let url = FileManager.default.temporaryDirectory.appendingPathComponent("media-\(taskId)-\(UUID().uuidString).m4a")
+		try? Data("media".utf8).write(to: url)
+		continuations.removeValue(forKey: taskId)?.resume(returning: MediaDownloadResult(duration: 120, mediaLocation: url))
+	}
+
+	func download(
+		taskId: String,
+		manifestURL: URL,
+		licenseDownloadResult: LicenseDownloadResult?,
+		title: String,
+		onProgress: @escaping @Sendable (Double) async -> Void
+	) async throws -> MediaDownloadResult {
+		startedTaskIds.insert(taskId)
+		if failingTaskIds.contains(taskId) {
+			throw FakeError.downloadFailed
+		}
+		return try await withCheckedThrowingContinuation { continuation in
+			continuations[taskId] = continuation
 		}
 	}
 }

--- a/Tests/OfflinerTests/TestFakes.swift
+++ b/Tests/OfflinerTests/TestFakes.swift
@@ -342,8 +342,13 @@ actor SuspendingArtworkDownloader: ArtworkDownloaderProtocol {
 
 final class SucceedingMediaDownloader: MediaDownloaderProtocol {
 	var progressValues: [Double] = []
+	var handlesBackgroundSessionEvents = false
+	private(set) var backgroundSessionIdentifiers: [String] = []
 
-	func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void) {}
+	func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void) -> Bool {
+		backgroundSessionIdentifiers.append(identifier)
+		return handlesBackgroundSessionEvents
+	}
 	func cancelAll() async {}
 
 	func download(
@@ -369,7 +374,7 @@ final class SucceedingMediaDownloader: MediaDownloaderProtocol {
 }
 
 final class FailingMediaDownloader: MediaDownloaderProtocol {
-	func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void) {}
+	func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void) -> Bool { false }
 	func cancelAll() async {}
 
 	func download(
@@ -395,7 +400,7 @@ actor SuspendingMediaDownloader: MediaDownloaderProtocol {
 		self.resumesOnCancel = resumesOnCancel
 	}
 
-	nonisolated func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void) {}
+	nonisolated func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void) -> Bool { false }
 
 	func cancelAll() {
 		cancelled = true
@@ -465,7 +470,7 @@ actor SelectiveSuspendingMediaDownloader: MediaDownloaderProtocol {
 		self.failingTaskIds = failingTaskIds
 	}
 
-	nonisolated func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void) {}
+	nonisolated func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void) -> Bool { false }
 
 	func cancelAll() {
 		for continuation in continuations.values {


### PR DESCRIPTION
## Why

Enable Offliner on watchOS without coupling consumers to Player, while providing a supported persisted-license playback path and making offline data, task ownership, user-facing operation state, and the aggregate download queue safe across logout, account switches, relaunch, repeat taps, and connectivity changes.

## What changed

- Raised Swift tools to 5.9 and the package watchOS floor to 10.
- Removed the Offliner dependency on Player and the SDK-owned `OfflineItemProvider` conformance.
- Added Player-independent `OfflinePlaybackAsset` and `getOfflinePlaybackAsset(mediaType:resourceId:)`; bookmarks resolve only when playback is requested, and unresolved stored files retain the existing redownload behavior.
- Added Player-independent AVFoundation playback preparation:
  - `OfflinePlaybackAVAsset`, which exposes `urlAsset` and retains the FairPlay content-key session, stored-license delegate, delegate queue, and license data for protected assets.
  - `OfflinePlaybackAVAssetError.storedLicenseNotFound` and `.storedLicenseUnreadable` for diagnostic construction.
  - `getOfflinePlaybackAVAsset(mediaType:resourceId:)`, the supported watchOS lookup that prepares protected/unprotected assets and schedules one idempotent replacement download when stored media/license preparation fails.
- Corrupt playback assets are invalidated locally without registering a backend removal. Their collection relationships remain so the replacement task can restore the media item in place.
- Added installation-scoped databases, artifacts, and background URL-session identifiers. Legacy iOS database and artifacts migrate once into the first active installation scope without invalidating stored bookmarks.
- Added local-only `reset() async throws`. Reset permanently invalidates the instance, stops and awaits work, finishes streams, blocks stale writes/callbacks, and deletes local state without enqueueing backend removals.
- Added local-only, error-preserving `getStoredOfflineCollections(collectionType:) async throws` for stored album/playlist snapshots while offline.
- Added resource-scoped state for media and collections:
  - `OfflineResource`
  - `OfflineResourceAction`
  - `OfflineResourceState`: `notDownloaded`, `queued`, `downloading`, `downloaded`, `removing`, `failed(action:)`
  - `getOfflineResourceState(for:) async throws`
  - `observeOfflineResourceState(for:)`
  - `OfflineResourceOperationError.conflictingOperationInProgress(currentState:)`
- Added a persistent aggregate download queue:
  - `OfflineDownloadQueueEntry`
  - `getOfflineDownloadQueue() async throws`
  - `observeOfflineDownloadQueue()`
- Queue snapshots wait for backend task synchronization. Observation is multi-subscriber and broadcasts distinct synchronized snapshots until cancellation or reset.
- Queue entries preserve a stable retry resource, optional parent collection, queued/downloading/failed-download state, and progress when known. Failures survive task removal and Offliner recreation; successful work disappears.
- Collection metadata and member work aggregate under one collection entry when active/failed collection intent exists. Standalone media remains independently retryable. Historical terminal collection metadata cannot absorb standalone media identity.
- State is persisted per installation, reconciled with paginated backend tasks when available, and recovered after Offliner recreation. Registration and task failures preserve retry direction. A sibling success cannot erase a collection failure.
- Same-direction member stores retain parallelism. Opposite collection/member work conflicts, and repeated same-direction requests are idempotent.
- Added `taskId`, `resource`, and optional `collection` correlation to public `Download` values.
- Preserved the legacy collection state stream. Failed downloads map to `notDownloaded`; failed removals preserve actual local collection availability.
- Rejects track manifests unless `trackPresentation == .full`, preventing preview assets from being accepted as completed offline downloads.
- Modernized AV asset downloads with `AVAssetDownloadConfiguration`, `makeAssetDownloadTask(downloadConfiguration:)`, and KVO on `task.progress`.
- Kept `didFinishDownloadingTo` for iOS 15–17 and macOS 12–13, and added `willDownloadTo` for iOS 18+, macOS 14+, and watchOS 10+. Both callbacks route through one helper. `didFinishDownloadingTo` is deprecated on watchOS 10, not unavailable.
- Preserved mainline orphan-task recovery and prevented old-installation callbacks from writing through a replacement Offliner.
- Removed unused AVFoundation imports from store handlers.
- Updated README guidance, including consumer-owned retroactive `OfflineItemProvider` mapping from `OfflinePlaybackAsset` to Player `OfflinePlaybackItem`.
- Uses the shared Offliner scheme and test plan supplied by merged #414.

## Public behavior

Consumers observe one `OfflineResource` per album, playlist, user-collection-track set, track, or video. `failed(action:)` is directional: retry `.download` with `download(...)`, and retry `.remove` with `remove(...)`. Same active actions are no-ops; opposite active actions throw the typed conflict and are not registered. Call `run()` to process recovered work.

`getOfflineDownloadQueue()` throws lifecycle, backend synchronization, and local persistence errors. `observeOfflineDownloadQueue()` gives every subscriber a synchronized initial snapshot followed by the same distinct broadcasts; cancelling one subscriber does not affect others, and reset finishes all queue streams. Queue failures are always `.failed(action: .download)` and remain until retry, removal, or reset.

Watch consumers call `getOfflinePlaybackAVAsset(mediaType:resourceId:)`, create an `AVPlayerItem` from its public `urlAsset`, and retain the `OfflinePlaybackAVAsset` wrapper for the complete queued/player-item lifetime. A plain `AVURLAsset` is insufficient when `licenseURL` is present because the player item does not retain or configure a FairPlay content-key session. The throwing `OfflinePlaybackAVAsset(playbackAsset:)` initializer remains available for diagnostics; the Offliner-owned lookup is preferred because it couples preparation failure to local invalidation and replacement download.

On logout or installation/account switch, call `try await offliner.reset()` before releasing the old instance, then construct a new Offliner using the next installation ID.

## Fresh local validation

Validated at `3127dbfe0e6a5d4ef90dec4f06e65ffc97228c09`, based on current `origin/main` `268cde75f6196cb7811d6cc14ef81f6ae31f46d3`:

- `xcodebuild build -scheme Offliner -destination generic/platform=watchOS` — passed
- `xcodebuild build -scheme Offliner -destination generic/platform=iOS` — passed
- `xcodebuild test -scheme Offliner -destination platform=macOS` — 114 tests, 0 failures
- `xcodebuild test -scheme Offliner -destination platform=iOS Simulator,id=<iPhone 17 Pro>` — 114 tests, 1 expected skip, 0 failures
- `xcodebuild test -scheme Offliner -destination platform=watchOS Simulator,id=<watchOS 11.5>` — 114 tests, 1 expected skip, 0 failures
- SwiftLint for all 4 Swift files changed by the latest commit — 0 violations
- `git diff --check` — passed
- `swift package dump-package` — passed

The simulator skip is `testProtectedAssetRetainsStoredLicenseContext`: AVFoundation raises an Objective-C exception when `AVContentKeySession(.fairPlayStreaming)` is constructed on a simulator. The protected construction test passes on macOS, generic iOS/watchOS device builds compile the path, and simulator tests still cover unprotected construction, missing/unreadable/empty license rejection, local invalidation, and single replacement registration.

All fresh GitHub checks are green on this head, including the xcodebuild job without a retry. The previous head's initial xcodebuild job hit the unrelated Player `HTTPClientTests.testBackoffCancellation()` timing flake (`counter` 0 instead of 1); its failed-only rerun passed without code changes.

The repository SwiftFormat hook was skipped only for this focused commit because it rewrites untouched pre-existing lines. That unrelated churn was not included. New lines match surrounding style; SwiftLint, every other commit hook, `git diff --check`, builds, and tests passed.

## TM-1574 runtime validation

TM-1574 remains responsible for real downloads, DRM/license acquisition, real FairPlay key delivery/playback on device, and background-session rejoin validation. The validation above establishes compile and unit behavior only. This PR makes no runtime DRM, playback, or background-rejoin claims.

## Risk and human review

Medium. Human review should focus on the public playback-wrapper lifetime contract, corrupt-license recovery, stored-key delegate behavior, public state and queue contracts, legacy migration, queue aggregation and retry identity, failure-generation aggregation, collection/member conflict rules, cancellation ordering, and background-session ownership. TM-1574 device/runtime validation remains required before release.

## References

- [TM-1573](https://linear.app/tidal/issue/TM-1573)
- #414 (merged; supplies the shared Offliner scheme and test plan)
