### PR TITLE
TIDE-3046: Fix Offliner task poller skipping tasks over the draining queue

### DIFF
--- a/Sources/Offliner/Internal/TaskRunner.swift
+++ b/Sources/Offliner/Internal/TaskRunner.swift
@@ -23,7 +23,6 @@ actor TaskRunner {
 	private var taskIds: Set<String> = []
 
 	private var processTask: Task<Void, Never>?
-	private var cursor: String?
 
 	private(set) var currentDownloads: [Download] = []
 	private var downloadsContinuation: AsyncStream<Download>.Continuation?
@@ -106,7 +105,14 @@ actor TaskRunner {
 	}
 
 	private func refresh() async throws {
-		let (tasks, cursor) = try await offlineApiClient.getTasks(cursor: self.cursor)
+		// The backend `/offline/tasks` endpoint returns the *current* set of pending tasks and drains
+		// as the client PATCHes tasks to `.completed`/`.failed`. It is a live work queue, not a stable
+		// append-only log, so we must always re-read from the head (cursor: nil). Persisting a
+		// monotonically-advancing cursor across refreshes skips tasks that shift toward the head as
+		// earlier ones complete, and never revisits the head to pick up items added after the queue has
+		// drained — the "can't download more than one page of a collection" and "newly-added tracks
+		// never download" regressions (introduced by 2bb80702, "Use cursor for incremental task fetching").
+		let (tasks, _) = try await offlineApiClient.getTasks(cursor: nil)
 
 		for task in tasks where taskIds.insert(task.id).inserted {
 			let pendingTask = handle(task)
@@ -115,10 +121,6 @@ actor TaskRunner {
 				currentDownloads.append(download)
 				downloadsContinuation?.yield(download)
 			}
-		}
-
-		if let cursor {
-			self.cursor = cursor
 		}
 	}
 

--- a/Tests/OfflinerTests/TaskRunnerCursorRegressionTests.swift
+++ b/Tests/OfflinerTests/TaskRunnerCursorRegressionTests.swift
@@ -1,0 +1,134 @@
+@testable import Offliner
+import Foundation
+import TidalAPI
+import XCTest
+
+/// Regression coverage for the `TaskRunner` task-poll cursor.
+///
+/// The backend `/offline/tasks` endpoint is a *live* queue: it returns the current set of pending
+/// tasks and drains as the client PATCHes them to `.completed`/`.failed`. A persistent,
+/// monotonically-advancing page cursor (introduced by 2bb80702, "Use cursor for incremental task
+/// fetching") skips tasks that shift toward the head as earlier ones complete, and never revisits
+/// the head to pick up items enqueued after the queue has drained. That surfaced to users as
+/// "can't download more than one page of a collection" and "newly-added tracks/playlists never
+/// download".
+///
+/// Unlike `StubOfflineApiClient` (which always returns the full pending set with a nil cursor, so it
+/// never exercises pagination), `PaginatingOfflineApiClient` models offset pagination over the
+/// mutating queue — the shape that made the regression invisible to the existing suite.
+final class TaskRunnerCursorRegressionTests: OfflinerTestCase {
+	/// A newly-added track must download even after the queue has already drained once.
+	/// This is the exact "newly-added tracks never download" report.
+	func testNewlyAddedTrackDownloadsAfterQueueDrained() async throws {
+		let backend = PaginatingOfflineApiClient(pageSize: 2)
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+
+		// Initial collection: 3 tracks (spans two pages, so the buggy cursor advances off nil).
+		try await backend.addItem(type: .track, id: "track-1")
+		try await backend.addItem(type: .track, id: "track-2")
+		try await backend.addItem(type: .track, id: "track-3")
+		await offliner.run()
+		try await awaitStoredTrackCount(offliner, expected: 3)
+
+		// User adds one more track to the (already-downloaded) collection.
+		try await backend.addItem(type: .track, id: "track-4-new")
+		await offliner.run()
+		try await awaitStoredTrackCount(offliner, expected: 4)
+	}
+
+	/// Every track of a multi-page collection must download, not just the first page.
+	/// This is the "unable to download more than N tracks from collection" report.
+	func testAllTracksOfMultiPageCollectionDownload() async throws {
+		let backend = PaginatingOfflineApiClient(pageSize: 2)
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+
+		for index in 1...5 {
+			try await backend.addItem(type: .track, id: "track-\(index)")
+		}
+		await offliner.run()
+
+		try await awaitStoredTrackCount(offliner, expected: 5)
+	}
+
+	// MARK: - Helpers
+
+	/// Polls stored-track count up to a deadline, then asserts. A bounded wait is required because a
+	/// regressed `TaskRunner` strands tasks, so the queue never fully drains.
+	private func awaitStoredTrackCount(
+		_ offliner: Offliner,
+		expected: Int,
+		timeout: TimeInterval = 10
+	) async throws {
+		let deadline = Date().addingTimeInterval(timeout)
+		var lastCount = 0
+		while Date() < deadline {
+			lastCount = try await offliner.getOfflineMediaItems(mediaType: .tracks).count
+			if lastCount >= expected { break }
+			try? await Task.sleep(nanoseconds: 50_000_000)
+		}
+		XCTAssertEqual(lastCount, expected, "Expected \(expected) downloaded tracks, got \(lastCount)")
+	}
+}
+
+// MARK: - PaginatingOfflineApiClient
+
+/// Backend fake that models the real `/offline/tasks` contract: a pending-task queue paged by an
+/// offset cursor, which drains as tasks are PATCHed to a terminal state.
+private final class PaginatingOfflineApiClient: OfflineApiClientProtocol {
+	private let pageSize: Int
+	private var pending: [(id: String, task: OfflineTask)] = []
+	private var taskIdCounter = 0
+
+	init(pageSize: Int) {
+		self.pageSize = pageSize
+	}
+
+	func addItem(type: ResourceType, id: String) async throws {
+		let taskId = "task-\(taskIdCounter)"
+		let position = taskIdCounter + 1
+		taskIdCounter += 1
+
+		let task: OfflineTask
+		switch type {
+		case .track:
+			task = .storeTrack(StoreTrackTask(
+				id: taskId,
+				track: TracksResourceObject(id: id, type: "tracks"),
+				artists: [],
+				artwork: nil,
+				collectionResourceType: "albums",
+				collectionResourceId: "stub-album",
+				volume: 1,
+				position: position
+			))
+		default:
+			return
+		}
+		pending.append((id: taskId, task: task))
+	}
+
+	func removeItem(type: ResourceType, id: String) async throws {}
+
+	func getTasks(cursor: String?) async throws -> (tasks: [OfflineTask], cursor: String?) {
+		let offset = cursor.flatMap(Int.init) ?? 0
+		guard offset < pending.count else { return ([], nil) }
+		let end = min(offset + pageSize, pending.count)
+		let slice = pending[offset..<end].map(\.task)
+		let nextCursor = end < pending.count ? String(end) : nil
+		return (slice, nextCursor)
+	}
+
+	func updateTask(taskId: String, state: Download.State) async throws {
+		if state == .completed || state == .failed {
+			pending.removeAll { $0.id == taskId }
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`TaskRunner.refresh()` persisted a monotonically-advancing pagination cursor across polls of `GET /offline/tasks`. That endpoint is a **live work queue**: it returns the current set of `pending` tasks and drains as the client PATCHes them to `.completed`/`.failed`. Treating its opaque pagination offset as a stable high-water mark over an append-only log breaks in two ways, which map exactly onto the top user reports on the cloud-offliner:

1. **"Can't download more than N tracks of a collection."** As head tasks complete and leave the queue, the remaining tasks shift toward the head; a saved offset then skips past the seam. Tasks there are never fetched, so most of a large collection silently never downloads — even within a single run.
2. **"Newly-added tracks/playlists never download."** Once the queue drains, the saved cursor is stuck past the end. A track added later lands at the *head* of the now-near-empty queue, before the saved cursor, so `getTasks(cursor: <end>)` returns nothing and it never downloads.

Introduced by `2bb80702` ("Offliner: Use cursor for incremental task fetching", [#330](https://github.com/tidal-music/tidal-sdk-ios/pull/330)). Ironically, that change's stated goal was to "pick up new content that appears asynchronously on the backend" — the exact behavior it broke. The bug was latent until the GA rollout ramp exposed it at scale.

## Fix

Drop the persistent `cursor` field and always re-read from the head (`getTasks(cursor: nil)`). This is correct for a draining queue and restores #330's own intent — head-polling always sees newly-added items at the head. The existing `taskIds` dedup Set and the 80-item queue gate already prevent re-processing, so the only thing given up is a micro-optimization on a background poller (one ~20-item page fetched when the local queue is <80), which correctness dominates.

A fully incremental fetch would require a deletion-stable keyset cursor from the backend (e.g. "tasks with seq > X", monotonic and stable under completion) — a backend change, out of scope here. Offset paging over a draining queue cannot be made correct on the client alone.

## Test

Adds `TaskRunnerCursorRegressionTests` with a `PaginatingOfflineApiClient` that models the real contract — offset pagination over a queue that drains on PATCH. The existing `StubOfflineApiClient` always returned the full pending set with a nil cursor, so it never exercised pagination — the coverage gap that hid this for ~3.5 months.

- `testAllTracksOfMultiPageCollectionDownload` — 5 tracks, pageSize 2: pre-fix 4/5, post-fix 5/5.
- `testNewlyAddedTrackDownloadsAfterQueueDrained` — drain 3, add 1: pre-fix stuck at 2/4, post-fix 4/4.

Both fail on the pre-fix code and pass on the fix. Full Offliner suite green locally (56 tests, 0 failures, Swift 6.2).

## Context

Root-caused from a customer-support signal: iOS download/offline complaints spiked ~2.2× across the cloud-offliner GA ramp, corroborated by an independent LLM categorization stream. Full hand-off, evidence chain, and the other two bugs in the spike (frozen mid-fetch; pre-existing libraries invalidated) are tracked in **TIDE-3046** — this PR resolves the "newly-added / >N-track" forward-sync bug from that ticket.