### PR TITLE
Offliner: Fetch tasks only when queue below the parallel limit

### DIFF
--- a/Sources/Offliner/Internal/OfflineApiClient.swift
+++ b/Sources/Offliner/Internal/OfflineApiClient.swift
@@ -167,7 +167,7 @@ struct OfflineCollectionReference: Hashable, Sendable {
 protocol OfflineApiClientProtocol {
 	func addItem(type: ResourceType, id: String) async throws
 	func removeItem(type: ResourceType, id: String) async throws
-	func getTasks(cursor: String?) async throws -> (tasks: [OfflineTask], cursor: String?)
+	func getTasks() async throws -> [OfflineTask]
 	func updateTask(taskId: String, state: Download.State) async throws
 	func getPendingCollections(
 		type: OfflineCollectionType,
@@ -218,10 +218,9 @@ final class OfflineApiClient: OfflineApiClientProtocol {
 		)
 	}
 
-	func getTasks(cursor: String?) async throws -> (tasks: [OfflineTask], cursor: String?) {
+	func getTasks() async throws -> [OfflineTask] {
 		let response = try await OfflineTasksAPITidal.offlineTasksGet(
 			filterInstallationId: [installationId],
-			pageCursor: cursor,
 			include: ["item", "item.albums.coverArt", "item.coverArt", "item.thumbnailArt", "item.artists", "collection"]
 		)
 
@@ -231,7 +230,7 @@ final class OfflineApiClient: OfflineApiClientProtocol {
 			try? await updateTask(taskId: taskId, state: .failed)
 		}
 
-		return (tasks.compactMap { $0.1 }, response.links.meta?.nextCursor)
+		return tasks.compactMap { $0.1 }
 	}
 
 	func updateTask(taskId: String, state: Download.State) async throws {

--- a/Sources/Offliner/Internal/TaskRunner.swift
+++ b/Sources/Offliner/Internal/TaskRunner.swift
@@ -5,7 +5,6 @@ import OSLog
 actor TaskRunner {
 	private static let logger = Logger(subsystem: "com.tidal.sdk.offliner", category: "TaskRunner")
 	private static let maxConcurrentTasks = 5
-	private static let maxQueueSize = 80
 
 	private let storeTrackHandler: StoreTrackHandler
 	private let storeVideoHandler: StoreVideoHandler
@@ -23,7 +22,6 @@ actor TaskRunner {
 	private var taskIds: Set<String> = []
 
 	private var processTask: Task<Void, Never>?
-	private var cursor: String?
 
 	private(set) var currentDownloads: [Download] = []
 	private var downloadsContinuation: AsyncStream<Download>.Continuation?
@@ -106,7 +104,7 @@ actor TaskRunner {
 	}
 
 	private func refresh() async throws {
-		let (tasks, cursor) = try await offlineApiClient.getTasks(cursor: self.cursor)
+		let tasks = try await offlineApiClient.getTasks()
 
 		for task in tasks where taskIds.insert(task.id).inserted {
 			let pendingTask = handle(task)
@@ -115,10 +113,6 @@ actor TaskRunner {
 				currentDownloads.append(download)
 				downloadsContinuation?.yield(download)
 			}
-		}
-
-		if let cursor {
-			self.cursor = cursor
 		}
 	}
 
@@ -135,7 +129,7 @@ actor TaskRunner {
 	}
 
 	private func process() async {
-		if pendingTasks.count < Self.maxQueueSize {
+		if pendingTasks.count < Self.maxConcurrentTasks {
 			try? await refresh()
 		}
 
@@ -145,12 +139,15 @@ actor TaskRunner {
 			}
 
 			for await _ in group {
-				if let task = pendingTasks.first {
-					group.addTask { await self.start(task) }
+				// Re-poll before dispatching so that tasks surfaced by this refresh are handed to the group in the same
+				// iteration. Otherwise a refresh that first surfaces new work as the group empties would leave those tasks
+				// stranded in `pendingTasks` and the loop would exit.
+				if pendingTasks.count < Self.maxConcurrentTasks {
+					try? await refresh()
 				}
 
-				if pendingTasks.count < Self.maxQueueSize {
-					try? await refresh()
+				if let task = pendingTasks.first {
+					group.addTask { await self.start(task) }
 				}
 			}
 		}

--- a/Tests/OfflinerTests/MediaItemDownloadTests.swift
+++ b/Tests/OfflinerTests/MediaItemDownloadTests.swift
@@ -212,6 +212,51 @@ final class MediaItemDownloadTests: OfflinerTestCase {
 		XCTAssertTrue(resourceIds.contains("track-3"))
 	}
 
+	func testDownloadsMoreTracksThanMaxConcurrentTasks() async throws {
+		let offliner = createOffliner(
+			offlineApiClient: StubOfflineApiClient(),
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+
+		let trackCount = 12
+		for index in 0..<trackCount {
+			try await offliner.download(mediaType: .tracks, resourceId: .identifier("track-\(index)"))
+		}
+
+		await offliner.run()
+
+		let storedItems = try await waitForStoredMediaItems(offliner, mediaType: .tracks, target: trackCount)
+		XCTAssertEqual(storedItems.count, trackCount)
+	}
+
+	func testDownloadsTasksSurfacedByLaterFetch() async throws {
+		// The first getTasks() returns a single task; the remaining two are only surfaced by a *later* getTasks() once the
+		// first has completed. This is the core behavior of the small-queue change — the runner must keep re-polling and
+		// draining rather than stopping after the first response.
+		let apiClient = BatchedOfflineApiClient(
+			firstBatch: [.storeTrackStub(id: "task-1", trackId: "track-1")],
+			secondBatch: [
+				.storeTrackStub(id: "task-2", trackId: "track-2"),
+				.storeTrackStub(id: "task-3", trackId: "track-3"),
+			]
+		)
+
+		let offliner = createOffliner(
+			offlineApiClient: apiClient,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+
+		await offliner.run()
+
+		let storedItems = try await waitForStoredMediaItems(offliner, mediaType: .tracks, target: 3)
+		XCTAssertEqual(storedItems.count, 3, "Tasks surfaced by a later getTasks() were not downloaded")
+
+		let ids = Set(storedItems.map(\.catalogMetadata.id))
+		XCTAssertEqual(ids, ["track-1", "track-2", "track-3"])
+	}
+
 	func testDownloadTrackReportsProgress() async throws {
 		let media = SucceedingMediaDownloader()
 		media.progressValues = [0.25, 0.5, 0.75]

--- a/Tests/OfflinerTests/OfflinerTestCase.swift
+++ b/Tests/OfflinerTests/OfflinerTestCase.swift
@@ -44,6 +44,25 @@ class OfflinerTestCase: XCTestCase {
 		)
 	}
 
+	/// Polls the local store until at least `target` media items of the given type are present, or the poll budget is
+	/// exhausted. Used by tests that let the task runner drain in the background rather than observing the download stream.
+	@discardableResult
+	func waitForStoredMediaItems(
+		_ offliner: Offliner,
+		mediaType: OfflineMediaItemType,
+		target: Int,
+		maxPolls: Int = 300
+	) async throws -> [OfflineMediaItem] {
+		for _ in 0..<maxPolls {
+			let items = try await offliner.getOfflineMediaItems(mediaType: mediaType)
+			if items.count >= target {
+				return items
+			}
+			try? await Task.sleep(nanoseconds: 10_000_000)
+		}
+		return try await offliner.getOfflineMediaItems(mediaType: mediaType)
+	}
+
 	func downloadAndWaitForCompletion(_ offliner: Offliner) async throws {
 		let downloads = offliner.newDownloads
 		async let runTask: () = offliner.run()

--- a/Tests/OfflinerTests/TestFakes.swift
+++ b/Tests/OfflinerTests/TestFakes.swift
@@ -128,8 +128,8 @@ final class StubOfflineApiClient: OfflineApiClientProtocol {
 		}
 	}
 
-	func getTasks(cursor: String?) async throws -> (tasks: [OfflineTask], cursor: String?) {
-		(tasks, nil)
+	func getTasks() async throws -> [OfflineTask] {
+		tasks
 	}
 
 	func updateTask(taskId: String, state: Download.State) async throws {
@@ -163,6 +163,53 @@ final class StubOfflineApiClient: OfflineApiClientProtocol {
 	}
 }
 
+/// Serves store-track tasks in two batches. The second batch only becomes visible from `getTasks()` once every task in
+/// the first batch has been completed, mimicking a backend whose pending-task list shrinks as tasks finish. This exercises
+/// the task runner's re-poll/drain loop, where a later `getTasks()` must surface tasks that were absent from the first response.
+final class BatchedOfflineApiClient: OfflineApiClientProtocol {
+	private let firstBatch: [OfflineTask]
+	private let secondBatch: [OfflineTask]
+	private var completed: Set<String> = []
+	private(set) var getTasksCallCount = 0
+
+	init(firstBatch: [OfflineTask], secondBatch: [OfflineTask]) {
+		self.firstBatch = firstBatch
+		self.secondBatch = secondBatch
+	}
+
+	func addItem(type: ResourceType, id: String) async throws {}
+
+	func removeItem(type: ResourceType, id: String) async throws {}
+
+	func getTasks() async throws -> [OfflineTask] {
+		getTasksCallCount += 1
+		let remainingFirst = firstBatch.filter { !completed.contains($0.id) }
+		guard remainingFirst.isEmpty else { return remainingFirst }
+		return secondBatch.filter { !completed.contains($0.id) }
+	}
+
+	func updateTask(taskId: String, state: Download.State) async throws {
+		if state == .completed || state == .failed {
+			completed.insert(taskId)
+		}
+	}
+}
+
+extension OfflineTask {
+	static func storeTrackStub(id: String, trackId: String) -> OfflineTask {
+		.storeTrack(StoreTrackTask(
+			id: id,
+			track: TracksResourceObject(id: trackId, type: "tracks"),
+			artists: [],
+			artwork: nil,
+			collectionResourceType: "albums",
+			collectionResourceId: "stub-album",
+			volume: 1,
+			position: 1
+		))
+	}
+}
+
 final class FailingOfflineApiClient: OfflineApiClientProtocol {
 	func addItem(type: ResourceType, id: String) async throws {
 		throw FakeError.backendFailed
@@ -172,7 +219,7 @@ final class FailingOfflineApiClient: OfflineApiClientProtocol {
 		throw FakeError.backendFailed
 	}
 
-	func getTasks(cursor: String?) async throws -> (tasks: [OfflineTask], cursor: String?) {
+	func getTasks() async throws -> [OfflineTask] {
 		throw FakeError.backendFailed
 	}
 
@@ -192,8 +239,8 @@ final class FailOnUpdateToInProgressOfflineApiClient: OfflineApiClientProtocol {
 		try await stub.removeItem(type: type, id: id)
 	}
 
-	func getTasks(cursor: String?) async throws -> (tasks: [OfflineTask], cursor: String?) {
-		try await stub.getTasks(cursor: cursor)
+	func getTasks() async throws -> [OfflineTask] {
+		try await stub.getTasks()
 	}
 
 	func updateTask(taskId: String, state: Download.State) async throws {
@@ -215,8 +262,8 @@ final class FailOnUpdateToCompletedOfflineApiClient: OfflineApiClientProtocol {
 		try await stub.removeItem(type: type, id: id)
 	}
 
-	func getTasks(cursor: String?) async throws -> (tasks: [OfflineTask], cursor: String?) {
-		try await stub.getTasks(cursor: cursor)
+	func getTasks() async throws -> [OfflineTask] {
+		try await stub.getTasks()
 	}
 
 	func updateTask(taskId: String, state: Download.State) async throws {
@@ -232,7 +279,7 @@ final class FailOnGetTasksOfflineApiClient: OfflineApiClientProtocol {
 
 	func removeItem(type: ResourceType, id: String) async throws {}
 
-	func getTasks(cursor: String?) async throws -> (tasks: [OfflineTask], cursor: String?) {
+	func getTasks() async throws -> [OfflineTask] {
 		throw FakeError.backendFailed
 	}
 


### PR DESCRIPTION
## What

Changes how the Offliner `TaskRunner` selects tasks:

- **Only fetch from the backend when the local queue is below the parallel limit.** `refresh()` is now gated on `maxConcurrentTasks` (5) instead of the removed `maxQueueSize` (80), so we fetch just enough to keep the concurrent download slots busy.
- **Stop paginating.** Removed the `cursor` state; `getTasks()` fetches the first page only and returns `[OfflineTask]`. As tasks complete they're marked done on the backend, so the next fetch naturally surfaces the next batch of pending tasks — no cursor walk needed.

## Bug found & fixed

The re-poll design exposed a latent **task-stranding bug** in `process()`. The drain loop dispatched `pendingTasks.first` *before* calling `refresh()`. When a `refresh()` first surfaced new work at the moment the task group emptied, those tasks landed in `pendingTasks` but were never handed to the group, and `for await _ in group` then exited — abandoning them. The old paginated design masked this by front-loading all pages up to 80; making re-poll the primary mechanism turned late task-surfacing into the normal path.

Fix: re-poll before dispatch inside the loop so newly-surfaced tasks are dispatched in the same iteration, keeping the group alive.

## Tests

- `testDownloadsTasksSurfacedByLaterFetch` — a batched fake returns a second batch only after the first completes; asserts all are downloaded. Fails before the loop fix, passes after.
- `testDownloadsMoreTracksThanMaxConcurrentTasks` — 12 tasks (> the limit of 5) all drain and store.

All 56 Offliner tests pass; SwiftLint clean.

## Notes / follow-ups (not addressed here)

- **`.downloading` visibility window shrank.** `hasCurrentDownload` only sees locally-loaded tasks, so with multiple simultaneous collections spanning more than one page, a queued-but-not-yet-loaded collection can briefly report `.notDownloaded`. This is inherent to the no-pagination/small-queue design and consistent with `getOfflineCollectionDownloadState`'s documented contract (".downloading is reserved for active download/acquisition work already known by this SDK instance"). Single-collection downloads are unaffected.
- **Re-download on backend lag.** Since `refresh()` now re-polls the first page after each completion and `start()` clears the task id on completion, a task that reappears from `offlineTasksGet` before the completion PATCH propagates could be re-downloaded. Whether this can happen depends on the tasks endpoint's read-after-write consistency. Can add a completed-id guard if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)