### PR TITLE
Offliner: Serialize tasks targeting the same item

### DIFF
--- a/Sources/Offliner/Internal/Handlers/RemoveCollectionHandler.swift
+++ b/Sources/Offliner/Internal/Handlers/RemoveCollectionHandler.swift
@@ -24,6 +24,10 @@ private final class InternalRemoveCollectionTask: InternalTask {
 		self.offlineStore = offlineStore
 	}
 
+	var concurrencyKey: OfflineTaskConcurrencyKey {
+		OfflineTaskConcurrencyKey(resourceType: task.resourceType, resourceId: task.resourceId)
+	}
+
 	func run() async throws {
 		try offlineStore.deleteCollection(resourceType: task.resourceType, resourceId: task.resolvedResourceId)
 	}

--- a/Sources/Offliner/Internal/Handlers/RemoveItemHandler.swift
+++ b/Sources/Offliner/Internal/Handlers/RemoveItemHandler.swift
@@ -24,6 +24,15 @@ private final class InternalRemoveItemTask: InternalTask {
 		self.offlineStore = offlineStore
 	}
 
+	var concurrencyKey: OfflineTaskConcurrencyKey {
+		OfflineTaskConcurrencyKey(
+			collectionType: task.collectionResourceType,
+			collectionId: task.collectionResourceId,
+			resourceType: task.resourceType,
+			resourceId: task.resourceId
+		)
+	}
+
 	func run() async throws {
 		try offlineStore.deleteMediaItem(
 			resourceType: task.resourceType,

--- a/Sources/Offliner/Internal/Handlers/StoreAlbumHandler.swift
+++ b/Sources/Offliner/Internal/Handlers/StoreAlbumHandler.swift
@@ -33,6 +33,10 @@ private final class InternalAlbumTask: InternalTask {
 		self.artworkDownloader = artworkDownloader
 	}
 
+	var concurrencyKey: OfflineTaskConcurrencyKey {
+		OfflineTaskConcurrencyKey(resourceType: OfflineCollectionType.albums.rawValue, resourceId: task.album.id)
+	}
+
 	func isDownloadTask(for collection: OfflineCollectionReference) -> Bool {
 		collection.collectionType == .albums && collection.resourceId == task.album.id
 	}

--- a/Sources/Offliner/Internal/Handlers/StorePlaylistHandler.swift
+++ b/Sources/Offliner/Internal/Handlers/StorePlaylistHandler.swift
@@ -33,6 +33,10 @@ private final class InternalPlaylistTask: InternalTask {
 		self.artworkDownloader = artworkDownloader
 	}
 
+	var concurrencyKey: OfflineTaskConcurrencyKey {
+		OfflineTaskConcurrencyKey(resourceType: OfflineCollectionType.playlists.rawValue, resourceId: task.playlist.id)
+	}
+
 	func isDownloadTask(for collection: OfflineCollectionReference) -> Bool {
 		collection.collectionType == .playlists && collection.resourceId == task.playlist.id
 	}

--- a/Sources/Offliner/Internal/Handlers/StoreTrackHandler.swift
+++ b/Sources/Offliner/Internal/Handlers/StoreTrackHandler.swift
@@ -78,6 +78,15 @@ private final class InternalTrackTask: InternalTask {
 		self.licenseDownloader = licenseDownloader
 	}
 
+	var concurrencyKey: OfflineTaskConcurrencyKey {
+		OfflineTaskConcurrencyKey(
+			collectionType: task.collectionResourceType,
+			collectionId: task.collectionResourceId,
+			resourceType: OfflineMediaItemType.tracks.rawValue,
+			resourceId: task.track.id
+		)
+	}
+
 	func run() async throws {
 		try await withFileCleanup { cleanup in
 			async let artworkTask = artworkDownloader.downloadArtwork(for: task.artwork)

--- a/Sources/Offliner/Internal/Handlers/StoreUserCollectionTracksHandler.swift
+++ b/Sources/Offliner/Internal/Handlers/StoreUserCollectionTracksHandler.swift
@@ -25,6 +25,13 @@ private final class InternalUserCollectionTracksTask: InternalTask {
 		self.offlineStore = offlineStore
 	}
 
+	var concurrencyKey: OfflineTaskConcurrencyKey {
+		OfflineTaskConcurrencyKey(
+			resourceType: OfflineCollectionType.userCollectionTracks.rawValue,
+			resourceId: task.resourceId
+		)
+	}
+
 	func isDownloadTask(for collection: OfflineCollectionReference) -> Bool {
 		collection.collectionType == .userCollectionTracks && collection.resourceId == task.resolvedResourceId
 	}

--- a/Sources/Offliner/Internal/Handlers/StoreVideoHandler.swift
+++ b/Sources/Offliner/Internal/Handlers/StoreVideoHandler.swift
@@ -78,6 +78,15 @@ private final class InternalVideoTask: InternalTask {
 		self.licenseDownloader = licenseDownloader
 	}
 
+	var concurrencyKey: OfflineTaskConcurrencyKey {
+		OfflineTaskConcurrencyKey(
+			collectionType: task.collectionResourceType,
+			collectionId: task.collectionResourceId,
+			resourceType: OfflineMediaItemType.videos.rawValue,
+			resourceId: task.video.id
+		)
+	}
+
 	func run() async throws {
 		try await withFileCleanup { cleanup in
 			async let artworkTask = artworkDownloader.downloadArtwork(for: task.artwork)

--- a/Sources/Offliner/Internal/TaskRunner.swift
+++ b/Sources/Offliner/Internal/TaskRunner.swift
@@ -140,12 +140,14 @@ actor TaskRunner {
 		}
 
 		await withTaskGroup(of: Void.self) { group in
-			for task in pendingTasks.prefix(Self.maxConcurrentTasks) {
-				group.addTask { await self.start(task) }
+			for _ in 0 ..< Self.maxConcurrentTasks {
+				if let task = getTask() {
+					group.addTask { await self.start(task) }
+				}
 			}
 
 			for await _ in group {
-				if let task = pendingTasks.first {
+				if let task = getTask() {
 					group.addTask { await self.start(task) }
 				}
 
@@ -156,11 +158,22 @@ actor TaskRunner {
 		}
 	}
 
-	private func start(_ task: InternalTask) async {
-		guard await network.isInexpensive || allowDownloadsOnExpensiveNetworks else { return }
+	private func getTask() -> InternalTask? {
+		let runningKeys = Set(runningTasks.map(\.concurrencyKey))
 
-		pendingTasks.removeAll { $0 === task }
+		guard let index = pendingTasks.firstIndex(where: { !runningKeys.contains($0.concurrencyKey) }) else {
+			return nil
+		}
+
+		let task = pendingTasks.remove(at: index)
 		runningTasks.append(task)
+		return task
+	}
+
+	private func start(_ task: InternalTask) async {
+		while !allowDownloadsOnExpensiveNetworks, !(await network.isInexpensive) {
+			try? await Task.sleep(nanoseconds: 1_000_000_000)
+		}
 
 		do {
 			try await offlineApiClient.updateTask(taskId: task.id, state: .inProgress)
@@ -216,11 +229,29 @@ private actor Network {
 	}
 }
 
+// MARK: - OfflineTaskConcurrencyKey
+
+struct OfflineTaskConcurrencyKey: Hashable, Sendable {
+	let collectionType: String?
+	let collectionId: String?
+	let resourceType: String
+	let resourceId: String
+
+	init(collectionType: String? = nil, collectionId: String? = nil, resourceType: String, resourceId: String) {
+		let userCollectionTracks = OfflineCollectionType.userCollectionTracks.rawValue
+		self.collectionType = collectionType
+		self.collectionId = collectionType == userCollectionTracks ? ResourceId.me.stringValue : collectionId
+		self.resourceType = resourceType
+		self.resourceId = resourceType == userCollectionTracks ? ResourceId.me.stringValue : resourceId
+	}
+}
+
 // MARK: - InternalTask
 
 protocol InternalTask: AnyObject {
 	var id: String { get }
 	var download: Download? { get }
+	var concurrencyKey: OfflineTaskConcurrencyKey { get }
 	func isDownloadTask(for collection: OfflineCollectionReference) -> Bool
 	func run() async throws
 }

--- a/Tests/OfflinerTests/MediaItemDownloadTests.swift
+++ b/Tests/OfflinerTests/MediaItemDownloadTests.swift
@@ -96,7 +96,7 @@ final class MediaItemDownloadTests: OfflinerTestCase {
 
 		let storedItem = try await offliner.getOfflineMediaItem(mediaType: .tracks, resourceId: .identifier("track-123"))
 		let artworkURL = try XCTUnwrap(storedItem?.artworkURL)
-		let movedURL = artworkURL.deletingLastPathComponent().appendingPathComponent("moved-artwork.jpg")
+		let movedURL = artworkURL.deletingLastPathComponent().appendingPathComponent("moved-artwork-\(UUID().uuidString).jpg")
 		try FileManager.default.moveItem(at: artworkURL, to: movedURL)
 
 		let renewedItem = try await offliner.getOfflineMediaItem(mediaType: .tracks, resourceId: .identifier("track-123"))

--- a/Tests/OfflinerTests/TaskConflictTests.swift
+++ b/Tests/OfflinerTests/TaskConflictTests.swift
@@ -1,0 +1,85 @@
+@testable import Offliner
+import TidalAPI
+import XCTest
+
+final class TaskConflictTests: OfflinerTestCase {
+	func testRemoveTaskForSameItemWaitsForRunningStoreTask() async throws {
+		let backend = StubOfflineApiClient()
+		let media = SuspendingMediaDownloader()
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: media
+		)
+
+		backend.enqueueTasks([
+			.storeTrack(storeTrackTask(id: "store-task", trackId: "track-123")),
+			.removeItem(removeItemTask(id: "remove-task", trackId: "track-123")),
+		])
+
+		async let runTask: () = offliner.run()
+		await media.waitUntilStarted()
+
+		try await Task.sleep(nanoseconds: 200_000_000)
+		XCTAssertEqual(backend.completedTaskIds, [])
+
+		await media.complete()
+		await backend.waitForTasksToComplete()
+		await runTask
+
+		XCTAssertEqual(backend.completedTaskIds, ["store-task", "remove-task"])
+
+		let storedItem = try await offliner.getOfflineMediaItem(mediaType: .tracks, resourceId: .identifier("track-123"))
+		XCTAssertNil(storedItem)
+	}
+
+	func testRemoveTaskForOtherItemRunsWhileStoreTaskIsRunning() async throws {
+		let backend = StubOfflineApiClient()
+		let media = SuspendingMediaDownloader()
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: media
+		)
+
+		backend.enqueueTasks([
+			.storeTrack(storeTrackTask(id: "store-task", trackId: "track-123")),
+			.removeItem(removeItemTask(id: "remove-task", trackId: "track-456")),
+		])
+
+		async let runTask: () = offliner.run()
+		await media.waitUntilStarted()
+
+		while backend.completedTaskIds.isEmpty {
+			try await Task.sleep(nanoseconds: 10_000_000)
+		}
+		XCTAssertEqual(backend.completedTaskIds, ["remove-task"])
+
+		await media.complete()
+		await backend.waitForTasksToComplete()
+		await runTask
+	}
+
+	private func storeTrackTask(id: String, trackId: String) -> StoreTrackTask {
+		StoreTrackTask(
+			id: id,
+			track: TracksResourceObject(id: trackId, type: "tracks"),
+			artists: [],
+			artwork: nil,
+			collectionResourceType: "albums",
+			collectionResourceId: "album-1",
+			volume: 1,
+			position: 1
+		)
+	}
+
+	private func removeItemTask(id: String, trackId: String) -> RemoveItemTask {
+		RemoveItemTask(
+			id: id,
+			resourceType: "tracks",
+			resourceId: trackId,
+			collectionResourceType: "albums",
+			collectionResourceId: "album-1"
+		)
+	}
+}

--- a/Tests/OfflinerTests/TestFakes.swift
+++ b/Tests/OfflinerTests/TestFakes.swift
@@ -14,6 +14,7 @@ final class StubOfflineApiClient: OfflineApiClientProtocol {
 	private(set) var tasks: [OfflineTask] = []
 	private(set) var addedItems: [RecordedItem] = []
 	private(set) var removedItems: [RecordedItem] = []
+	private(set) var completedTaskIds: [String] = []
 	var taskIdCounter = 0
 
 	var pendingCollectionsPages: [(collections: [OfflineCollection], cursor: String?)] = []
@@ -133,6 +134,9 @@ final class StubOfflineApiClient: OfflineApiClientProtocol {
 	}
 
 	func updateTask(taskId: String, state: Download.State) async throws {
+		if state == .completed {
+			completedTaskIds.append(taskId)
+		}
 		if state == .completed || state == .failed {
 			tasks.removeAll { $0.id == taskId }
 		}


### PR DESCRIPTION
## Motivation

Tasks for the same item could run concurrently and finish out of order. Example: a content refresh creates a store task for a track, the user then deletes the track, and the resulting remove task finishes before the still-running store task — the track lingers on the device even though the user wanted it gone.

## Changes

- `InternalTask` now exposes an `OfflineTaskConcurrencyKey` (collection type, collection id, resource type, resource id). A pending task is skipped while a running task has the same key, so tasks for the same item execute one at a time in backend order. Collection-level tasks (album/playlist/userCollectionTracks) key on the collection itself, so e.g. a store-album and remove-album can't overlap either.
- Task pickup (`getTask()`) now claims synchronously on the actor: the task moves from `pendingTasks` to `runningTasks` at pick time, before any suspension point. This makes the conflict check race-free and also closes a pre-existing window where `pendingTasks.first` could hand the same task to two task-group children.
- When downloads aren't allowed (expensive network and `allowDownloadsOnExpensiveNetworks` off), a claimed task now parks at the top of `start()` and rechecks both conditions once a second. Previously the runner cycled claim→skip through the queue and called `getTasks` once per iteration for as long as the network stayed expensive.

Also fixes a test flake: `testMovedArtworkFileRenewsStoredBookmark` moved artwork to a fixed filename in the shared temp directory and failed on every second run on the same machine.

## Testing

- New `TaskConflictTests` verify that a remove task for the same track+collection stays queued while the store task runs and completes after it (leaving the track deleted), and that a remove task for a different item is not blocked.
- Verified the tests catch the regression: with the key filter disabled, all assertions fail with the remove task completing first.
- All 58 Offliner tests pass; SwiftLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)