### PR TITLE
TidalAPI: add body-ignoring create dry-run APIs

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -77,6 +77,12 @@ let package = Package(
 				"README.md",
 			]
 		),
+		.testTarget(
+			name: "TidalAPITests",
+			dependencies: [
+				.tidalAPI,
+			]
+		),
 		.target(
 			name: "Common",
 			dependencies: [

--- a/Sources/TidalAPI/Utils/CreateDryRunAPI.swift
+++ b/Sources/TidalAPI/Utils/CreateDryRunAPI.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+public extension ArtistsAPITidal {
+	/// Validates an artist creation without decoding a created resource from the successful response.
+	static func artistsPostDryRun(
+		idempotencyKey: String? = nil,
+		artistsCreateOperationPayload: ArtistsCreateOperationPayload
+	) async throws {
+		var payload = artistsCreateOperationPayload
+		if payload.meta == nil {
+			payload.meta = ArtistsCreateOperationPayloadMeta()
+		}
+		payload.meta?.dryRun = true
+
+		try await RequestHelper.createRequestIgnoringResponseBody {
+			ArtistsAPI.artistsPostWithRequestBuilder(
+				idempotencyKey: idempotencyKey,
+				artistsCreateOperationPayload: payload
+			)
+		}
+	}
+}
+
+public extension AppreciationsAPITidal {
+	/// Validates an appreciation creation without decoding a created resource from the successful response.
+	static func appreciationsPostDryRun(
+		idempotencyKey: String? = nil,
+		appreciationsCreateOperationPayload: AppreciationsCreateOperationPayload
+	) async throws {
+		var payload = appreciationsCreateOperationPayload
+		if payload.meta == nil {
+			payload.meta = AppreciationsCreateOperationPayloadMeta()
+		}
+		payload.meta?.dryRun = true
+
+		try await RequestHelper.createRequestIgnoringResponseBody {
+			AppreciationsAPI.appreciationsPostWithRequestBuilder(
+				idempotencyKey: idempotencyKey,
+				appreciationsCreateOperationPayload: payload
+			)
+		}
+	}
+}

--- a/Sources/TidalAPI/Utils/RequestHelper.swift
+++ b/Sources/TidalAPI/Utils/RequestHelper.swift
@@ -15,9 +15,31 @@ enum RequestHelper {
 					customHeaders: customHeaders,
 					builder: builder
 				)
-			})
+			}
+		)
 
 		return try await retryHandler.execute()
+	}
+
+	static func createRequestIgnoringResponseBody<T>(
+		customHeaders: [String: String] = [:],
+		requestBuilder: @escaping () async throws -> RequestBuilder<T>
+	) async throws {
+		let builder = try await requestBuilder()
+		try await createRequest(customHeaders: customHeaders) {
+			requestBuilderIgnoringResponseBody(builder)
+		}
+	}
+
+	static func requestBuilderIgnoringResponseBody<T>(_ builder: RequestBuilder<T>) -> RequestBuilder<Void> {
+		let builderType: RequestBuilder<Void>.Type = OpenAPIClientAPI.requestBuilderFactory.getNonDecodableBuilder()
+		return builderType.init(
+			method: builder.method,
+			URLString: builder.URLString,
+			parameters: builder.parameters,
+			headers: builder.headers,
+			requiresAuthentication: builder.requiresAuthentication
+		)
 	}
 
 	private static func executeRequestWithAuth<T>(

--- a/Tests/TidalAPITests/CreateDryRunAPITests.swift
+++ b/Tests/TidalAPITests/CreateDryRunAPITests.swift
@@ -1,0 +1,118 @@
+import Foundation
+@testable import TidalAPI
+import XCTest
+
+// MARK: - CreateDryRunAPITests
+
+final class CreateDryRunAPITests: XCTestCase {
+	func testIgnoringResponseBodyPreservesGeneratedRequest() {
+		let original = ArtistsAPI.artistsPostWithRequestBuilder(
+			idempotencyKey: "idempotency-key",
+			artistsCreateOperationPayload: nil
+		)
+
+		let bodyIgnoring = RequestHelper.requestBuilderIgnoringResponseBody(original)
+
+		XCTAssertEqual(bodyIgnoring.method, original.method)
+		XCTAssertEqual(bodyIgnoring.URLString, original.URLString)
+		XCTAssertEqual(bodyIgnoring.headers, original.headers)
+		XCTAssertEqual(bodyIgnoring.requiresAuthentication, original.requiresAuthentication)
+	}
+
+	func testGenericSuccessDocumentIsAcceptedFor200() async throws {
+		let response: Response<Void> = try await execute(
+			statusCode: 200,
+			data: Data(#"{"links":{"self":"/artists"},"meta":{"dryRun":true}}"#.utf8)
+		)
+
+		XCTAssertEqual(response.statusCode, 200)
+	}
+
+	func testGenericSuccessDocumentIsAcceptedFor201() async throws {
+		let response: Response<Void> = try await execute(
+			statusCode: 201,
+			data: Data(#"{"links":{"self":"/artists"},"meta":{"dryRun":true}}"#.utf8)
+		)
+
+		XCTAssertEqual(response.statusCode, 201)
+	}
+
+	func testErrorResponseStillFails() async {
+		do {
+			let _: Response<Void> = try await execute(
+				statusCode: 400,
+				data: Data(#"{"errors":[{"status":"400"}]}"#.utf8)
+			)
+			XCTFail("Expected an error response to fail")
+		} catch {
+			// Expected.
+		}
+	}
+
+	private func execute(statusCode: Int, data: Data?) async throws -> Response<Void> {
+		let builder = StubRequestBuilder<Void>(
+			method: "POST",
+			URLString: "https://openapi.tidal.com/v2/artists",
+			parameters: nil,
+			requiresAuthentication: false
+		)
+		builder.stubSession = StubURLSession(statusCode: statusCode, data: data)
+		return try await builder.execute()
+	}
+}
+
+// MARK: - StubRequestBuilder
+
+private final class StubRequestBuilder<T>: URLSessionRequestBuilder<T> {
+	var stubSession: URLSessionProtocol = StubURLSession(statusCode: 500, data: nil)
+
+	override func createURLSession() -> URLSessionProtocol {
+		stubSession
+	}
+}
+
+// MARK: - StubURLSession
+
+private final class StubURLSession: URLSessionProtocol, @unchecked Sendable {
+	private let statusCode: Int
+	private let data: Data?
+
+	init(statusCode: Int, data: Data?) {
+		self.statusCode = statusCode
+		self.data = data
+	}
+
+	func dataTaskFromProtocol(
+		with request: URLRequest,
+		completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void
+	) -> URLSessionDataTaskProtocol {
+		let response = HTTPURLResponse(
+			url: request.url!,
+			statusCode: statusCode,
+			httpVersion: nil,
+			headerFields: ["Content-Type": "application/vnd.api+json"]
+		)
+		return StubURLSessionDataTask {
+			completionHandler(self.data, response, nil)
+		}
+	}
+}
+
+// MARK: - StubURLSessionDataTask
+
+private final class StubURLSessionDataTask: URLSessionDataTaskProtocol, @unchecked Sendable {
+	let taskIdentifier = 1
+	let progress = Progress(totalUnitCount: 1)
+
+	private let completion: @Sendable () -> Void
+
+	init(completion: @escaping @Sendable () -> Void) {
+		self.completion = completion
+	}
+
+	func resume() {
+		completion()
+	}
+
+	func cancel() {}
+}


### PR DESCRIPTION
## Summary

- Add explicit `artistsPostDryRun` and `appreciationsPostDryRun` APIs that force `meta.dryRun = true`.
- Reuse the generated request builders, authentication, and retry behavior while intentionally ignoring successful response bodies.
- Cover minimal JSON:API success documents returned with either `200` or `201`, while continuing to reject non-2xx responses.

## Scope

This is the minimal client-side compatibility change needed before the server can return a generic `{ links, meta }` document for create dry runs. It does not edit the SDK-local OAS, regenerate endpoint signatures, or document/add `204`. Ordinary non-dry-run create methods remain typed and strict.

## Verification

- `swift build --target TidalAPI`
- `swiftformat --lint` on changed Swift files
- Focused unit tests run in CI