### PR TITLE
TM-1767: Stabilize collection download state

### DIFF
--- a/Sources/Offliner/Internal/TaskRunner.swift
+++ b/Sources/Offliner/Internal/TaskRunner.swift
@@ -2,7 +2,14 @@ import Foundation
 import Network
 import OSLog
 
+// MARK: - TaskRunner
+
 actor TaskRunner {
+	private enum CollectionDownloadRequestState {
+		case requested
+		case acknowledged
+	}
+
 	private static let logger = Logger(subsystem: "com.tidal.sdk.offliner", category: "TaskRunner")
 	private static let maxConcurrentTasks = 5
 	private static let refreshThreshold = 10
@@ -21,6 +28,7 @@ actor TaskRunner {
 	private var pendingTasks: [InternalTask] = []
 	private var runningTasks: [InternalTask] = []
 	private var taskIds: Set<String> = []
+	private var collectionDownloadRequests: [OfflineCollectionReference: CollectionDownloadRequestState] = [:]
 
 	private var processTask: Task<Void, Never>?
 	private var rerunRequested = false
@@ -43,42 +51,42 @@ actor TaskRunner {
 		videoManifestFetcher: VideoManifestFetcherProtocol
 	) {
 		self.offlineApiClient = offlineApiClient
-		self.allowDownloadsOnExpensiveNetworks = configuration.allowDownloadsOnExpensiveNetworks
-		self.network = Network()
+		allowDownloadsOnExpensiveNetworks = configuration.allowDownloadsOnExpensiveNetworks
+		network = Network()
 
 		let (stream, continuation) = AsyncStream<Download>.makeStream()
-		self.newDownloads = stream
-		self.downloadsContinuation = continuation
+		newDownloads = stream
+		downloadsContinuation = continuation
 
-		self.storeTrackHandler = StoreTrackHandler(
+		storeTrackHandler = StoreTrackHandler(
 			offlineStore: offlineStore,
 			artworkDownloader: artworkDownloader,
 			mediaDownloader: mediaDownloader,
 			manifestFetcher: trackManifestFetcher,
 			licenseDownloader: licenseDownloader
 		)
-		self.storeVideoHandler = StoreVideoHandler(
+		storeVideoHandler = StoreVideoHandler(
 			offlineStore: offlineStore,
 			artworkDownloader: artworkDownloader,
 			mediaDownloader: mediaDownloader,
 			manifestFetcher: videoManifestFetcher,
 			licenseDownloader: licenseDownloader
 		)
-		self.storeAlbumHandler = StoreAlbumHandler(
+		storeAlbumHandler = StoreAlbumHandler(
 			offlineStore: offlineStore,
 			artworkDownloader: artworkDownloader
 		)
-		self.storePlaylistHandler = StorePlaylistHandler(
+		storePlaylistHandler = StorePlaylistHandler(
 			offlineStore: offlineStore,
 			artworkDownloader: artworkDownloader
 		)
-		self.storeUserCollectionTracksHandler = StoreUserCollectionTracksHandler(
+		storeUserCollectionTracksHandler = StoreUserCollectionTracksHandler(
 			offlineStore: offlineStore
 		)
-		self.removeItemHandler = RemoveItemHandler(
+		removeItemHandler = RemoveItemHandler(
 			offlineStore: offlineStore
 		)
-		self.removeCollectionHandler = RemoveCollectionHandler(
+		removeCollectionHandler = RemoveCollectionHandler(
 			offlineStore: offlineStore
 		)
 	}
@@ -107,7 +115,45 @@ actor TaskRunner {
 
 	func hasCurrentDownload(relatedTo collectionType: OfflineCollectionType, resourceId: ResourceId) -> Bool {
 		let collection = OfflineCollectionReference(collectionType: collectionType, resourceId: resourceId)
-		return pendingTasks.contains { $0.isDownloadTask(for: collection) } ||
+		return hasCurrentDownload(for: collection)
+	}
+
+	func beginCollectionDownload(collectionType: OfflineCollectionType, resourceId: ResourceId) {
+		let collection = OfflineCollectionReference(collectionType: collectionType, resourceId: resourceId)
+		if collectionDownloadRequests[collection] == nil {
+			collectionDownloadRequests[collection] = hasCurrentDownload(for: collection) ? .acknowledged : .requested
+		}
+	}
+
+	func cancelCollectionDownloadRequest(collectionType: OfflineCollectionType, resourceId: ResourceId) {
+		collectionDownloadRequests.removeValue(
+			forKey: OfflineCollectionReference(collectionType: collectionType, resourceId: resourceId)
+		)
+	}
+
+	func isCollectionDownloadRequestActive(relatedTo collectionType: OfflineCollectionType, resourceId: ResourceId) -> Bool {
+		let collection = OfflineCollectionReference(collectionType: collectionType, resourceId: resourceId)
+		guard let requestState = collectionDownloadRequests[collection] else {
+			return false
+		}
+
+		let hasCurrentDownload = hasCurrentDownload(for: collection)
+		switch requestState {
+		case .requested:
+			if hasCurrentDownload {
+				collectionDownloadRequests[collection] = .acknowledged
+			}
+			return true
+		case .acknowledged where hasCurrentDownload:
+			return true
+		case .acknowledged:
+			collectionDownloadRequests[collection] = nil
+			return false
+		}
+	}
+
+	private func hasCurrentDownload(for collection: OfflineCollectionReference) -> Bool {
+		pendingTasks.contains { $0.isDownloadTask(for: collection) } ||
 			runningTasks.contains { $0.isDownloadTask(for: collection) }
 	}
 
@@ -116,6 +162,10 @@ actor TaskRunner {
 
 		for task in tasks where taskIds.insert(task.id).inserted {
 			let pendingTask = handle(task)
+			let matchingRequests = collectionDownloadRequests.keys.filter { pendingTask.isDownloadTask(for: $0) }
+			for collection in matchingRequests {
+				collectionDownloadRequests[collection] = .acknowledged
+			}
 			pendingTasks.append(pendingTask)
 			if let download = pendingTask.download {
 				currentDownloads.append(download)
@@ -126,13 +176,13 @@ actor TaskRunner {
 
 	private func handle(_ offlineTask: OfflineTask) -> InternalTask {
 		switch offlineTask {
-		case .storeTrack(let task): storeTrackHandler.handle(task)
-		case .storeVideo(let task): storeVideoHandler.handle(task)
-		case .storeAlbum(let task): storeAlbumHandler.handle(task)
-		case .storePlaylist(let task): storePlaylistHandler.handle(task)
-		case .storeUserCollectionTracks(let task): storeUserCollectionTracksHandler.handle(task)
-		case .removeItem(let task): removeItemHandler.handle(task)
-		case .removeCollection(let task): removeCollectionHandler.handle(task)
+		case let .storeTrack(task): storeTrackHandler.handle(task)
+		case let .storeVideo(task): storeVideoHandler.handle(task)
+		case let .storeAlbum(task): storeAlbumHandler.handle(task)
+		case let .storePlaylist(task): storePlaylistHandler.handle(task)
+		case let .storeUserCollectionTracks(task): storeUserCollectionTracksHandler.handle(task)
+		case let .removeItem(task): removeItemHandler.handle(task)
+		case let .removeCollection(task): removeCollectionHandler.handle(task)
 		}
 	}
 
@@ -173,7 +223,7 @@ actor TaskRunner {
 	}
 
 	private func start(_ task: InternalTask) async {
-		while !allowDownloadsOnExpensiveNetworks, !(await network.isInexpensive) {
+		while !allowDownloadsOnExpensiveNetworks, await !(network.isInexpensive) {
 			try? await Task.sleep(nanoseconds: 1_000_000_000)
 		}
 
@@ -218,8 +268,12 @@ private actor Network {
 
 	init() {
 		monitor.pathUpdateHandler = { [weak self] path in
-			guard path.status == .satisfied else { return }
-			guard let self else { return }
+			guard path.status == .satisfied else {
+				return
+			}
+			guard let self else {
+				return
+			}
 			let inexpensive = !path.isExpensive && !path.isConstrained
 			Task { await self.setInexpensive(inexpensive) }
 		}

--- a/Sources/Offliner/Offliner.swift
+++ b/Sources/Offliner/Offliner.swift
@@ -5,7 +5,7 @@ import Player
 // MARK: - Offliner
 
 public final class Offliner {
-	static let defaultCollectionDownloadStatePollInterval: UInt64 = 1_000_000_000
+	static let defaultDownloadStatePollInterval: UInt64 = 1_000_000_000
 
 	private let offlineApiClient: OfflineApiClientProtocol
 	private let offlineStore: OfflineStore
@@ -53,10 +53,10 @@ public final class Offliner {
 		self.offlineApiClient = offlineApiClient
 		self.offlineStore = offlineStore
 		self.mediaDownloader = mediaDownloader
-		self.collectionDownloadStatePollInterval = Self.defaultCollectionDownloadStatePollInterval
+		collectionDownloadStatePollInterval = Self.defaultDownloadStatePollInterval
 		self.trackManifestFetcher = trackManifestFetcher
-		self.audioFormats = configuration.audioFormats
-		self.taskRunner = TaskRunner(
+		audioFormats = configuration.audioFormats
+		taskRunner = TaskRunner(
 			configuration: configuration,
 			offlineApiClient: offlineApiClient,
 			offlineStore: offlineStore,
@@ -68,7 +68,9 @@ public final class Offliner {
 		)
 
 		mediaDownloader.orphanedTaskHandler = { [weak self] taskId in
-			guard let self, let taskId else { return }
+			guard let self, let taskId else {
+				return
+			}
 			Task {
 				try? await self.offlineApiClient.updateTask(taskId: taskId, state: .failed)
 				await self.run()
@@ -85,15 +87,15 @@ public final class Offliner {
 		licenseDownloader: LicenseDownloader = LicenseDownloader(),
 		trackManifestFetcher: TrackManifestFetcherProtocol,
 		videoManifestFetcher: VideoManifestFetcherProtocol,
-		collectionDownloadStatePollInterval: UInt64 = Offliner.defaultCollectionDownloadStatePollInterval
+		collectionDownloadStatePollInterval: UInt64 = Offliner.defaultDownloadStatePollInterval
 	) {
 		self.offlineApiClient = offlineApiClient
 		self.offlineStore = offlineStore
 		self.mediaDownloader = mediaDownloader
 		self.collectionDownloadStatePollInterval = collectionDownloadStatePollInterval
 		self.trackManifestFetcher = trackManifestFetcher
-		self.audioFormats = configuration.audioFormats
-		self.taskRunner = TaskRunner(
+		audioFormats = configuration.audioFormats
+		taskRunner = TaskRunner(
 			configuration: configuration,
 			offlineApiClient: offlineApiClient,
 			offlineStore: offlineStore,
@@ -160,7 +162,7 @@ public final class Offliner {
 	) -> AsyncStream<Set<OfflineCollection>> {
 		AsyncStream { continuation in
 			let task = Task {
-				let local = (try? await offlineStore.getCollections(collectionType: collectionType)) ?? []
+				let local = await (try? offlineStore.getCollections(collectionType: collectionType)) ?? []
 				var collections = Set(local)
 				continuation.yield(collections)
 
@@ -189,11 +191,11 @@ public final class Offliner {
 
 	/// Streams collection-level offline availability.
 	///
-	/// The stream emits a fast initial value from local storage and active in-memory downloads, then continues polling for
-	/// later local changes.
+	/// The stream emits a fast initial value from local storage and downloads requested through this SDK instance, then
+	/// continues polling for later local changes.
 	///
 	/// The stream does not poll backend task inventory. Removal is represented as `.notDownloaded`; `.downloading` is
-	/// reserved for active download/acquisition work already known by this SDK instance.
+	/// reserved for requested or active download/acquisition work when the collection is not already locally available.
 	public func getOfflineCollectionDownloadState(
 		collectionType: OfflineCollectionType,
 		resourceId: ResourceId
@@ -231,7 +233,9 @@ public final class Offliner {
 
 				while !Task.isCancelled {
 					try? await Task.sleep(nanoseconds: collectionDownloadStatePollInterval)
-					guard !Task.isCancelled else { break }
+					guard !Task.isCancelled else {
+						break
+					}
 
 					let state = await offlineCollectionDownloadState(
 						collectionType: collectionType,
@@ -272,7 +276,7 @@ public final class Offliner {
 				limit: limit,
 				after: cursor
 			)
-		case .title(let direction):
+		case let .title(direction):
 			(page, failures) = try await offlineStore.getCollectionItemsOrderByTitle(
 				collectionType: collectionType,
 				resourceId: resourceId,
@@ -280,7 +284,7 @@ public final class Offliner {
 				limit: limit,
 				after: cursor
 			)
-		case .album(let direction):
+		case let .album(direction):
 			(page, failures) = try await offlineStore.getCollectionItemsOrderByAlbum(
 				collectionType: collectionType,
 				resourceId: resourceId,
@@ -288,7 +292,7 @@ public final class Offliner {
 				limit: limit,
 				after: cursor
 			)
-		case .artist(let direction):
+		case let .artist(direction):
 			(page, failures) = try await offlineStore.getCollectionItemsOrderByArtist(
 				collectionType: collectionType,
 				resourceId: resourceId,
@@ -296,7 +300,7 @@ public final class Offliner {
 				limit: limit,
 				after: cursor
 			)
-		case .dateAdded(let direction):
+		case let .dateAdded(direction):
 			(page, failures) = try await offlineStore.getCollectionItemsOrderByDateAdded(
 				collectionType: collectionType,
 				resourceId: resourceId,
@@ -332,7 +336,9 @@ public final class Offliner {
 	}
 
 	private func scheduleRedownload(for failures: [FailedOfflineItem]) {
-		guard !failures.isEmpty else { return }
+		guard !failures.isEmpty else {
+			return
+		}
 		Task {
 			for failure in failures {
 				try? await download(mediaType: failure.mediaType, resourceId: .identifier(failure.resourceId))
@@ -362,7 +368,13 @@ public final class Offliner {
 	}
 
 	public func download(collectionType: OfflineCollectionType, resourceId: ResourceId) async throws {
-		try await offlineApiClient.addItem(type: collectionType.toResourceType, id: resourceId.stringValue)
+		await taskRunner.beginCollectionDownload(collectionType: collectionType, resourceId: resourceId)
+		do {
+			try await offlineApiClient.addItem(type: collectionType.toResourceType, id: resourceId.stringValue)
+		} catch {
+			await taskRunner.cancelCollectionDownloadRequest(collectionType: collectionType, resourceId: resourceId)
+			throw error
+		}
 		await taskRunner.run()
 	}
 
@@ -373,6 +385,7 @@ public final class Offliner {
 
 	public func remove(collectionType: OfflineCollectionType, resourceId: ResourceId) async throws {
 		try await offlineApiClient.removeItem(type: collectionType.toResourceType, id: resourceId.stringValue)
+		await taskRunner.cancelCollectionDownloadRequest(collectionType: collectionType, resourceId: resourceId)
 		// Optimistically update local availability; the remove task performs the same idempotent cleanup.
 		try? offlineStore.deleteCollection(
 			resourceType: collectionType.rawValue,
@@ -385,7 +398,7 @@ public final class Offliner {
 		collectionType: OfflineCollectionType,
 		resourceId: ResourceId
 	) async -> OfflineCollectionDownloadState {
-		if await taskRunner.hasCurrentDownload(relatedTo: collectionType, resourceId: resourceId) {
+		if await taskRunner.isCollectionDownloadRequestActive(relatedTo: collectionType, resourceId: resourceId) {
 			return .downloading
 		}
 
@@ -393,8 +406,13 @@ public final class Offliner {
 			collectionType: collectionType,
 			resourceId: collectionLocalResourceId(collectionType: collectionType, resourceId: resourceId)
 		)
+		if localCollection != nil {
+			return .downloaded
+		}
 
-		return localCollection == nil ? .notDownloaded : .downloaded
+		return await taskRunner.hasCurrentDownload(relatedTo: collectionType, resourceId: resourceId)
+			? .downloading
+			: .notDownloaded
 	}
 
 	private func collectionLocalResourceId(
@@ -405,7 +423,7 @@ public final class Offliner {
 	}
 }
 
-// MARK: - OfflineItemProvider
+// MARK: OfflineItemProvider
 
 extension Offliner: OfflineItemProvider {
 	public func get(productType: ProductType, productId: String) async -> OfflinePlaybackItem? {
@@ -432,8 +450,8 @@ extension Offliner: OfflineItemProvider {
 extension OfflineMediaItemType {
 	var toResourceType: ResourceType {
 		switch self {
-		case .tracks: return .track
-		case .videos: return .video
+		case .tracks: .track
+		case .videos: .video
 		}
 	}
 }
@@ -441,9 +459,9 @@ extension OfflineMediaItemType {
 extension OfflineCollectionType {
 	var toResourceType: ResourceType {
 		switch self {
-		case .albums: return .album
-		case .playlists: return .playlist
-		case .userCollectionTracks: return .userCollectionTracks
+		case .albums: .album
+		case .playlists: .playlist
+		case .userCollectionTracks: .userCollectionTracks
 		}
 	}
 }

--- a/Sources/Offliner/Types.swift
+++ b/Sources/Offliner/Types.swift
@@ -105,10 +105,10 @@ public enum OfflineCollectionDownloadState: Sendable, Hashable {
 	/// The collection is not locally downloaded, or it is being removed.
 	case notDownloaded
 
-	/// The collection or one of its members has active download/acquisition work known by this SDK instance.
+	/// The collection is not yet locally available and has requested or active download/acquisition work known by this SDK instance.
 	case downloading
 
-	/// The collection is locally stored and there is no locally known pending download/acquisition work.
+	/// The collection is locally stored, regardless of any background acquisition work.
 	case downloaded
 }
 
@@ -196,10 +196,14 @@ public struct OfflineCollection: Hashable {
 	}
 }
 
+// MARK: - SortDirection
+
 public enum SortDirection: Hashable {
 	case ascending
 	case descending
 }
+
+// MARK: - OfflineCollectionItemSort
 
 public enum OfflineCollectionItemSort: Hashable {
 	case title(direction: SortDirection)

--- a/Tests/OfflinerTests/CollectionDownloadTests.swift
+++ b/Tests/OfflinerTests/CollectionDownloadTests.swift
@@ -87,6 +87,30 @@ final class CollectionDownloadTests: OfflinerTestCase {
 		await runTask.value
 	}
 
+	func testOfflineCollectionDownloadStateUsesRequestBeforeTaskIsAvailable() async throws {
+		let backend = SuspendingAddOfflineApiClient()
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+
+		let downloadTask = Task {
+			try await offliner.download(collectionType: .albums, resourceId: .identifier("album-123"))
+		}
+		await backend.waitUntilAddStarted()
+
+		let state = await offliner.getOfflineCollectionDownloadState(
+			collectionType: .albums,
+			resourceId: .identifier("album-123")
+		).first()
+
+		XCTAssertEqual(state, .downloading)
+
+		await backend.completeAdd()
+		try await downloadTask.value
+	}
+
 	func testOfflineCollectionDownloadStateUsesCurrentRelatedDownloads() async throws {
 		let backend = StubOfflineApiClient()
 		let mediaDownloader = SuspendingMediaDownloader()
@@ -113,6 +137,34 @@ final class CollectionDownloadTests: OfflinerTestCase {
 		XCTAssertEqual(state, .downloading)
 
 		await mediaDownloader.complete()
+		await backend.waitForTasksToComplete()
+	}
+
+	func testOfflineCollectionDownloadStateKeepsDownloadedStateDuringRelatedWork() async throws {
+		let backend = StubOfflineApiClient()
+		let mediaDownloader = SuspendingMediaDownloader()
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: mediaDownloader
+		)
+
+		try await offliner.download(collectionType: .albums, resourceId: .identifier("album-123"))
+		await backend.waitForTasksToComplete()
+
+		try await backend.addItem(type: .track, id: "track-123")
+		let runTask = Task { await offliner.run() }
+		await mediaDownloader.waitUntilStarted()
+
+		let state = await offliner.getOfflineCollectionDownloadState(
+			collectionType: .albums,
+			resourceId: .identifier("album-123")
+		).first()
+
+		XCTAssertEqual(state, .downloaded)
+
+		await mediaDownloader.complete()
+		await runTask.value
 		await backend.waitForTasksToComplete()
 	}
 
@@ -155,6 +207,26 @@ final class CollectionDownloadTests: OfflinerTestCase {
 		XCTAssertEqual(state, .notDownloaded)
 	}
 
+	func testOfflineCollectionDownloadStateClearsRequestWhenSubmissionFails() async throws {
+		let offliner = createOffliner(
+			offlineApiClient: FailingOfflineApiClient(),
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+
+		do {
+			try await offliner.download(collectionType: .albums, resourceId: .identifier("album-123"))
+			XCTFail("Expected download submission to fail")
+		} catch {}
+
+		let state = await offliner.getOfflineCollectionDownloadState(
+			collectionType: .albums,
+			resourceId: .identifier("album-123")
+		).first()
+
+		XCTAssertEqual(state, .notDownloaded)
+	}
+
 	func testRedownloadAlbumDeletesOldArtworkAndStoresNewOne() async throws {
 		let backend = StubOfflineApiClient()
 		let offliner = createOffliner(
@@ -167,7 +239,8 @@ final class CollectionDownloadTests: OfflinerTestCase {
 		await offliner.run()
 		await backend.waitForTasksToComplete()
 
-		let firstCollectionOptional = await offliner.getOfflineCollection(collectionType: .albums, resourceId: .identifier("album-123")).latest()
+		let firstCollectionOptional = await offliner.getOfflineCollection(collectionType: .albums, resourceId: .identifier("album-123"))
+			.latest()
 		let firstCollection = try XCTUnwrap(firstCollectionOptional)
 		let firstArtworkURL = try XCTUnwrap(firstCollection.artworkURL)
 		XCTAssertTrue(FileManager.default.fileExists(atPath: firstArtworkURL.path))
@@ -176,7 +249,8 @@ final class CollectionDownloadTests: OfflinerTestCase {
 		await offliner.run()
 		await backend.waitForTasksToComplete()
 
-		let secondCollectionOptional = await offliner.getOfflineCollection(collectionType: .albums, resourceId: .identifier("album-123")).latest()
+		let secondCollectionOptional = await offliner
+			.getOfflineCollection(collectionType: .albums, resourceId: .identifier("album-123")).latest()
 		let secondCollection = try XCTUnwrap(secondCollectionOptional)
 		let secondArtworkURL = try XCTUnwrap(secondCollection.artworkURL)
 

--- a/Tests/OfflinerTests/TestFakes.swift
+++ b/Tests/OfflinerTests/TestFakes.swift
@@ -1,9 +1,9 @@
-@testable import Offliner
 import AVFoundation
 import Foundation
+@testable import Offliner
 import TidalAPI
 
-// MARK: - Backend Client Fakes
+// MARK: - StubOfflineApiClient
 
 final class StubOfflineApiClient: OfflineApiClientProtocol {
 	struct RecordedItem {
@@ -152,7 +152,9 @@ final class StubOfflineApiClient: OfflineApiClientProtocol {
 		type: OfflineCollectionType,
 		cursor: String?
 	) async throws -> (collections: [OfflineCollection], cursor: String?) {
-		guard !pendingCollectionsPages.isEmpty else { return ([], nil) }
+		guard !pendingCollectionsPages.isEmpty else {
+			return ([], nil)
+		}
 		return pendingCollectionsPages.removeFirst()
 	}
 
@@ -166,6 +168,8 @@ final class StubOfflineApiClient: OfflineApiClientProtocol {
 		return pendingCollection
 	}
 }
+
+// MARK: - FailingOfflineApiClient
 
 final class FailingOfflineApiClient: OfflineApiClientProtocol {
 	func addItem(type: ResourceType, id: String) async throws {
@@ -184,6 +188,50 @@ final class FailingOfflineApiClient: OfflineApiClientProtocol {
 		throw FakeError.backendFailed
 	}
 }
+
+// MARK: - SuspendingAddOfflineApiClient
+
+actor SuspendingAddOfflineApiClient: OfflineApiClientProtocol {
+	private var addContinuation: CheckedContinuation<Void, Never>?
+	private var addStartedContinuation: CheckedContinuation<Void, Never>?
+	private var addStarted = false
+
+	func waitUntilAddStarted() async {
+		if addStarted {
+			return
+		}
+
+		await withCheckedContinuation { continuation in
+			addStartedContinuation = continuation
+		}
+	}
+
+	func completeAdd() {
+		let continuation = addContinuation
+		addContinuation = nil
+		continuation?.resume()
+	}
+
+	func addItem(type: ResourceType, id: String) async throws {
+		await withCheckedContinuation { continuation in
+			addContinuation = continuation
+			addStarted = true
+			let startedContinuation = addStartedContinuation
+			addStartedContinuation = nil
+			startedContinuation?.resume()
+		}
+	}
+
+	func removeItem(type: ResourceType, id: String) async throws {}
+
+	func getTasks(cursor: String?) async throws -> (tasks: [OfflineTask], cursor: String?) {
+		([], nil)
+	}
+
+	func updateTask(taskId: String, state: Download.State) async throws {}
+}
+
+// MARK: - FailOnUpdateToInProgressOfflineApiClient
 
 actor FailOnUpdateToInProgressOfflineApiClient: OfflineApiClientProtocol {
 	private let stub = StubOfflineApiClient()
@@ -221,6 +269,8 @@ actor FailOnUpdateToInProgressOfflineApiClient: OfflineApiClientProtocol {
 	}
 }
 
+// MARK: - FailOnUpdateToCompletedOfflineApiClient
+
 final class FailOnUpdateToCompletedOfflineApiClient: OfflineApiClientProtocol {
 	private let stub = StubOfflineApiClient()
 
@@ -244,6 +294,8 @@ final class FailOnUpdateToCompletedOfflineApiClient: OfflineApiClientProtocol {
 	}
 }
 
+// MARK: - FailOnGetTasksOfflineApiClient
+
 final class FailOnGetTasksOfflineApiClient: OfflineApiClientProtocol {
 	func addItem(type: ResourceType, id: String) async throws {}
 
@@ -256,7 +308,7 @@ final class FailOnGetTasksOfflineApiClient: OfflineApiClientProtocol {
 	func updateTask(taskId: String, state: Download.State) async throws {}
 }
 
-// MARK: - Artwork Downloader Fakes
+// MARK: - SucceedingArtworkDownloader
 
 final class SucceedingArtworkDownloader: ArtworkDownloaderProtocol {
 	func downloadArtwork(for artwork: ArtworksResourceObject?) async throws -> URL? {
@@ -267,11 +319,15 @@ final class SucceedingArtworkDownloader: ArtworkDownloaderProtocol {
 	}
 }
 
+// MARK: - FailingArtworkDownloader
+
 final class FailingArtworkDownloader: ArtworkDownloaderProtocol {
 	func downloadArtwork(for artwork: ArtworksResourceObject?) async throws -> URL? {
 		throw FakeError.artworkDownloadFailed
 	}
 }
+
+// MARK: - SuspendingArtworkDownloader
 
 actor SuspendingArtworkDownloader: ArtworkDownloaderProtocol {
 	private var startedContinuation: CheckedContinuation<Void, Never>?
@@ -310,7 +366,7 @@ actor SuspendingArtworkDownloader: ArtworkDownloaderProtocol {
 	}
 }
 
-// MARK: - Media Downloader Fakes
+// MARK: - SucceedingMediaDownloader
 
 final class SucceedingMediaDownloader: MediaDownloaderProtocol {
 	var progressValues: [Double] = []
@@ -339,6 +395,8 @@ final class SucceedingMediaDownloader: MediaDownloaderProtocol {
 	}
 }
 
+// MARK: - FailingMediaDownloader
+
 final class FailingMediaDownloader: MediaDownloaderProtocol {
 	func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void) {}
 
@@ -352,6 +410,8 @@ final class FailingMediaDownloader: MediaDownloaderProtocol {
 		throw FakeError.downloadFailed
 	}
 }
+
+// MARK: - SuspendingMediaDownloader
 
 actor SuspendingMediaDownloader: MediaDownloaderProtocol {
 	private var startedContinuation: CheckedContinuation<Void, Never>?
@@ -399,7 +459,7 @@ actor SuspendingMediaDownloader: MediaDownloaderProtocol {
 	}
 }
 
-// MARK: - Manifest Fetcher Fakes
+// MARK: - SucceedingTrackManifestFetcher
 
 final class SucceedingTrackManifestFetcher: TrackManifestFetcherProtocol {
 	var audioFormats: [AudioFormat] = [.heaacv1]
@@ -413,6 +473,8 @@ final class SucceedingTrackManifestFetcher: TrackManifestFetcherProtocol {
 	}
 }
 
+// MARK: - SucceedingVideoManifestFetcher
+
 final class SucceedingVideoManifestFetcher: VideoManifestFetcherProtocol {
 	func fetchVideoManifest(videoId: String) async throws -> ManifestFetchResult {
 		ManifestFetchResult(
@@ -423,7 +485,7 @@ final class SucceedingVideoManifestFetcher: VideoManifestFetcherProtocol {
 	}
 }
 
-// MARK: - Errors
+// MARK: - FakeError
 
 enum FakeError: Error {
 	case backendFailed


### PR DESCRIPTION
## Actual logic changes

### Track download intent inside the SDK

Collection downloads are registered with TaskRunner before the backend submission begins. This closes the gap where a newly opened observer could report notDownloaded after the user had already started a download but before the backend task appeared in TaskRunner.

TaskRunner distinguishes two request phases:

1. requested — the command has started but no related SDK task has been observed yet
2. acknowledged — TaskRunner has observed related acquisition work

The request remains active until its related tasks finish. Submission failure and successful removal clear it explicitly.

### Make local availability stable

Collection state is now resolved in this order:

1. A user-requested download that has not finished reports downloading.
2. A locally stored collection reports downloaded.
3. Other active related acquisition work reports downloading only when the collection is not locally stored.
4. Otherwise the collection reports notDownloaded.

This prevents an already-offline collection from temporarily changing to downloading during background reconciliation, without reporting a newly requested download as complete merely because collection metadata was stored before its remaining item tasks finished.

### Regression coverage

- request state is visible while backend submission is still suspended
- locally available content stays downloaded during unrelated related work
- failed submission clears the pending request
- existing state-stream behavior remains covered

## Consumer impact

This lets the iOS app use the SDK stream as the durable source of truth across navigation. The app only needs a transient optimistic button transition for immediate tap feedback; it no longer needs its own download-state coordinator or a second local-availability query.

## Mechanical formatting

The repository pre-commit SwiftFormat hook reformatted the touched files. Changes such as removing redundant self references, normalizing enum case patterns, wrapping guards, and adding MARK separators are formatter-only and do not affect behavior.

## Validation

- pre-commit SwiftFormat passed
- pre-commit SwiftLint passed
- tests not run locally