### PR TITLE
TM-1573: Format Offliner module with pinned SwiftFormat 0.54.6

### DIFF
--- a/Sources/Offliner/Download.swift
+++ b/Sources/Offliner/Download.swift
@@ -21,7 +21,7 @@ public actor Download {
 
 	private let continuation: AsyncStream<Event>.Continuation
 
-	internal init(
+	init(
 		title: String,
 		artists: [String],
 		imageURL: URL?,
@@ -33,11 +33,11 @@ public actor Download {
 		self.relatedCollection = relatedCollection
 
 		let (stream, continuation) = AsyncStream<Event>.makeStream()
-		self.events = stream
+		events = stream
 		self.continuation = continuation
 	}
 
-	internal func updateState(_ newState: State) {
+	func updateState(_ newState: State) {
 		continuation.yield(.state(newState))
 
 		if newState == .completed || newState == .failed {
@@ -45,7 +45,7 @@ public actor Download {
 		}
 	}
 
-	internal func updateProgress(_ newProgress: Double) {
+	func updateProgress(_ newProgress: Double) {
 		continuation.yield(.progress(newProgress))
 	}
 }

--- a/Sources/Offliner/Internal/ArtworkDownloader.swift
+++ b/Sources/Offliner/Internal/ArtworkDownloader.swift
@@ -1,9 +1,13 @@
 import Foundation
 import TidalAPI
 
+// MARK: - ArtworkDownloaderProtocol
+
 protocol ArtworkDownloaderProtocol {
 	func downloadArtwork(for artwork: ArtworksResourceObject?) async throws -> URL?
 }
+
+// MARK: - ArtworkDownloader
 
 final class ArtworkDownloader: ArtworkDownloaderProtocol {
 	private let urlSession: URLSession
@@ -13,21 +17,25 @@ final class ArtworkDownloader: ArtworkDownloaderProtocol {
 	}
 
 	func downloadArtwork(for artwork: ArtworksResourceObject?) async throws -> URL? {
-		guard let artwork else { return nil }
+		guard let artwork else {
+			return nil
+		}
 		return try await download(artwork: artwork)
 	}
 
 	private func download(artwork: ArtworksResourceObject) async throws -> URL {
 		let files = artwork.attributes?.files.sorted { $0.area > $1.area }
 		guard let file = files?.first,
-			  let imageURL = URL(string: file.href) else {
+		      let imageURL = URL(string: file.href)
+		else {
 			throw ArtworkDownloaderError.missingArtworkURL
 		}
 
 		let (tempURL, response) = try await urlSession.download(from: imageURL)
 
 		guard let httpResponse = response as? HTTPURLResponse,
-			  (200 ... 299).contains(httpResponse.statusCode) else {
+		      (200 ... 299).contains(httpResponse.statusCode)
+		else {
 			throw ArtworkDownloaderError.downloadFailed
 		}
 
@@ -37,6 +45,8 @@ final class ArtworkDownloader: ArtworkDownloaderProtocol {
 		return try FileStorage.move(from: tempURL, subdirectory: "Artworks", filename: filename)
 	}
 }
+
+// MARK: - ArtworkDownloaderError
 
 enum ArtworkDownloaderError: Error {
 	case missingArtworkURL

--- a/Sources/Offliner/Internal/Configuration.swift
+++ b/Sources/Offliner/Internal/Configuration.swift
@@ -1,6 +1,8 @@
 import Foundation
 import TidalAPI
 
+// MARK: - AudioFormat
+
 public enum AudioFormat: String, CaseIterable, Codable {
 	case heaacv1 = "HEAACV1"
 	case aaclc = "AACLC"
@@ -10,14 +12,16 @@ public enum AudioFormat: String, CaseIterable, Codable {
 
 	var toAPIFormat: TrackManifestsAPITidal.Formats_trackManifestsIdGet {
 		switch self {
-		case .heaacv1: return .heaacv1
-		case .aaclc: return .aaclc
-		case .flac: return .flac
-		case .flacHires: return .flacHires
-		case .eac3Joc: return .eac3Joc
+		case .heaacv1: .heaacv1
+		case .aaclc: .aaclc
+		case .flac: .flac
+		case .flacHires: .flacHires
+		case .eac3Joc: .eac3Joc
 		}
 	}
 }
+
+// MARK: - Configuration
 
 public struct Configuration {
 	let audioFormats: [AudioFormat]

--- a/Sources/Offliner/Internal/FileStorage.swift
+++ b/Sources/Offliner/Internal/FileStorage.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+// MARK: - FileStorage
+
 enum FileStorage {
 	static func store(_ data: Data, subdirectory: String, filename: String) throws -> URL {
 		let dir = try directory(for: subdirectory)
@@ -40,6 +42,8 @@ enum FileStorage {
 		return directory
 	}
 }
+
+// MARK: - FileStorageError
 
 enum FileStorageError: Error {
 	case noApplicationSupportDirectory

--- a/Sources/Offliner/Internal/Handlers/RemoveCollectionHandler.swift
+++ b/Sources/Offliner/Internal/Handlers/RemoveCollectionHandler.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+// MARK: - RemoveCollectionHandler
+
 final class RemoveCollectionHandler {
 	private let offlineStore: OfflineStore
 
@@ -12,6 +14,8 @@ final class RemoveCollectionHandler {
 	}
 }
 
+// MARK: - InternalRemoveCollectionTask
+
 private final class InternalRemoveCollectionTask: InternalTask {
 	let id: String
 
@@ -19,7 +23,7 @@ private final class InternalRemoveCollectionTask: InternalTask {
 	private let offlineStore: OfflineStore
 
 	init(task: RemoveCollectionTask, offlineStore: OfflineStore) {
-		self.id = task.id
+		id = task.id
 		self.task = task
 		self.offlineStore = offlineStore
 	}

--- a/Sources/Offliner/Internal/Handlers/RemoveItemHandler.swift
+++ b/Sources/Offliner/Internal/Handlers/RemoveItemHandler.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+// MARK: - RemoveItemHandler
+
 final class RemoveItemHandler {
 	private let offlineStore: OfflineStore
 
@@ -12,6 +14,8 @@ final class RemoveItemHandler {
 	}
 }
 
+// MARK: - InternalRemoveItemTask
+
 private final class InternalRemoveItemTask: InternalTask {
 	let id: String
 
@@ -19,7 +23,7 @@ private final class InternalRemoveItemTask: InternalTask {
 	private let offlineStore: OfflineStore
 
 	init(task: RemoveItemTask, offlineStore: OfflineStore) {
-		self.id = task.id
+		id = task.id
 		self.task = task
 		self.offlineStore = offlineStore
 	}

--- a/Sources/Offliner/Internal/Handlers/StoreAlbumHandler.swift
+++ b/Sources/Offliner/Internal/Handlers/StoreAlbumHandler.swift
@@ -27,7 +27,7 @@ private final class InternalAlbumTask: InternalTask {
 	private let artworkDownloader: ArtworkDownloaderProtocol
 
 	init(task: StoreAlbumTask, offlineStore: OfflineStore, artworkDownloader: ArtworkDownloaderProtocol) {
-		self.id = task.id
+		id = task.id
 		self.task = task
 		self.offlineStore = offlineStore
 		self.artworkDownloader = artworkDownloader

--- a/Sources/Offliner/Internal/Handlers/StorePlaylistHandler.swift
+++ b/Sources/Offliner/Internal/Handlers/StorePlaylistHandler.swift
@@ -27,7 +27,7 @@ private final class InternalPlaylistTask: InternalTask {
 	private let artworkDownloader: ArtworkDownloaderProtocol
 
 	init(task: StorePlaylistTask, offlineStore: OfflineStore, artworkDownloader: ArtworkDownloaderProtocol) {
-		self.id = task.id
+		id = task.id
 		self.task = task
 		self.offlineStore = offlineStore
 		self.artworkDownloader = artworkDownloader

--- a/Sources/Offliner/Internal/Handlers/StoreTrackHandler.swift
+++ b/Sources/Offliner/Internal/Handlers/StoreTrackHandler.swift
@@ -2,6 +2,8 @@ import AVFoundation
 import Foundation
 import TidalAPI
 
+// MARK: - StoreTrackHandler
+
 final class StoreTrackHandler {
 	private let offlineStore: OfflineStore
 	private let artworkDownloader: ArtworkDownloaderProtocol
@@ -48,6 +50,8 @@ final class StoreTrackHandler {
 	}
 }
 
+// MARK: - InternalTrackTask
+
 private final class InternalTrackTask: InternalTask {
 	let id: String
 	let download: Download?
@@ -68,7 +72,7 @@ private final class InternalTrackTask: InternalTask {
 		manifestFetcher: TrackManifestFetcherProtocol,
 		licenseDownloader: LicenseDownloader
 	) {
-		self.id = task.id
+		id = task.id
 		self.task = task
 		self.download = download
 		self.offlineStore = offlineStore
@@ -104,7 +108,9 @@ private final class InternalTrackTask: InternalTask {
 				licenseDownloadResult: licenseResult,
 				title: "\(task.artists.compactMap { $0.attributes?.name }.joined(separator: ",")) - \(task.track.attributes?.title ?? "")",
 				onProgress: { [weak self] progress in
-					guard let download = self?.download else { return }
+					guard let download = self?.download else {
+						return
+					}
 					await download.updateProgress(progress)
 				}
 			)

--- a/Sources/Offliner/Internal/Handlers/StoreUserCollectionTracksHandler.swift
+++ b/Sources/Offliner/Internal/Handlers/StoreUserCollectionTracksHandler.swift
@@ -1,6 +1,8 @@
 import Foundation
 import TidalAPI
 
+// MARK: - StoreUserCollectionTracksHandler
+
 final class StoreUserCollectionTracksHandler {
 	private let offlineStore: OfflineStore
 
@@ -13,6 +15,8 @@ final class StoreUserCollectionTracksHandler {
 	}
 }
 
+// MARK: - InternalUserCollectionTracksTask
+
 private final class InternalUserCollectionTracksTask: InternalTask {
 	let id: String
 
@@ -20,7 +24,7 @@ private final class InternalUserCollectionTracksTask: InternalTask {
 	private let offlineStore: OfflineStore
 
 	init(task: StoreUserCollectionTracksTask, offlineStore: OfflineStore) {
-		self.id = task.id
+		id = task.id
 		self.task = task
 		self.offlineStore = offlineStore
 	}

--- a/Sources/Offliner/Internal/Handlers/StoreVideoHandler.swift
+++ b/Sources/Offliner/Internal/Handlers/StoreVideoHandler.swift
@@ -2,6 +2,8 @@ import AVFoundation
 import Foundation
 import TidalAPI
 
+// MARK: - StoreVideoHandler
+
 final class StoreVideoHandler {
 	private let offlineStore: OfflineStore
 	private let artworkDownloader: ArtworkDownloaderProtocol
@@ -48,6 +50,8 @@ final class StoreVideoHandler {
 	}
 }
 
+// MARK: - InternalVideoTask
+
 private final class InternalVideoTask: InternalTask {
 	let id: String
 	let download: Download?
@@ -68,7 +72,7 @@ private final class InternalVideoTask: InternalTask {
 		manifestFetcher: VideoManifestFetcherProtocol,
 		licenseDownloader: LicenseDownloader
 	) {
-		self.id = task.id
+		id = task.id
 		self.task = task
 		self.download = download
 		self.offlineStore = offlineStore
@@ -104,7 +108,9 @@ private final class InternalVideoTask: InternalTask {
 				licenseDownloadResult: licenseResult,
 				title: "\(task.artists.compactMap { $0.attributes?.name }.joined(separator: ",")) - \(task.video.attributes?.title ?? "")",
 				onProgress: { [weak self] progress in
-					guard let download = self?.download else { return }
+					guard let download = self?.download else {
+						return
+					}
 					await download.updateProgress(progress)
 				}
 			)

--- a/Sources/Offliner/Internal/ManifestFetcher.swift
+++ b/Sources/Offliner/Internal/ManifestFetcher.swift
@@ -44,7 +44,8 @@ final class TrackManifestFetcher: TrackManifestFetcherProtocol {
 		let attributes = response.data.attributes
 
 		guard let uriString = attributes?.uri,
-			  let url = URL(string: uriString) else {
+		      let url = URL(string: uriString)
+		else {
 			throw MediaDownloaderError.manifestNotFound
 		}
 
@@ -75,7 +76,8 @@ final class VideoManifestFetcher: VideoManifestFetcherProtocol {
 		let attributes = response.data.attributes
 
 		guard let hrefString = attributes?.link?.href,
-			  let url = URL(string: hrefString) else {
+		      let url = URL(string: hrefString)
+		else {
 			throw MediaDownloaderError.manifestNotFound
 		}
 
@@ -87,7 +89,9 @@ final class VideoManifestFetcher: VideoManifestFetcherProtocol {
 
 private extension OfflineMediaItem.NormalizationData {
 	init?(_ apiData: AudioNormalizationData?) {
-		guard let apiData else { return nil }
+		guard let apiData else {
+			return nil
+		}
 		self.init(peakAmplitude: apiData.peakAmplitude, replayGain: apiData.replayGain)
 	}
 }

--- a/Sources/Offliner/Internal/MediaDownloader.swift
+++ b/Sources/Offliner/Internal/MediaDownloader.swift
@@ -38,7 +38,7 @@ final class MediaDownloader: NSObject, MediaDownloaderProtocol {
 	var orphanedTaskHandler: ((String?) -> Void)?
 
 	init(configuration: Configuration) {
-		self.queue = DispatchQueue(label: "com.tidal.offliner.media-downloader", qos: .userInitiated)
+		queue = DispatchQueue(label: "com.tidal.offliner.media-downloader", qos: .userInitiated)
 
 		super.init()
 
@@ -46,7 +46,7 @@ final class MediaDownloader: NSObject, MediaDownloaderProtocol {
 		delegateQueue.underlyingQueue = queue
 		delegateQueue.maxConcurrentOperationCount = 1
 
-		self.session = AVAssetDownloadURLSession(
+		session = AVAssetDownloadURLSession(
 			configuration: URLSessionConfiguration.background(withIdentifier: Self.backgroundSessionIdentifier),
 			assetDownloadDelegate: self,
 			delegateQueue: delegateQueue
@@ -55,7 +55,9 @@ final class MediaDownloader: NSObject, MediaDownloaderProtocol {
 
 	func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void) {
 		DispatchQueue.main.async {
-			guard identifier == Self.backgroundSessionIdentifier else { return }
+			guard identifier == Self.backgroundSessionIdentifier else {
+				return
+			}
 			self.backgroundCompletionHandler = completionHandler
 		}
 	}
@@ -72,7 +74,7 @@ final class MediaDownloader: NSObject, MediaDownloaderProtocol {
 		let asset = AVURLAsset(url: manifestURL)
 		licenseDownloadResult?.contentKeySession.addContentKeyRecipient(asset)
 
-		let duration = Int(CMTimeGetSeconds(try await asset.load(.duration)))
+		let duration = try await Int(CMTimeGetSeconds(asset.load(.duration)))
 
 		return try await withCheckedThrowingContinuation { continuation in
 			queue.async {
@@ -104,7 +106,7 @@ final class MediaDownloader: NSObject, MediaDownloaderProtocol {
 	}
 }
 
-// MARK: - AVAssetDownloadDelegate
+// MARK: AVAssetDownloadDelegate
 
 extension MediaDownloader: AVAssetDownloadDelegate {
 	func urlSession(
@@ -115,7 +117,8 @@ extension MediaDownloader: AVAssetDownloadDelegate {
 		Self.logger.debug("didFinishDownloadingTo called [task: \(assetDownloadTask.taskDescription ?? "?", privacy: .public)]")
 
 		guard let activeDownload = activeDownloads[assetDownloadTask.taskIdentifier] else {
-			Self.logger.debug("orphaned didFinishDownloadingTo called [task: \(assetDownloadTask.taskDescription ?? "?", privacy: .public)]")
+			Self.logger
+				.debug("orphaned didFinishDownloadingTo called [task: \(assetDownloadTask.taskDescription ?? "?", privacy: .public)]")
 
 			try? FileStorage.delete(url: location)
 			return
@@ -129,7 +132,10 @@ extension MediaDownloader: AVAssetDownloadDelegate {
 		task: URLSessionTask,
 		didCompleteWithError error: Error?
 	) {
-		Self.logger.debug("didCompleteWithError called: \(error.map { "\($0)" } ?? "success", privacy: .public) [task: \(task.taskDescription ?? "?", privacy: .public)]")
+		Self.logger
+			.debug(
+				"didCompleteWithError called: \(error.map { "\($0)" } ?? "success", privacy: .public) [task: \(task.taskDescription ?? "?", privacy: .public)]"
+			)
 
 		guard let activeDownload = activeDownloads.removeValue(forKey: task.taskIdentifier) else {
 			Self.logger.debug("orphaned didCompleteWithError called [task: \(task.taskDescription ?? "?", privacy: .public)]")

--- a/Sources/Offliner/Internal/Migrations.swift
+++ b/Sources/Offliner/Internal/Migrations.swift
@@ -1,6 +1,8 @@
 import Foundation
 import GRDB
 
+// MARK: - Migrations
+
 enum Migrations {
 	static func run(_ dbQueue: DatabaseQueue) throws {
 		var migrator = DatabaseMigrator()
@@ -26,7 +28,9 @@ enum Migrations {
 		}
 
 		for path in searchPaths {
-			guard let contents = try? fileManager.contentsOfDirectory(atPath: path) else { continue }
+			guard let contents = try? fileManager.contentsOfDirectory(atPath: path) else {
+				continue
+			}
 
 			let migrations = try contents
 				.filter { $0.hasSuffix(".sql") && $0.hasPrefix("V") }
@@ -47,6 +51,8 @@ enum Migrations {
 	}
 }
 
+// MARK: - Migration
+
 private struct Migration {
 	let version: Int
 	let identifier: String
@@ -60,8 +66,8 @@ private struct Migration {
 		}
 
 		self.version = version
-		self.identifier = filename
-		self.sql = try String(contentsOf: url, encoding: .utf8)
+		identifier = filename
+		sql = try String(contentsOf: url, encoding: .utf8)
 	}
 
 	private static func parseVersion(from filename: String) -> Int? {
@@ -73,6 +79,8 @@ private struct Migration {
 		return Int(versionString)
 	}
 }
+
+// MARK: - MigrationError
 
 enum MigrationError: Error {
 	case migrationsDirectoryNotFound

--- a/Sources/Offliner/Internal/OfflineApiClient.swift
+++ b/Sources/Offliner/Internal/OfflineApiClient.swift
@@ -12,7 +12,7 @@ enum ResourceType {
 	case userCollectionTracks
 }
 
-// MARK: - Task Types
+// MARK: - StoreTrackTask
 
 struct StoreTrackTask {
 	let id: String
@@ -51,6 +51,8 @@ struct StoreTrackTask {
 	}
 }
 
+// MARK: - StoreVideoTask
+
 struct StoreVideoTask {
 	let id: String
 	let video: VideosResourceObject
@@ -85,6 +87,8 @@ struct StoreVideoTask {
 	}
 }
 
+// MARK: - StoreAlbumTask
+
 struct StoreAlbumTask {
 	let id: String
 	let album: AlbumsResourceObject
@@ -92,16 +96,22 @@ struct StoreAlbumTask {
 	let artwork: ArtworksResourceObject?
 }
 
+// MARK: - StorePlaylistTask
+
 struct StorePlaylistTask {
 	let id: String
 	let playlist: PlaylistsResourceObject
 	let artwork: ArtworksResourceObject?
 }
 
+// MARK: - StoreUserCollectionTracksTask
+
 struct StoreUserCollectionTracksTask {
 	let id: String
 	let resourceId: String
 }
+
+// MARK: - RemoveItemTask
 
 struct RemoveItemTask {
 	let id: String
@@ -110,6 +120,8 @@ struct RemoveItemTask {
 	let collectionResourceType: String
 	let collectionResourceId: String
 }
+
+// MARK: - RemoveCollectionTask
 
 struct RemoveCollectionTask {
 	let id: String
@@ -130,13 +142,13 @@ enum OfflineTask {
 
 	var id: String {
 		switch self {
-		case .storeTrack(let task): return task.id
-		case .storeVideo(let task): return task.id
-		case .storeAlbum(let task): return task.id
-		case .storePlaylist(let task): return task.id
-		case .storeUserCollectionTracks(let task): return task.id
-		case .removeItem(let task): return task.id
-		case .removeCollection(let task): return task.id
+		case let .storeTrack(task): task.id
+		case let .storeVideo(task): task.id
+		case let .storeAlbum(task): task.id
+		case let .storePlaylist(task): task.id
+		case let .storeUserCollectionTracks(task): task.id
+		case let .removeItem(task): task.id
+		case let .removeCollection(task): task.id
 		}
 	}
 }
@@ -157,7 +169,9 @@ struct OfflineCollectionReference: Hashable, Sendable {
 	}
 
 	init?(collectionResourceType: String, collectionResourceId: String) {
-		guard let collectionType = OfflineCollectionType(rawValue: collectionResourceType) else { return nil }
+		guard let collectionType = OfflineCollectionType(rawValue: collectionResourceType) else {
+			return nil
+		}
 		self.init(collectionType: collectionType, resourceId: collectionResourceId)
 	}
 }
@@ -267,26 +281,26 @@ private extension OfflineApiClient {
 	func mapResourceType(_ type: ResourceType) -> InstallationsOfflineInventoryItemIdentifier.ModelType {
 		switch type {
 		case .track:
-			return .tracks
+			.tracks
 		case .video:
-			return .videos
+			.videos
 		case .album:
-			return .albums
+			.albums
 		case .playlist:
-			return .playlists
+			.playlists
 		case .userCollectionTracks:
-			return .usercollectiontracks
+			.usercollectiontracks
 		}
 	}
 
 	func mapTaskState(_ state: Download.State) -> OfflineTasksUpdateOperationPayloadDataAttributes.State {
 		switch state {
 		case .pending, .inProgress:
-			return .inProgress
+			.inProgress
 		case .failed:
-			return .failed
+			.failed
 		case .completed:
-			return .completed
+			.completed
 		}
 	}
 
@@ -332,9 +346,9 @@ private extension OfflineApiClient {
 private extension OfflineCollectionType {
 	var toFilterType: InstallationsAPITidal.FilterType_installationsIdRelationshipsOfflineInventoryGet {
 		switch self {
-		case .albums: return .albums
-		case .playlists: return .playlists
-		case .userCollectionTracks: return .usercollectiontracks
+		case .albums: .albums
+		case .playlists: .playlists
+		case .userCollectionTracks: .usercollectiontracks
 		}
 	}
 }
@@ -351,7 +365,8 @@ private extension OfflineTasksMultiResourceDataDocument {
 private extension OfflineTasksResourceObject {
 	func createOfflineTask(includedItems: IncludedItemsMap) -> OfflineTask? {
 		guard let attributes,
-			  let itemData = relationships?.item?.data else {
+		      let itemData = relationships?.item?.data
+		else {
 			return nil
 		}
 
@@ -405,7 +420,9 @@ private final class IncludedItemsMap {
 	private var storage: [Key: IncludedItem] = [:]
 
 	init(from included: [IncludedInner]?) {
-		guard let included else { return }
+		guard let included else {
+			return
+		}
 		populateStorage(from: included)
 		wireAllRelationships(from: included)
 	}
@@ -413,17 +430,17 @@ private final class IncludedItemsMap {
 	private func populateStorage(from included: [IncludedInner]) {
 		for item in included {
 			switch item {
-			case .tracksResourceObject(let track):
+			case let .tracksResourceObject(track):
 				add(IncludedItem(resource: .track(track)), type: track.type, id: track.id)
-			case .videosResourceObject(let video):
+			case let .videosResourceObject(video):
 				add(IncludedItem(resource: .video(video)), type: video.type, id: video.id)
-			case .albumsResourceObject(let album):
+			case let .albumsResourceObject(album):
 				add(IncludedItem(resource: .album(album)), type: album.type, id: album.id)
-			case .playlistsResourceObject(let playlist):
+			case let .playlistsResourceObject(playlist):
 				add(IncludedItem(resource: .playlist(playlist)), type: playlist.type, id: playlist.id)
-			case .artworksResourceObject(let artwork):
+			case let .artworksResourceObject(artwork):
 				add(IncludedItem(resource: .artwork(artwork)), type: artwork.type, id: artwork.id)
-			case .artistsResourceObject(let artist):
+			case let .artistsResourceObject(artist):
 				add(IncludedItem(resource: .artist(artist)), type: artist.type, id: artist.id)
 			default:
 				break
@@ -434,26 +451,38 @@ private final class IncludedItemsMap {
 	private func wireAllRelationships(from included: [IncludedInner]) {
 		for item in included {
 			switch item {
-			case .tracksResourceObject(let track):
+			case let .tracksResourceObject(track):
 				guard let includedItem = get(type: track.type, id: track.id),
-					  let rels = track.relationships else { continue }
+				      let rels = track.relationships
+				else {
+					continue
+				}
 				let album = rels.albums?.data?.first.map { (type: $0.type, id: $0.id) }
 				wireRelationships(for: includedItem, album: album, artists: rels.artists, coverArt: nil)
 
-			case .videosResourceObject(let video):
+			case let .videosResourceObject(video):
 				guard let includedItem = get(type: video.type, id: video.id),
-					  let rels = video.relationships else { continue }
+				      let rels = video.relationships
+				else {
+					continue
+				}
 				let album = rels.albums?.data?.first.map { (type: $0.type, id: $0.id) }
 				wireRelationships(for: includedItem, album: album, artists: rels.artists, coverArt: rels.thumbnailArt)
 
-			case .albumsResourceObject(let album):
+			case let .albumsResourceObject(album):
 				guard let includedItem = get(type: album.type, id: album.id),
-					  let rels = album.relationships else { continue }
+				      let rels = album.relationships
+				else {
+					continue
+				}
 				wireRelationships(for: includedItem, album: nil, artists: rels.artists, coverArt: rels.coverArt)
 
-			case .playlistsResourceObject(let playlist):
+			case let .playlistsResourceObject(playlist):
 				guard let includedItem = get(type: playlist.type, id: playlist.id),
-					  let rels = playlist.relationships else { continue }
+				      let rels = playlist.relationships
+				else {
+					continue
+				}
 				wireRelationships(for: includedItem, album: nil, artists: nil, coverArt: rels.coverArt)
 
 			default:
@@ -517,7 +546,9 @@ private class IncludedItem {
 
 	var artistObjects: [ArtistsResourceObject] {
 		artists?.compactMap { item -> ArtistsResourceObject? in
-			if case .artist(let artist) = item.resource { return artist }
+			if case let .artist(artist) = item.resource {
+				return artist
+			}
 			return nil
 		} ?? []
 	}
@@ -530,21 +561,21 @@ private class IncludedItem {
 		case .playlist: coverArt
 		default: nil
 		}
-		guard let artworkItem, case .artwork(let artwork) = artworkItem.resource else {
+		guard let artworkItem, case let .artwork(artwork) = artworkItem.resource else {
 			return nil
 		}
 		return artwork
 	}
 
 	var albumObject: AlbumsResourceObject? {
-		guard let album, case .album(let albumObject) = album.resource else {
+		guard let album, case let .album(albumObject) = album.resource else {
 			return nil
 		}
 		return albumObject
 	}
 
 	func playlistItemAddedAt(for itemData: OfflineTasksItemResourceIdentifier) -> Date? {
-		guard case .playlist(let playlist) = resource else {
+		guard case let .playlist(playlist) = resource else {
 			return nil
 		}
 
@@ -560,7 +591,7 @@ private class IncludedItem {
 		let artwork = artworkObject
 		let artworkURL = artwork?.largestFileURL
 		switch resource {
-		case .album(let album):
+		case let .album(album):
 			let metadata = OfflineCollection.Metadata.album(OfflineCollection.AlbumMetadata(
 				id: album.id,
 				title: album.attributes?.title ?? "",
@@ -571,7 +602,7 @@ private class IncludedItem {
 				backgroundColorHex: artwork?.attributes?.visualMetadata?.selectedPaletteColor
 			))
 			return OfflineCollection(catalogMetadata: metadata, artworkURL: artworkURL, state: state, addedAt: addedAt)
-		case .playlist(let playlist):
+		case let .playlist(playlist):
 			let metadata = OfflineCollection.Metadata.playlist(OfflineCollection.PlaylistMetadata(
 				id: playlist.id,
 				title: playlist.attributes?.name ?? "",
@@ -602,7 +633,9 @@ private extension StoreTrackTask {
 		collectionData: OfflineTasksCollectionResourceIdentifier?,
 		addedAt: Date?
 	) {
-		guard let item, case .track(let track) = item.resource, let collectionData else { return nil }
+		guard let item, case let .track(track) = item.resource, let collectionData else {
+			return nil
+		}
 		self.init(
 			id: resourceObject.id,
 			track: track,
@@ -626,7 +659,9 @@ private extension StoreVideoTask {
 		collectionData: OfflineTasksCollectionResourceIdentifier?,
 		addedAt: Date?
 	) {
-		guard let item, case .video(let video) = item.resource, let collectionData else { return nil }
+		guard let item, case let .video(video) = item.resource, let collectionData else {
+			return nil
+		}
 		self.init(
 			id: resourceObject.id,
 			video: video,
@@ -643,14 +678,18 @@ private extension StoreVideoTask {
 
 private extension StoreAlbumTask {
 	init?(_ resourceObject: OfflineTasksResourceObject, item: IncludedItem?) {
-		guard let item, case .album(let album) = item.resource else { return nil }
+		guard let item, case let .album(album) = item.resource else {
+			return nil
+		}
 		self.init(id: resourceObject.id, album: album, artists: item.artistObjects, artwork: item.artworkObject)
 	}
 }
 
 private extension StorePlaylistTask {
 	init?(_ resourceObject: OfflineTasksResourceObject, item: IncludedItem?) {
-		guard let item, case .playlist(let playlist) = item.resource else { return nil }
+		guard let item, case let .playlist(playlist) = item.resource else {
+			return nil
+		}
 		self.init(id: resourceObject.id, playlist: playlist, artwork: item.artworkObject)
 	}
 }

--- a/Sources/Offliner/Internal/OfflineStore.swift
+++ b/Sources/Offliner/Internal/OfflineStore.swift
@@ -1,6 +1,8 @@
 import Foundation
 import GRDB
 
+// MARK: - OfflineStore
+
 final class OfflineStore {
 	private let databaseQueue: DatabaseQueue
 
@@ -9,7 +11,9 @@ final class OfflineStore {
 	}
 
 	static let foldFunction = DatabaseFunction("FOLD", argumentCount: 1, pure: true) { values in
-		guard let value = String.fromDatabaseValue(values[0]) else { return nil }
+		guard let value = String.fromDatabaseValue(values[0]) else {
+			return nil
+		}
 		return searchKey(value)
 	}
 
@@ -50,16 +54,16 @@ final class OfflineStore {
 
 			try database.execute(
 				sql: """
-					INSERT INTO offline_item \
-					(resource_type, resource_id, catalog_metadata, playback_metadata, media_bookmark, license_bookmark, artwork_bookmark)
-					VALUES (?, ?, ?, ?, ?, ?, ?)
-					ON CONFLICT (resource_type, resource_id) DO UPDATE SET
-						catalog_metadata = excluded.catalog_metadata,
-						playback_metadata = excluded.playback_metadata,
-						media_bookmark = excluded.media_bookmark,
-						license_bookmark = excluded.license_bookmark,
-						artwork_bookmark = excluded.artwork_bookmark
-					""",
+				INSERT INTO offline_item \
+				(resource_type, resource_id, catalog_metadata, playback_metadata, media_bookmark, license_bookmark, artwork_bookmark)
+				VALUES (?, ?, ?, ?, ?, ?, ?)
+				ON CONFLICT (resource_type, resource_id) DO UPDATE SET
+					catalog_metadata = excluded.catalog_metadata,
+					playback_metadata = excluded.playback_metadata,
+					media_bookmark = excluded.media_bookmark,
+					license_bookmark = excluded.license_bookmark,
+					artwork_bookmark = excluded.artwork_bookmark
+				""",
 				arguments: [
 					result.resourceType,
 					result.resourceId,
@@ -67,35 +71,35 @@ final class OfflineStore {
 					playbackMetadataJson,
 					mediaBookmark,
 					licenseBookmark,
-					artworkBookmark
+					artworkBookmark,
 				]
 			)
 
 			try database.execute(
 				sql: """
-					INSERT INTO offline_item_relationship (
-						collection_resource_type,
-						collection_resource_id,
-						member_resource_type,
-						member_resource_id,
-						volume,
-						position,
-						added_at,
-						title_sort,
-						album_sort,
-						artist_sort)
-					VALUES (?, ?, ?, ?, ?, ?, ?,
-						LOWER(COALESCE(json_extract(?, '$.title'), '')),
-						LOWER(COALESCE(json_extract(?, '$.albumTitle'), '')),
-						LOWER(COALESCE((SELECT group_concat(value, ', ') FROM json_each(?, '$.artists')), '')))
-					ON CONFLICT (collection_resource_type, collection_resource_id, volume, position) DO UPDATE SET
-						member_resource_type = excluded.member_resource_type,
-						member_resource_id = excluded.member_resource_id,
-						added_at = COALESCE(excluded.added_at, offline_item_relationship.added_at),
-						title_sort = excluded.title_sort,
-						album_sort = excluded.album_sort,
-						artist_sort = excluded.artist_sort
-					""",
+				INSERT INTO offline_item_relationship (
+					collection_resource_type,
+					collection_resource_id,
+					member_resource_type,
+					member_resource_id,
+					volume,
+					position,
+					added_at,
+					title_sort,
+					album_sort,
+					artist_sort)
+				VALUES (?, ?, ?, ?, ?, ?, ?,
+					LOWER(COALESCE(json_extract(?, '$.title'), '')),
+					LOWER(COALESCE(json_extract(?, '$.albumTitle'), '')),
+					LOWER(COALESCE((SELECT group_concat(value, ', ') FROM json_each(?, '$.artists')), '')))
+				ON CONFLICT (collection_resource_type, collection_resource_id, volume, position) DO UPDATE SET
+					member_resource_type = excluded.member_resource_type,
+					member_resource_id = excluded.member_resource_id,
+					added_at = COALESCE(excluded.added_at, offline_item_relationship.added_at),
+					title_sort = excluded.title_sort,
+					album_sort = excluded.album_sort,
+					artist_sort = excluded.artist_sort
+				""",
 				arguments: [
 					result.collectionResourceType,
 					result.collectionResourceId,
@@ -106,7 +110,8 @@ final class OfflineStore {
 					encodeRelationshipAddedAt(result.addedAt),
 					catalogMetadataJson,
 					catalogMetadataJson,
-					catalogMetadataJson]
+					catalogMetadataJson,
+				]
 			)
 
 			return .commit
@@ -122,17 +127,21 @@ final class OfflineStore {
 		var replacedBookmarks: [Data] = []
 
 		try databaseQueue.inTransaction { database in
-			replacedBookmarks = try collectBookmarks(resourceType: result.resourceType.rawValue, resourceId: result.resourceId, database: database)
+			replacedBookmarks = try collectBookmarks(
+				resourceType: result.resourceType.rawValue,
+				resourceId: result.resourceId,
+				database: database
+			)
 
 			try database.execute(
 				sql: """
-					INSERT INTO offline_item \
-					(resource_type, resource_id, catalog_metadata, artwork_bookmark)
-					VALUES (?, ?, ?, ?)
-					ON CONFLICT (resource_type, resource_id) DO UPDATE SET
-						catalog_metadata = excluded.catalog_metadata,
-						artwork_bookmark = excluded.artwork_bookmark
-					""",
+				INSERT INTO offline_item \
+				(resource_type, resource_id, catalog_metadata, artwork_bookmark)
+				VALUES (?, ?, ?, ?)
+				ON CONFLICT (resource_type, resource_id) DO UPDATE SET
+					catalog_metadata = excluded.catalog_metadata,
+					artwork_bookmark = excluded.artwork_bookmark
+				""",
 				arguments: [result.resourceType.rawValue, result.resourceId, catalogMetadataJson, artworkBookmark]
 			)
 
@@ -175,10 +184,10 @@ final class OfflineStore {
 		try databaseQueue.inTransaction { database in
 			try database.execute(
 				sql: """
-					DELETE FROM offline_item_relationship
-					WHERE collection_resource_type = ? AND collection_resource_id = ?
-					  AND member_resource_type = ? AND member_resource_id = ?
-					""",
+				DELETE FROM offline_item_relationship
+				WHERE collection_resource_type = ? AND collection_resource_id = ?
+				  AND member_resource_type = ? AND member_resource_id = ?
+				""",
 				arguments: [collectionType, collectionId, resourceType, resourceId]
 			)
 
@@ -208,21 +217,23 @@ final class OfflineStore {
 			try Row.fetchOne(
 				database,
 				sql: """
-					SELECT resource_type, resource_id, catalog_metadata, artwork_bookmark, created_at
-					FROM offline_item
-					WHERE resource_type = ? AND resource_id = ?
-					""",
+				SELECT resource_type, resource_id, catalog_metadata, artwork_bookmark, created_at
+				FROM offline_item
+				WHERE resource_type = ? AND resource_id = ?
+				""",
 				arguments: [collectionType.rawValue, resourceId]
 			)
 		}
 
-		guard let row else { return nil }
+		guard let row else {
+			return nil
+		}
 
 		let collectionType = OfflineCollectionType(rawValue: row["resource_type"])!
 
 		var renewals: [BookmarkRenewal] = []
-		let collection = OfflineCollection(
-			catalogMetadata: try OfflineCollection.Metadata.deserialize(collectionType: collectionType, json: row["catalog_metadata"]),
+		let collection = try OfflineCollection(
+			catalogMetadata: OfflineCollection.Metadata.deserialize(collectionType: collectionType, json: row["catalog_metadata"]),
 			artworkURL: try? Self.resolveBookmarkIfPresent(row, column: "artwork_bookmark", renewals: &renewals),
 			addedAt: row["created_at"]
 		)
@@ -236,10 +247,10 @@ final class OfflineStore {
 			try Row.fetchOne(
 				database,
 				sql: """
-					SELECT resource_type, resource_id, catalog_metadata, playback_metadata, artwork_bookmark
-					FROM offline_item
-					WHERE resource_type = ? AND resource_id = ?
-					""",
+				SELECT resource_type, resource_id, catalog_metadata, playback_metadata, artwork_bookmark
+				FROM offline_item
+				WHERE resource_type = ? AND resource_id = ?
+				""",
 				arguments: [mediaType.rawValue, resourceId]
 			)
 		}
@@ -256,23 +267,25 @@ final class OfflineStore {
 			try Row.fetchOne(
 				database,
 				sql: """
-					SELECT resource_type, resource_id, playback_metadata, media_bookmark, license_bookmark
-					FROM offline_item
-					WHERE resource_type = ? AND resource_id = ?
-					""",
+				SELECT resource_type, resource_id, playback_metadata, media_bookmark, license_bookmark
+				FROM offline_item
+				WHERE resource_type = ? AND resource_id = ?
+				""",
 				arguments: [mediaType.rawValue, resourceId]
 			)
 		}
 
-		guard let row else { return nil }
+		guard let row else {
+			return nil
+		}
 
 		let playbackMetadataJson: String? = row["playback_metadata"]
 
 		var renewals: [BookmarkRenewal] = []
-		let item = PlayableOfflineMediaItem(
-			playbackMetadata: try playbackMetadataJson.map { try OfflineMediaItem.PlaybackMetadata.deserialize($0) },
-			mediaURL: try Self.resolveBookmark(row, column: "media_bookmark", renewals: &renewals),
-			licenseURL: try Self.resolveBookmarkIfPresent(row, column: "license_bookmark", renewals: &renewals)
+		let item = try PlayableOfflineMediaItem(
+			playbackMetadata: playbackMetadataJson.map { try OfflineMediaItem.PlaybackMetadata.deserialize($0) },
+			mediaURL: Self.resolveBookmark(row, column: "media_bookmark", renewals: &renewals),
+			licenseURL: Self.resolveBookmarkIfPresent(row, column: "license_bookmark", renewals: &renewals)
 		)
 		try await storeRenewedBookmarks(renewals)
 
@@ -284,11 +297,11 @@ final class OfflineStore {
 			try Row.fetchAll(
 				database,
 				sql: """
-					SELECT resource_type, resource_id, catalog_metadata, playback_metadata, artwork_bookmark
-					FROM offline_item
-					WHERE resource_type = ?
-					ORDER BY created_at DESC
-					""",
+				SELECT resource_type, resource_id, catalog_metadata, playback_metadata, artwork_bookmark
+				FROM offline_item
+				WHERE resource_type = ?
+				ORDER BY created_at DESC
+				""",
 				arguments: [mediaType.rawValue]
 			)
 		}
@@ -299,7 +312,7 @@ final class OfflineStore {
 
 		for row in rows {
 			do {
-				items.append(try OfflineMediaItem(from: row, renewals: &renewals))
+				try items.append(OfflineMediaItem(from: row, renewals: &renewals))
 			} catch {
 				FailedOfflineItem(from: row).map { failures.append($0) }
 			}
@@ -315,11 +328,11 @@ final class OfflineStore {
 			try Row.fetchAll(
 				database,
 				sql: """
-					SELECT resource_type, resource_id, catalog_metadata, artwork_bookmark, created_at
-					FROM offline_item
-					WHERE resource_type = ?
-					ORDER BY created_at DESC
-					""",
+				SELECT resource_type, resource_id, catalog_metadata, artwork_bookmark, created_at
+				FROM offline_item
+				WHERE resource_type = ?
+				ORDER BY created_at DESC
+				""",
 				arguments: [collectionType.rawValue]
 			)
 		}
@@ -328,8 +341,8 @@ final class OfflineStore {
 		let collections = try rows.map { row in
 			let collectionType = OfflineCollectionType(rawValue: row["resource_type"])!
 
-			return OfflineCollection(
-				catalogMetadata: try OfflineCollection.Metadata.deserialize(collectionType: collectionType, json: row["catalog_metadata"]),
+			return try OfflineCollection(
+				catalogMetadata: OfflineCollection.Metadata.deserialize(collectionType: collectionType, json: row["catalog_metadata"]),
 				artworkURL: try? Self.resolveBookmarkIfPresent(row, column: "artwork_bookmark", renewals: &renewals),
 				addedAt: row["created_at"]
 			)
@@ -344,11 +357,11 @@ final class OfflineStore {
 			let count = try Int.fetchOne(
 				database,
 				sql: """
-					SELECT COUNT(*)
-					FROM offline_item_relationship
-					WHERE collection_resource_type = ? AND collection_resource_id = ?
-					  AND (member_resource_type != collection_resource_type OR member_resource_id != collection_resource_id)
-					""",
+				SELECT COUNT(*)
+				FROM offline_item_relationship
+				WHERE collection_resource_type = ? AND collection_resource_id = ?
+				  AND (member_resource_type != collection_resource_type OR member_resource_id != collection_resource_id)
+				""",
 				arguments: [collectionType.rawValue, resourceId]
 			)
 			return count ?? 0
@@ -369,17 +382,17 @@ final class OfflineStore {
 			try Row.fetchAll(
 				database,
 				sql: """
-					SELECT i.resource_type, i.resource_id, i.catalog_metadata, i.playback_metadata,
-					       i.artwork_bookmark,
-					       r.volume, r.position, r.added_at AS relationship_added_at
-					FROM offline_item_relationship r
-					JOIN offline_item i ON r.member_resource_type = i.resource_type AND r.member_resource_id = i.resource_id
-					WHERE r.collection_resource_type = ? AND r.collection_resource_id = ?
-					  AND (r.volume > ? OR (r.volume = ? AND r.position > ?))
-					  AND (r.member_resource_type != r.collection_resource_type OR r.member_resource_id != r.collection_resource_id)
-					ORDER BY r.volume, r.position
-					LIMIT ?
-					""",
+				SELECT i.resource_type, i.resource_id, i.catalog_metadata, i.playback_metadata,
+				       i.artwork_bookmark,
+				       r.volume, r.position, r.added_at AS relationship_added_at
+				FROM offline_item_relationship r
+				JOIN offline_item i ON r.member_resource_type = i.resource_type AND r.member_resource_id = i.resource_id
+				WHERE r.collection_resource_type = ? AND r.collection_resource_id = ?
+				  AND (r.volume > ? OR (r.volume = ? AND r.position > ?))
+				  AND (r.member_resource_type != r.collection_resource_type OR r.member_resource_id != r.collection_resource_id)
+				ORDER BY r.volume, r.position
+				LIMIT ?
+				""",
 				arguments: [collectionType.rawValue, resourceId, cursorVolume, cursorVolume, cursorPosition, limit]
 			)
 		}
@@ -407,18 +420,18 @@ final class OfflineStore {
 			try Row.fetchAll(
 				database,
 				sql: """
-					SELECT i.resource_type, i.resource_id, i.catalog_metadata, i.playback_metadata,
-					       i.artwork_bookmark,
-					       r.volume, r.position, r.id AS relationship_id, r.added_at AS relationship_added_at,
-					       r.title_sort AS sort_value
-					FROM offline_item_relationship r
-					JOIN offline_item i ON r.member_resource_type = i.resource_type AND r.member_resource_id = i.resource_id
-					WHERE r.collection_resource_type = ? AND r.collection_resource_id = ?
-					  AND (r.member_resource_type != r.collection_resource_type OR r.member_resource_id != r.collection_resource_id)
-					  \(cursorPredicate)
-					ORDER BY r.title_sort \(order), r.id \(order)
-					LIMIT ?
-					""",
+				SELECT i.resource_type, i.resource_id, i.catalog_metadata, i.playback_metadata,
+				       i.artwork_bookmark,
+				       r.volume, r.position, r.id AS relationship_id, r.added_at AS relationship_added_at,
+				       r.title_sort AS sort_value
+				FROM offline_item_relationship r
+				JOIN offline_item i ON r.member_resource_type = i.resource_type AND r.member_resource_id = i.resource_id
+				WHERE r.collection_resource_type = ? AND r.collection_resource_id = ?
+				  AND (r.member_resource_type != r.collection_resource_type OR r.member_resource_id != r.collection_resource_id)
+				  \(cursorPredicate)
+				ORDER BY r.title_sort \(order), r.id \(order)
+				LIMIT ?
+				""",
 				arguments: self.sortQueryArguments(
 					collectionType: collectionType,
 					resourceId: resourceId,
@@ -450,18 +463,18 @@ final class OfflineStore {
 			try Row.fetchAll(
 				database,
 				sql: """
-					SELECT i.resource_type, i.resource_id, i.catalog_metadata, i.playback_metadata,
-					       i.artwork_bookmark,
-					       r.volume, r.position, r.id AS relationship_id, r.added_at AS relationship_added_at,
-					       r.album_sort AS sort_value
-					FROM offline_item_relationship r
-					JOIN offline_item i ON r.member_resource_type = i.resource_type AND r.member_resource_id = i.resource_id
-					WHERE r.collection_resource_type = ? AND r.collection_resource_id = ?
-					  AND (r.member_resource_type != r.collection_resource_type OR r.member_resource_id != r.collection_resource_id)
-					  \(cursorPredicate)
-					ORDER BY r.album_sort \(order), r.id \(order)
-					LIMIT ?
-					""",
+				SELECT i.resource_type, i.resource_id, i.catalog_metadata, i.playback_metadata,
+				       i.artwork_bookmark,
+				       r.volume, r.position, r.id AS relationship_id, r.added_at AS relationship_added_at,
+				       r.album_sort AS sort_value
+				FROM offline_item_relationship r
+				JOIN offline_item i ON r.member_resource_type = i.resource_type AND r.member_resource_id = i.resource_id
+				WHERE r.collection_resource_type = ? AND r.collection_resource_id = ?
+				  AND (r.member_resource_type != r.collection_resource_type OR r.member_resource_id != r.collection_resource_id)
+				  \(cursorPredicate)
+				ORDER BY r.album_sort \(order), r.id \(order)
+				LIMIT ?
+				""",
 				arguments: self.sortQueryArguments(
 					collectionType: collectionType,
 					resourceId: resourceId,
@@ -493,18 +506,18 @@ final class OfflineStore {
 			try Row.fetchAll(
 				database,
 				sql: """
-					SELECT i.resource_type, i.resource_id, i.catalog_metadata, i.playback_metadata,
-					       i.artwork_bookmark,
-					       r.volume, r.position, r.id AS relationship_id, r.added_at AS relationship_added_at,
-					       r.artist_sort AS sort_value
-					FROM offline_item_relationship r
-					JOIN offline_item i ON r.member_resource_type = i.resource_type AND r.member_resource_id = i.resource_id
-					WHERE r.collection_resource_type = ? AND r.collection_resource_id = ?
-					  AND (r.member_resource_type != r.collection_resource_type OR r.member_resource_id != r.collection_resource_id)
-					  \(cursorPredicate)
-					ORDER BY r.artist_sort \(order), r.id \(order)
-					LIMIT ?
-					""",
+				SELECT i.resource_type, i.resource_id, i.catalog_metadata, i.playback_metadata,
+				       i.artwork_bookmark,
+				       r.volume, r.position, r.id AS relationship_id, r.added_at AS relationship_added_at,
+				       r.artist_sort AS sort_value
+				FROM offline_item_relationship r
+				JOIN offline_item i ON r.member_resource_type = i.resource_type AND r.member_resource_id = i.resource_id
+				WHERE r.collection_resource_type = ? AND r.collection_resource_id = ?
+				  AND (r.member_resource_type != r.collection_resource_type OR r.member_resource_id != r.collection_resource_id)
+				  \(cursorPredicate)
+				ORDER BY r.artist_sort \(order), r.id \(order)
+				LIMIT ?
+				""",
 				arguments: self.sortQueryArguments(
 					collectionType: collectionType,
 					resourceId: resourceId,
@@ -536,18 +549,18 @@ final class OfflineStore {
 			try Row.fetchAll(
 				database,
 				sql: """
-					SELECT i.resource_type, i.resource_id, i.catalog_metadata, i.playback_metadata,
-					       i.artwork_bookmark,
-					       r.volume, r.position, r.id AS relationship_id, r.added_at AS relationship_added_at,
-					       r.added_at_sort AS sort_value
-					FROM offline_item_relationship r
-					JOIN offline_item i ON r.member_resource_type = i.resource_type AND r.member_resource_id = i.resource_id
-					WHERE r.collection_resource_type = ? AND r.collection_resource_id = ?
-					  AND (r.member_resource_type != r.collection_resource_type OR r.member_resource_id != r.collection_resource_id)
-					  \(cursorPredicate)
-					ORDER BY r.added_at_sort \(order), r.id \(order)
-					LIMIT ?
-					""",
+				SELECT i.resource_type, i.resource_id, i.catalog_metadata, i.playback_metadata,
+				       i.artwork_bookmark,
+				       r.volume, r.position, r.id AS relationship_id, r.added_at AS relationship_added_at,
+				       r.added_at_sort AS sort_value
+				FROM offline_item_relationship r
+				JOIN offline_item i ON r.member_resource_type = i.resource_type AND r.member_resource_id = i.resource_id
+				WHERE r.collection_resource_type = ? AND r.collection_resource_id = ?
+				  AND (r.member_resource_type != r.collection_resource_type OR r.member_resource_id != r.collection_resource_id)
+				  \(cursorPredicate)
+				ORDER BY r.added_at_sort \(order), r.id \(order)
+				LIMIT ?
+				""",
 				arguments: self.sortQueryArguments(
 					collectionType: collectionType,
 					resourceId: resourceId,
@@ -586,20 +599,20 @@ final class OfflineStore {
 			try Row.fetchAll(
 				database,
 				sql: """
-					SELECT i.resource_type, i.resource_id, i.catalog_metadata, i.playback_metadata,
-					       i.artwork_bookmark,
-					       r.volume, r.position, r.id AS relationship_id, r.added_at AS relationship_added_at
-					       \(searchSort.sortColumnSelect)
-					FROM offline_item_relationship r
-					JOIN offline_item i
-					  ON i.resource_type = r.member_resource_type AND i.resource_id = r.member_resource_id
-					WHERE r.collection_resource_type = ? AND r.collection_resource_id = ?
-					  AND (r.member_resource_type != r.collection_resource_type OR r.member_resource_id != r.collection_resource_id)
-					  AND (FOLD(r.title_sort) LIKE ? ESCAPE '\\' OR FOLD(r.artist_sort) LIKE ? ESCAPE '\\')
-					  \(cursorPredicate)
-					ORDER BY \(searchSort.orderClause)
-					LIMIT ?
-					""",
+				SELECT i.resource_type, i.resource_id, i.catalog_metadata, i.playback_metadata,
+				       i.artwork_bookmark,
+				       r.volume, r.position, r.id AS relationship_id, r.added_at AS relationship_added_at
+				       \(searchSort.sortColumnSelect)
+				FROM offline_item_relationship r
+				JOIN offline_item i
+				  ON i.resource_type = r.member_resource_type AND i.resource_id = r.member_resource_id
+				WHERE r.collection_resource_type = ? AND r.collection_resource_id = ?
+				  AND (r.member_resource_type != r.collection_resource_type OR r.member_resource_id != r.collection_resource_id)
+				  AND (FOLD(r.title_sort) LIKE ? ESCAPE '\\' OR FOLD(r.artist_sort) LIKE ? ESCAPE '\\')
+				  \(cursorPredicate)
+				ORDER BY \(searchSort.orderClause)
+				LIMIT ?
+				""",
 				arguments: StatementArguments(arguments)
 			)
 		}
@@ -624,7 +637,9 @@ final class OfflineStore {
 
 	private func likePattern(for query: String) -> String? {
 		let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
-		guard !trimmed.isEmpty else { return nil }
+		guard !trimmed.isEmpty else {
+			return nil
+		}
 
 		let escaped = Self.searchKey(trimmed)
 			.replacingOccurrences(of: "\\", with: "\\\\")
@@ -672,7 +687,7 @@ final class OfflineStore {
 
 		for row in rows {
 			do {
-				items.append(try makeCollectionItem(from: row, renewals: &renewals))
+				try items.append(makeCollectionItem(from: row, renewals: &renewals))
 			} catch {
 				FailedOfflineItem(from: row).map { failures.append($0) }
 			}
@@ -689,18 +704,20 @@ final class OfflineStore {
 			let row = try Row.fetchOne(
 				database,
 				sql: """
-					SELECT i.playback_metadata
-					FROM offline_item_relationship r
-					JOIN offline_item i ON r.member_resource_type = i.resource_type AND r.member_resource_id = i.resource_id
-					WHERE r.collection_resource_type = ? AND r.collection_resource_id = ?
-					  AND r.member_resource_type = ?
-					ORDER BY r.volume, r.position
-					LIMIT 1
-					""",
-					arguments: [collectionType.rawValue, resourceId, OfflineMediaItemType.tracks.rawValue]
+				SELECT i.playback_metadata
+				FROM offline_item_relationship r
+				JOIN offline_item i ON r.member_resource_type = i.resource_type AND r.member_resource_id = i.resource_id
+				WHERE r.collection_resource_type = ? AND r.collection_resource_id = ?
+				  AND r.member_resource_type = ?
+				ORDER BY r.volume, r.position
+				LIMIT 1
+				""",
+				arguments: [collectionType.rawValue, resourceId, OfflineMediaItemType.tracks.rawValue]
 			)
 
-			guard let row else { return nil }
+			guard let row else {
+				return nil
+			}
 
 			let playbackMetadataJson: String? = row["playback_metadata"]
 			let playbackMetadata = try playbackMetadataJson.map { try OfflineMediaItem.PlaybackMetadata.deserialize($0) }
@@ -716,12 +733,12 @@ final class OfflineStore {
 			let duration = try Int.fetchOne(
 				database,
 				sql: """
-					SELECT COALESCE(SUM(json_extract(i.catalog_metadata, '$.duration')), 0)
-					FROM offline_item_relationship r
-					JOIN offline_item i ON r.member_resource_type = i.resource_type AND r.member_resource_id = i.resource_id
-					WHERE r.collection_resource_type = ? AND r.collection_resource_id = ?
-					  AND (r.member_resource_type != r.collection_resource_type OR r.member_resource_id != r.collection_resource_id)
-					""",
+				SELECT COALESCE(SUM(json_extract(i.catalog_metadata, '$.duration')), 0)
+				FROM offline_item_relationship r
+				JOIN offline_item i ON r.member_resource_type = i.resource_type AND r.member_resource_id = i.resource_id
+				WHERE r.collection_resource_type = ? AND r.collection_resource_id = ?
+				  AND (r.member_resource_type != r.collection_resource_type OR r.member_resource_id != r.collection_resource_id)
+				""",
 				arguments: [collectionType.rawValue, resourceId]
 			)
 			return duration ?? 0
@@ -744,8 +761,8 @@ final class OfflineStore {
 	}
 
 	private func makeCollectionItem(from row: Row, renewals: inout [BookmarkRenewal]) throws -> OfflineCollectionItem {
-		OfflineCollectionItem(
-			item: try OfflineMediaItem(from: row, renewals: &renewals),
+		try OfflineCollectionItem(
+			item: OfflineMediaItem(from: row, renewals: &renewals),
 			volume: row["volume"],
 			position: row["position"],
 			addedAt: decodeRelationshipAddedAt(row["relationship_added_at"])
@@ -763,6 +780,8 @@ private extension SortDirection {
 	}
 }
 
+// MARK: - SearchSort
+
 private enum SearchSort {
 	case natural
 	case keyed(column: String, direction: SortDirection)
@@ -770,41 +789,45 @@ private enum SearchSort {
 	init(_ sort: OfflineCollectionItemSort?) {
 		switch sort {
 		case nil: self = .natural
-		case .title(let direction): self = .keyed(column: "title_sort", direction: direction)
-		case .album(let direction): self = .keyed(column: "album_sort", direction: direction)
-		case .artist(let direction): self = .keyed(column: "artist_sort", direction: direction)
-		case .dateAdded(let direction): self = .keyed(column: "added_at_sort", direction: direction)
+		case let .title(direction): self = .keyed(column: "title_sort", direction: direction)
+		case let .album(direction): self = .keyed(column: "album_sort", direction: direction)
+		case let .artist(direction): self = .keyed(column: "artist_sort", direction: direction)
+		case let .dateAdded(direction): self = .keyed(column: "added_at_sort", direction: direction)
 		}
 	}
 
 	var orderClause: String {
 		switch self {
 		case .natural:
-			return "r.volume, r.position"
-		case .keyed(let column, let direction):
-			return "r.\(column) \(direction.order), r.id \(direction.order)"
+			"r.volume, r.position"
+		case let .keyed(column, direction):
+			"r.\(column) \(direction.order), r.id \(direction.order)"
 		}
 	}
 
 	var sortColumnSelect: String {
 		switch self {
 		case .natural:
-			return ""
-		case .keyed(let column, _):
-			return ", r.\(column) AS sort_value"
+			""
+		case let .keyed(column, _):
+			", r.\(column) AS sort_value"
 		}
 	}
 
 	func cursorClause(for cursor: String?) -> (predicate: String, arguments: [DatabaseValueConvertible?]) {
-		guard let cursor else { return ("", []) }
+		guard let cursor else {
+			return ("", [])
+		}
 
 		switch self {
 		case .natural:
-			guard let value = Int64(cursor) else { return ("", []) }
+			guard let value = Int64(cursor) else {
+				return ("", [])
+			}
 			let volume = Int(value / 1_000_000)
 			let position = Int(value % 1_000_000)
 			return ("AND (r.volume > ? OR (r.volume = ? AND r.position > ?))", [volume, volume, position])
-		case .keyed(let column, let direction):
+		case let .keyed(column, direction):
 			guard let separator = cursor.firstIndex(of: ":"), let relationshipId = Int64(cursor[..<separator]) else {
 				return ("", [])
 			}
@@ -828,14 +851,18 @@ private enum SearchSort {
 }
 
 private func encodeRelationshipAddedAt(_ date: Date?) -> String? {
-	guard let date else { return nil }
+	guard let date else {
+		return nil
+	}
 	let formatter = ISO8601DateFormatter()
 	formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 	return formatter.string(from: date)
 }
 
 private func decodeRelationshipAddedAt(_ string: String?) -> Date? {
-	guard let string else { return nil }
+	guard let string else {
+		return nil
+	}
 
 	let formatter = ISO8601DateFormatter()
 	formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
@@ -859,11 +886,11 @@ struct FailedOfflineItem {
 			return nil
 		}
 		self.mediaType = mediaType
-		self.resourceId = row["resource_id"]
+		resourceId = row["resource_id"]
 	}
 }
 
-// MARK: - Result Types
+// MARK: - StoreItemTaskResult
 
 struct StoreItemTaskResult {
 	let resourceType: String
@@ -880,6 +907,8 @@ struct StoreItemTaskResult {
 	let artworkURL: URL?
 }
 
+// MARK: - StoreCollectionTaskResult
+
 struct StoreCollectionTaskResult {
 	let resourceType: OfflineCollectionType
 	let resourceId: String
@@ -894,10 +923,10 @@ extension OfflineMediaItem.Metadata {
 		let encoder = JSONEncoder()
 
 		switch self {
-		case .track(let metadata):
+		case let .track(metadata):
 			let data = try encoder.encode(metadata)
 			return String(data: data, encoding: .utf8)!
-		case .video(let metadata):
+		case let .video(metadata):
 			let data = try encoder.encode(metadata)
 			return String(data: data, encoding: .utf8)!
 		}
@@ -909,9 +938,9 @@ extension OfflineMediaItem.Metadata {
 
 		switch mediaType {
 		case .tracks:
-			return .track(try decoder.decode(OfflineMediaItem.TrackMetadata.self, from: data))
+			return try .track(decoder.decode(OfflineMediaItem.TrackMetadata.self, from: data))
 		case .videos:
-			return .video(try decoder.decode(OfflineMediaItem.VideoMetadata.self, from: data))
+			return try .video(decoder.decode(OfflineMediaItem.VideoMetadata.self, from: data))
 		}
 	}
 }
@@ -923,13 +952,13 @@ extension OfflineCollection.Metadata {
 		let encoder = JSONEncoder()
 
 		switch self {
-		case .album(let metadata):
+		case let .album(metadata):
 			let data = try encoder.encode(metadata)
 			return String(data: data, encoding: .utf8)!
-		case .playlist(let metadata):
+		case let .playlist(metadata):
 			let data = try encoder.encode(metadata)
 			return String(data: data, encoding: .utf8)!
-		case .userCollectionTracks(let id):
+		case let .userCollectionTracks(id):
 			let data = try encoder.encode(["id": id])
 			return String(data: data, encoding: .utf8)!
 		}
@@ -941,9 +970,9 @@ extension OfflineCollection.Metadata {
 
 		switch collectionType {
 		case .albums:
-			return .album(try decoder.decode(OfflineCollection.AlbumMetadata.self, from: data))
+			return try .album(decoder.decode(OfflineCollection.AlbumMetadata.self, from: data))
 		case .playlists:
-			return .playlist(try decoder.decode(OfflineCollection.PlaylistMetadata.self, from: data))
+			return try .playlist(decoder.decode(OfflineCollection.PlaylistMetadata.self, from: data))
 		case .userCollectionTracks:
 			let container = try decoder.decode([String: String].self, from: data)
 			return .userCollectionTracks(id: container["id"]!)
@@ -1044,11 +1073,11 @@ extension OfflineStore {
 
 					try database.execute(
 						sql: """
-							UPDATE offline_item
-							SET \(column) = v.column3
-							FROM (VALUES \(values)) AS v
-							WHERE offline_item.resource_type = v.column1 AND offline_item.resource_id = v.column2
-							""",
+						UPDATE offline_item
+						SET \(column) = v.column3
+						FROM (VALUES \(values)) AS v
+						WHERE offline_item.resource_type = v.column1 AND offline_item.resource_id = v.column2
+						""",
 						arguments: StatementArguments(arguments)
 					)
 				}

--- a/Sources/Offliner/Internal/TaskRunner.swift
+++ b/Sources/Offliner/Internal/TaskRunner.swift
@@ -2,6 +2,8 @@ import Foundation
 import Network
 import OSLog
 
+// MARK: - TaskRunner
+
 actor TaskRunner {
 	private static let logger = Logger(subsystem: "com.tidal.sdk.offliner", category: "TaskRunner")
 	private static let maxConcurrentTasks = 5
@@ -43,42 +45,42 @@ actor TaskRunner {
 		videoManifestFetcher: VideoManifestFetcherProtocol
 	) {
 		self.offlineApiClient = offlineApiClient
-		self.allowDownloadsOnExpensiveNetworks = configuration.allowDownloadsOnExpensiveNetworks
-		self.network = Network()
+		allowDownloadsOnExpensiveNetworks = configuration.allowDownloadsOnExpensiveNetworks
+		network = Network()
 
 		let (stream, continuation) = AsyncStream<Download>.makeStream()
-		self.newDownloads = stream
-		self.downloadsContinuation = continuation
+		newDownloads = stream
+		downloadsContinuation = continuation
 
-		self.storeTrackHandler = StoreTrackHandler(
+		storeTrackHandler = StoreTrackHandler(
 			offlineStore: offlineStore,
 			artworkDownloader: artworkDownloader,
 			mediaDownloader: mediaDownloader,
 			manifestFetcher: trackManifestFetcher,
 			licenseDownloader: licenseDownloader
 		)
-		self.storeVideoHandler = StoreVideoHandler(
+		storeVideoHandler = StoreVideoHandler(
 			offlineStore: offlineStore,
 			artworkDownloader: artworkDownloader,
 			mediaDownloader: mediaDownloader,
 			manifestFetcher: videoManifestFetcher,
 			licenseDownloader: licenseDownloader
 		)
-		self.storeAlbumHandler = StoreAlbumHandler(
+		storeAlbumHandler = StoreAlbumHandler(
 			offlineStore: offlineStore,
 			artworkDownloader: artworkDownloader
 		)
-		self.storePlaylistHandler = StorePlaylistHandler(
+		storePlaylistHandler = StorePlaylistHandler(
 			offlineStore: offlineStore,
 			artworkDownloader: artworkDownloader
 		)
-		self.storeUserCollectionTracksHandler = StoreUserCollectionTracksHandler(
+		storeUserCollectionTracksHandler = StoreUserCollectionTracksHandler(
 			offlineStore: offlineStore
 		)
-		self.removeItemHandler = RemoveItemHandler(
+		removeItemHandler = RemoveItemHandler(
 			offlineStore: offlineStore
 		)
-		self.removeCollectionHandler = RemoveCollectionHandler(
+		removeCollectionHandler = RemoveCollectionHandler(
 			offlineStore: offlineStore
 		)
 	}
@@ -126,13 +128,13 @@ actor TaskRunner {
 
 	private func handle(_ offlineTask: OfflineTask) -> InternalTask {
 		switch offlineTask {
-		case .storeTrack(let task): storeTrackHandler.handle(task)
-		case .storeVideo(let task): storeVideoHandler.handle(task)
-		case .storeAlbum(let task): storeAlbumHandler.handle(task)
-		case .storePlaylist(let task): storePlaylistHandler.handle(task)
-		case .storeUserCollectionTracks(let task): storeUserCollectionTracksHandler.handle(task)
-		case .removeItem(let task): removeItemHandler.handle(task)
-		case .removeCollection(let task): removeCollectionHandler.handle(task)
+		case let .storeTrack(task): storeTrackHandler.handle(task)
+		case let .storeVideo(task): storeVideoHandler.handle(task)
+		case let .storeAlbum(task): storeAlbumHandler.handle(task)
+		case let .storePlaylist(task): storePlaylistHandler.handle(task)
+		case let .storeUserCollectionTracks(task): storeUserCollectionTracksHandler.handle(task)
+		case let .removeItem(task): removeItemHandler.handle(task)
+		case let .removeCollection(task): removeCollectionHandler.handle(task)
 		}
 	}
 
@@ -173,7 +175,7 @@ actor TaskRunner {
 	}
 
 	private func start(_ task: InternalTask) async {
-		while !allowDownloadsOnExpensiveNetworks, !(await network.isInexpensive) {
+		while !allowDownloadsOnExpensiveNetworks, await !(network.isInexpensive) {
 			try? await Task.sleep(nanoseconds: 1_000_000_000)
 		}
 
@@ -218,8 +220,12 @@ private actor Network {
 
 	init() {
 		monitor.pathUpdateHandler = { [weak self] path in
-			guard path.status == .satisfied else { return }
-			guard let self else { return }
+			guard path.status == .satisfied else {
+				return
+			}
+			guard let self else {
+				return
+			}
 			let inexpensive = !path.isExpensive && !path.isConstrained
 			Task { await self.setInexpensive(inexpensive) }
 		}

--- a/Sources/Offliner/Offliner.swift
+++ b/Sources/Offliner/Offliner.swift
@@ -53,10 +53,10 @@ public final class Offliner {
 		self.offlineApiClient = offlineApiClient
 		self.offlineStore = offlineStore
 		self.mediaDownloader = mediaDownloader
-		self.collectionDownloadStatePollInterval = Self.defaultCollectionDownloadStatePollInterval
+		collectionDownloadStatePollInterval = Self.defaultCollectionDownloadStatePollInterval
 		self.trackManifestFetcher = trackManifestFetcher
-		self.audioFormats = configuration.audioFormats
-		self.taskRunner = TaskRunner(
+		audioFormats = configuration.audioFormats
+		taskRunner = TaskRunner(
 			configuration: configuration,
 			offlineApiClient: offlineApiClient,
 			offlineStore: offlineStore,
@@ -68,7 +68,9 @@ public final class Offliner {
 		)
 
 		mediaDownloader.orphanedTaskHandler = { [weak self] taskId in
-			guard let self, let taskId else { return }
+			guard let self, let taskId else {
+				return
+			}
 			Task {
 				try? await self.offlineApiClient.updateTask(taskId: taskId, state: .failed)
 				await self.run()
@@ -92,8 +94,8 @@ public final class Offliner {
 		self.mediaDownloader = mediaDownloader
 		self.collectionDownloadStatePollInterval = collectionDownloadStatePollInterval
 		self.trackManifestFetcher = trackManifestFetcher
-		self.audioFormats = configuration.audioFormats
-		self.taskRunner = TaskRunner(
+		audioFormats = configuration.audioFormats
+		taskRunner = TaskRunner(
 			configuration: configuration,
 			offlineApiClient: offlineApiClient,
 			offlineStore: offlineStore,
@@ -160,7 +162,7 @@ public final class Offliner {
 	) -> AsyncStream<Set<OfflineCollection>> {
 		AsyncStream { continuation in
 			let task = Task {
-				let local = (try? await offlineStore.getCollections(collectionType: collectionType)) ?? []
+				let local = await (try? offlineStore.getCollections(collectionType: collectionType)) ?? []
 				var collections = Set(local)
 				continuation.yield(collections)
 
@@ -231,7 +233,9 @@ public final class Offliner {
 
 				while !Task.isCancelled {
 					try? await Task.sleep(nanoseconds: collectionDownloadStatePollInterval)
-					guard !Task.isCancelled else { break }
+					guard !Task.isCancelled else {
+						break
+					}
 
 					let state = await offlineCollectionDownloadState(
 						collectionType: collectionType,
@@ -272,7 +276,7 @@ public final class Offliner {
 				limit: limit,
 				after: cursor
 			)
-		case .title(let direction):
+		case let .title(direction):
 			(page, failures) = try await offlineStore.getCollectionItemsOrderByTitle(
 				collectionType: collectionType,
 				resourceId: resourceId,
@@ -280,7 +284,7 @@ public final class Offliner {
 				limit: limit,
 				after: cursor
 			)
-		case .album(let direction):
+		case let .album(direction):
 			(page, failures) = try await offlineStore.getCollectionItemsOrderByAlbum(
 				collectionType: collectionType,
 				resourceId: resourceId,
@@ -288,7 +292,7 @@ public final class Offliner {
 				limit: limit,
 				after: cursor
 			)
-		case .artist(let direction):
+		case let .artist(direction):
 			(page, failures) = try await offlineStore.getCollectionItemsOrderByArtist(
 				collectionType: collectionType,
 				resourceId: resourceId,
@@ -296,7 +300,7 @@ public final class Offliner {
 				limit: limit,
 				after: cursor
 			)
-		case .dateAdded(let direction):
+		case let .dateAdded(direction):
 			(page, failures) = try await offlineStore.getCollectionItemsOrderByDateAdded(
 				collectionType: collectionType,
 				resourceId: resourceId,
@@ -332,7 +336,9 @@ public final class Offliner {
 	}
 
 	private func scheduleRedownload(for failures: [FailedOfflineItem]) {
-		guard !failures.isEmpty else { return }
+		guard !failures.isEmpty else {
+			return
+		}
 		Task {
 			for failure in failures {
 				try? await download(mediaType: failure.mediaType, resourceId: .identifier(failure.resourceId))
@@ -405,7 +411,7 @@ public final class Offliner {
 	}
 }
 
-// MARK: - OfflineItemProvider
+// MARK: OfflineItemProvider
 
 extension Offliner: OfflineItemProvider {
 	public func get(productType: ProductType, productId: String) async -> OfflinePlaybackItem? {
@@ -432,8 +438,8 @@ extension Offliner: OfflineItemProvider {
 extension OfflineMediaItemType {
 	var toResourceType: ResourceType {
 		switch self {
-		case .tracks: return .track
-		case .videos: return .video
+		case .tracks: .track
+		case .videos: .video
 		}
 	}
 }
@@ -441,9 +447,9 @@ extension OfflineMediaItemType {
 extension OfflineCollectionType {
 	var toResourceType: ResourceType {
 		switch self {
-		case .albums: return .album
-		case .playlists: return .playlist
-		case .userCollectionTracks: return .userCollectionTracks
+		case .albums: .album
+		case .playlists: .playlist
+		case .userCollectionTracks: .userCollectionTracks
 		}
 	}
 }

--- a/Sources/Offliner/Types.swift
+++ b/Sources/Offliner/Types.swift
@@ -196,10 +196,14 @@ public struct OfflineCollection: Hashable {
 	}
 }
 
+// MARK: - SortDirection
+
 public enum SortDirection: Hashable {
 	case ascending
 	case descending
 }
+
+// MARK: - OfflineCollectionItemSort
 
 public enum OfflineCollectionItemSort: Hashable {
 	case title(direction: SortDirection)

--- a/Tests/OfflinerTests/BackendFailureTests.swift
+++ b/Tests/OfflinerTests/BackendFailureTests.swift
@@ -49,7 +49,9 @@ final class BackendFailureTests: OfflinerTestCase {
 		for await download in downloads {
 			let events = download.events
 			await assertEventually(events) { event in
-				if case .state(.completed) = event { return true }
+				if case .state(.completed) = event {
+					return true
+				}
 				return false
 			}
 			break

--- a/Tests/OfflinerTests/CollectionDownloadTests.swift
+++ b/Tests/OfflinerTests/CollectionDownloadTests.swift
@@ -167,7 +167,8 @@ final class CollectionDownloadTests: OfflinerTestCase {
 		await offliner.run()
 		await backend.waitForTasksToComplete()
 
-		let firstCollectionOptional = await offliner.getOfflineCollection(collectionType: .albums, resourceId: .identifier("album-123")).latest()
+		let firstCollectionOptional = await offliner.getOfflineCollection(collectionType: .albums, resourceId: .identifier("album-123"))
+			.latest()
 		let firstCollection = try XCTUnwrap(firstCollectionOptional)
 		let firstArtworkURL = try XCTUnwrap(firstCollection.artworkURL)
 		XCTAssertTrue(FileManager.default.fileExists(atPath: firstArtworkURL.path))
@@ -176,7 +177,8 @@ final class CollectionDownloadTests: OfflinerTestCase {
 		await offliner.run()
 		await backend.waitForTasksToComplete()
 
-		let secondCollectionOptional = await offliner.getOfflineCollection(collectionType: .albums, resourceId: .identifier("album-123")).latest()
+		let secondCollectionOptional = await offliner
+			.getOfflineCollection(collectionType: .albums, resourceId: .identifier("album-123")).latest()
 		let secondCollection = try XCTUnwrap(secondCollectionOptional)
 		let secondArtworkURL = try XCTUnwrap(secondCollection.artworkURL)
 

--- a/Tests/OfflinerTests/CollectionDurationTests.swift
+++ b/Tests/OfflinerTests/CollectionDurationTests.swift
@@ -112,7 +112,9 @@ final class CollectionDurationTests: OfflinerTestCase {
 		var downloadsList: [Download] = []
 		for await download in downloads {
 			downloadsList.append(download)
-			if downloadsList.count == expectedDownloads { break }
+			if downloadsList.count == expectedDownloads {
+				break
+			}
 		}
 
 		await withTaskGroup(of: Void.self) { group in
@@ -120,8 +122,12 @@ final class CollectionDurationTests: OfflinerTestCase {
 				let events = download.events
 				group.addTask {
 					for await event in events {
-						if case .state(.completed) = event { break }
-						if case .state(.failed) = event { break }
+						if case .state(.completed) = event {
+							break
+						}
+						if case .state(.failed) = event {
+							break
+						}
 					}
 				}
 			}

--- a/Tests/OfflinerTests/CollectionItemsTests.swift
+++ b/Tests/OfflinerTests/CollectionItemsTests.swift
@@ -1,11 +1,10 @@
-@testable import Offliner
 import Foundation
 import GRDB
+@testable import Offliner
 import TidalAPI
 import XCTest
 
 final class CollectionItemsTests: OfflinerTestCase {
-
 	// MARK: - Happy Path: Album with tracks
 
 	func testOfflineAlbumWithTracksReturnsAllItems() async throws {
@@ -75,7 +74,9 @@ final class CollectionItemsTests: OfflinerTestCase {
 		)
 
 		XCTAssertEqual(page.items.count, 3, "Album should contain 3 tracks")
-		guard page.items.count == 3 else { return }
+		guard page.items.count == 3 else {
+			return
+		}
 
 		let trackIds = page.items.map(\.item.catalogMetadata.id)
 		XCTAssertEqual(trackIds, ["track-1", "track-2", "track-3"])
@@ -411,7 +412,7 @@ final class CollectionItemsTests: OfflinerTestCase {
 			limit: 10
 		)
 
-		guard case .track(let metadata) = page.items.first?.item.catalogMetadata else {
+		guard case let .track(metadata) = page.items.first?.item.catalogMetadata else {
 			XCTFail("Expected track metadata")
 			return
 		}
@@ -596,7 +597,9 @@ final class CollectionItemsTests: OfflinerTestCase {
 		var downloadsList: [Download] = []
 		for await download in downloads {
 			downloadsList.append(download)
-			if downloadsList.count == expectedDownloads { break }
+			if downloadsList.count == expectedDownloads {
+				break
+			}
 		}
 
 		await withTaskGroup(of: Void.self) { group in
@@ -604,8 +607,12 @@ final class CollectionItemsTests: OfflinerTestCase {
 				let events = download.events
 				group.addTask {
 					for await event in events {
-						if case .state(.completed) = event { break }
-						if case .state(.failed) = event { break }
+						if case .state(.completed) = event {
+							break
+						}
+						if case .state(.failed) = event {
+							break
+						}
 					}
 				}
 			}

--- a/Tests/OfflinerTests/MediaItemDownloadTests.swift
+++ b/Tests/OfflinerTests/MediaItemDownloadTests.swift
@@ -1,5 +1,5 @@
-@testable import Offliner
 import GRDB
+@testable import Offliner
 import XCTest
 
 final class MediaItemDownloadTests: OfflinerTestCase {
@@ -42,7 +42,9 @@ final class MediaItemDownloadTests: OfflinerTestCase {
 		for await download in downloads {
 			let events = download.events
 			await assertEventually(events) { event in
-				if case .state(.completed) = event { return true }
+				if case .state(.completed) = event {
+					return true
+				}
 				return false
 			}
 			break
@@ -66,7 +68,9 @@ final class MediaItemDownloadTests: OfflinerTestCase {
 		for await download in downloads {
 			let events = download.events
 			await assertEventually(events) { event in
-				if case .state(.completed) = event { return true }
+				if case .state(.completed) = event {
+					return true
+				}
 				return false
 			}
 			break
@@ -112,9 +116,9 @@ final class MediaItemDownloadTests: OfflinerTestCase {
 				sql: "SELECT artwork_bookmark FROM offline_item WHERE resource_type = 'tracks' AND resource_id = 'track-123'"
 			)
 		}
-		let embeddedValues = URL.resourceValues(
+		let embeddedValues = try URL.resourceValues(
 			forKeys: [.pathKey, .canonicalPathKey],
-			fromBookmarkData: try XCTUnwrap(renewedBookmark)
+			fromBookmarkData: XCTUnwrap(renewedBookmark)
 		)
 		let embeddedPath = try XCTUnwrap(embeddedValues?.path ?? embeddedValues?.canonicalPath)
 		XCTAssertEqual(URL(fileURLWithPath: embeddedPath).standardizedFileURL.path, movedURL.standardizedFileURL.path)
@@ -172,7 +176,9 @@ final class MediaItemDownloadTests: OfflinerTestCase {
 		for await download in downloads {
 			let events = download.events
 			await assertEventually(events) { event in
-				if case .state(.failed) = event { return true }
+				if case .state(.failed) = event {
+					return true
+				}
 				return false
 			}
 			break
@@ -196,7 +202,9 @@ final class MediaItemDownloadTests: OfflinerTestCase {
 		for await download in downloads {
 			let events = download.events
 			await assertEventually(events) { event in
-				if case .state(.failed) = event { return true }
+				if case .state(.failed) = event {
+					return true
+				}
 				return false
 			}
 			break
@@ -225,7 +233,9 @@ final class MediaItemDownloadTests: OfflinerTestCase {
 		var downloadsList: [Download] = []
 		for await download in downloads {
 			downloadsList.append(download)
-			if downloadsList.count == 3 { break }
+			if downloadsList.count == 3 {
+				break
+			}
 		}
 
 		await withTaskGroup(of: Void.self) { group in
@@ -233,8 +243,12 @@ final class MediaItemDownloadTests: OfflinerTestCase {
 				let events = download.events
 				group.addTask {
 					for await event in events {
-						if case .state(.completed) = event { break }
-						if case .state(.failed) = event { break }
+						if case .state(.completed) = event {
+							break
+						}
+						if case .state(.failed) = event {
+							break
+						}
 					}
 				}
 			}
@@ -270,7 +284,7 @@ final class MediaItemDownloadTests: OfflinerTestCase {
 			let events = download.events
 			var progressValues: [Double] = []
 			for await event in events {
-				if case .progress(let value) = event {
+				if case let .progress(value) = event {
 					progressValues.append(value)
 				}
 				if case .state(.completed) = event {
@@ -299,7 +313,9 @@ final class MediaItemDownloadTests: OfflinerTestCase {
 		for await download in downloads {
 			let events = download.events
 			await assertEventually(events) { event in
-				if case .state(.failed) = event { return true }
+				if case .state(.failed) = event {
+					return true
+				}
 				return false
 			}
 			break
@@ -325,7 +341,9 @@ final class MediaItemDownloadTests: OfflinerTestCase {
 		for await download in downloads {
 			let events = download.events
 			await assertEventually(events) { event in
-				if case .state(.completed) = event { return true }
+				if case .state(.completed) = event {
+					return true
+				}
 				return false
 			}
 			break
@@ -342,5 +360,4 @@ final class MediaItemDownloadTests: OfflinerTestCase {
 			XCTFail("Expected video metadata")
 		}
 	}
-
 }

--- a/Tests/OfflinerTests/OfflinerTestCase.swift
+++ b/Tests/OfflinerTests/OfflinerTestCase.swift
@@ -1,5 +1,5 @@
-@testable import Offliner
 import GRDB
+@testable import Offliner
 import XCTest
 
 class OfflinerTestCase: XCTestCase {
@@ -53,7 +53,9 @@ class OfflinerTestCase: XCTestCase {
 		for await download in downloads {
 			let events = download.events
 			await assertEventually(events) { event in
-				if case .state(.completed) = event { return true }
+				if case .state(.completed) = event {
+					return true
+				}
 				return false
 			}
 			break

--- a/Tests/OfflinerTests/RemoveTests.swift
+++ b/Tests/OfflinerTests/RemoveTests.swift
@@ -119,7 +119,8 @@ final class RemoveTests: OfflinerTestCase {
 		await offliner.run()
 		await backend.waitForTasksToComplete()
 
-		let storedCollectionOptional = await offliner.getOfflineCollection(collectionType: .albums, resourceId: .identifier("album-123")).latest()
+		let storedCollectionOptional = await offliner
+			.getOfflineCollection(collectionType: .albums, resourceId: .identifier("album-123")).latest()
 		let storedCollection = try XCTUnwrap(storedCollectionOptional)
 		let artworkURL = try XCTUnwrap(storedCollection.artworkURL)
 		XCTAssertTrue(FileManager.default.fileExists(atPath: artworkURL.path))

--- a/Tests/OfflinerTests/SearchTests.swift
+++ b/Tests/OfflinerTests/SearchTests.swift
@@ -3,7 +3,6 @@ import TidalAPI
 import XCTest
 
 final class SearchTests: OfflinerTestCase {
-
 	// MARK: - Matching
 
 	func testFindMatchesTitleCaseInsensitively() async throws {
@@ -18,7 +17,8 @@ final class SearchTests: OfflinerTestCase {
 		])
 		try await runAllTasks(offliner, backend: backend, expectedDownloads: 2)
 
-		let hits = try await offliner.findInOfflineCollection(search: "halo", collectionType: .albums, resourceId: .identifier(albumId)).hits
+		let hits = try await offliner.findInOfflineCollection(search: "halo", collectionType: .albums, resourceId: .identifier(albumId))
+			.hits
 		XCTAssertEqual(hits.map(\.item.item.catalogMetadata.id), ["track-1"])
 	}
 
@@ -29,12 +29,27 @@ final class SearchTests: OfflinerTestCase {
 		let albumId = "album-1"
 		backend.enqueueTasks([
 			.storeAlbum(albumTask(id: "task-0", albumId: albumId, title: "Compilation", artistNames: [])),
-			.storeTrack(trackTask(id: "task-1", trackId: "track-1", albumId: albumId, title: "One", artistNames: ["Daft Punk"], position: 1)),
-			.storeTrack(trackTask(id: "task-2", trackId: "track-2", albumId: albumId, title: "Two", artistNames: ["Justice"], position: 2)),
+			.storeTrack(trackTask(
+				id: "task-1",
+				trackId: "track-1",
+				albumId: albumId,
+				title: "One",
+				artistNames: ["Daft Punk"],
+				position: 1
+			)),
+			.storeTrack(trackTask(
+				id: "task-2",
+				trackId: "track-2",
+				albumId: albumId,
+				title: "Two",
+				artistNames: ["Justice"],
+				position: 2
+			)),
 		])
 		try await runAllTasks(offliner, backend: backend, expectedDownloads: 2)
 
-		let hits = try await offliner.findInOfflineCollection(search: "daft", collectionType: .albums, resourceId: .identifier(albumId)).hits
+		let hits = try await offliner.findInOfflineCollection(search: "daft", collectionType: .albums, resourceId: .identifier(albumId))
+			.hits
 		XCTAssertEqual(hits.map(\.item.item.catalogMetadata.id), ["track-1"])
 	}
 
@@ -53,12 +68,20 @@ final class SearchTests: OfflinerTestCase {
 				artistNames: ["Calvin Harris", "Dua Lipa"],
 				position: 1
 			)),
-			.storeTrack(trackTask(id: "task-2", trackId: "track-2", albumId: albumId, title: "Two", artistNames: ["Justice"], position: 2)),
+			.storeTrack(trackTask(
+				id: "task-2",
+				trackId: "track-2",
+				albumId: albumId,
+				title: "Two",
+				artistNames: ["Justice"],
+				position: 2
+			)),
 		])
 		try await runAllTasks(offliner, backend: backend, expectedDownloads: 2)
 
 		// `artist_sort` stores every credited artist as a comma-separated list, so a secondary artist matches too.
-		let hits = try await offliner.findInOfflineCollection(search: "dua", collectionType: .albums, resourceId: .identifier(albumId)).hits
+		let hits = try await offliner.findInOfflineCollection(search: "dua", collectionType: .albums, resourceId: .identifier(albumId))
+			.hits
 		XCTAssertEqual(hits.map(\.item.item.catalogMetadata.id), ["track-1"])
 	}
 
@@ -77,7 +100,8 @@ final class SearchTests: OfflinerTestCase {
 		])
 		try await runAllTasks(offliner, backend: backend, expectedDownloads: 3)
 
-		let hits = try await offliner.findInOfflineCollection(search: "halo", collectionType: .albums, resourceId: .identifier(albumA)).hits
+		let hits = try await offliner.findInOfflineCollection(search: "halo", collectionType: .albums, resourceId: .identifier(albumA))
+			.hits
 		XCTAssertEqual(hits.map(\.item.item.catalogMetadata.id), ["track-A1"])
 	}
 
@@ -88,8 +112,22 @@ final class SearchTests: OfflinerTestCase {
 		let albumId = "album-1"
 		backend.enqueueTasks([
 			.storeAlbum(albumTask(id: "task-0", albumId: albumId, title: "Lemonade", artistNames: ["Beyoncé"])),
-			.storeTrack(trackTask(id: "task-1", trackId: "track-1", albumId: albumId, title: "Halo", artistNames: ["Beyoncé"], position: 1)),
-			.storeTrack(trackTask(id: "task-2", trackId: "track-2", albumId: albumId, title: "Sorry", artistNames: ["Justice"], position: 2)),
+			.storeTrack(trackTask(
+				id: "task-1",
+				trackId: "track-1",
+				albumId: albumId,
+				title: "Halo",
+				artistNames: ["Beyoncé"],
+				position: 1
+			)),
+			.storeTrack(trackTask(
+				id: "task-2",
+				trackId: "track-2",
+				albumId: albumId,
+				title: "Sorry",
+				artistNames: ["Justice"],
+				position: 2
+			)),
 		])
 		try await runAllTasks(offliner, backend: backend, expectedDownloads: 2)
 
@@ -132,7 +170,8 @@ final class SearchTests: OfflinerTestCase {
 		])
 		try await runAllTasks(offliner, backend: backend, expectedDownloads: 1)
 
-		let hits = try await offliner.findInOfflineCollection(search: "halo", collectionType: .albums, resourceId: .identifier(albumId)).hits
+		let hits = try await offliner.findInOfflineCollection(search: "halo", collectionType: .albums, resourceId: .identifier(albumId))
+			.hits
 		XCTAssertTrue(hits.isEmpty)
 	}
 
@@ -147,7 +186,8 @@ final class SearchTests: OfflinerTestCase {
 		])
 		try await runAllTasks(offliner, backend: backend, expectedDownloads: 1)
 
-		let hits = try await offliner.findInOfflineCollection(search: "   ", collectionType: .albums, resourceId: .identifier(albumId)).hits
+		let hits = try await offliner.findInOfflineCollection(search: "   ", collectionType: .albums, resourceId: .identifier(albumId))
+			.hits
 		XCTAssertTrue(hits.isEmpty)
 	}
 
@@ -162,7 +202,8 @@ final class SearchTests: OfflinerTestCase {
 		])
 		try await runAllTasks(offliner, backend: backend, expectedDownloads: 1)
 
-		var hits = try await offliner.findInOfflineCollection(search: "halo", collectionType: .albums, resourceId: .identifier(albumId)).hits
+		var hits = try await offliner.findInOfflineCollection(search: "halo", collectionType: .albums, resourceId: .identifier(albumId))
+			.hits
 		XCTAssertEqual(hits.count, 1)
 
 		backend.enqueueTasks([.removeItem(RemoveItemTask(
@@ -174,7 +215,8 @@ final class SearchTests: OfflinerTestCase {
 		))])
 		try await runAllTasks(offliner, backend: backend, expectedDownloads: 0)
 
-		hits = try await offliner.findInOfflineCollection(search: "halo", collectionType: .albums, resourceId: .identifier(albumId)).hits
+		hits = try await offliner.findInOfflineCollection(search: "halo", collectionType: .albums, resourceId: .identifier(albumId))
+			.hits
 		XCTAssertTrue(hits.isEmpty)
 	}
 
@@ -195,7 +237,11 @@ final class SearchTests: OfflinerTestCase {
 		backend.enqueueTasks(enqueued)
 		try await runAllTasks(offliner, backend: backend, expectedDownloads: 10)
 
-		let hits = try await offliner.findInOfflineCollection(search: "needle", collectionType: .albums, resourceId: .identifier(albumId)).hits
+		let hits = try await offliner.findInOfflineCollection(
+			search: "needle",
+			collectionType: .albums,
+			resourceId: .identifier(albumId)
+		).hits
 		let hit = try XCTUnwrap(hits.first)
 		XCTAssertEqual(hit.item.item.catalogMetadata.id, "track-7")
 
@@ -278,7 +324,8 @@ final class SearchTests: OfflinerTestCase {
 		backend.enqueueTasks(enqueued)
 		try await runAllTasks(offliner, backend: backend, expectedDownloads: 25)
 
-		let hits = try await offliner.findInOfflineCollection(search: "song", collectionType: .albums, resourceId: .identifier(albumId)).hits
+		let hits = try await offliner.findInOfflineCollection(search: "song", collectionType: .albums, resourceId: .identifier(albumId))
+			.hits
 		XCTAssertEqual(hits.count, 20)
 	}
 
@@ -321,7 +368,11 @@ final class SearchTests: OfflinerTestCase {
 		backend.enqueueTasks(enqueued)
 		try await runAllTasks(offliner, backend: backend, expectedDownloads: 25)
 
-		let first = try await offliner.findInOfflineCollection(search: "song", collectionType: .albums, resourceId: .identifier(albumId))
+		let first = try await offliner.findInOfflineCollection(
+			search: "song",
+			collectionType: .albums,
+			resourceId: .identifier(albumId)
+		)
 		XCTAssertEqual(first.hits.count, 20)
 		let cursor = try XCTUnwrap(first.cursor)
 
@@ -368,7 +419,9 @@ final class SearchTests: OfflinerTestCase {
 				limit: 2,
 				after: cursor
 			)
-			if page.hits.isEmpty { break }
+			if page.hits.isEmpty {
+				break
+			}
 			pageSizes.append(page.hits.count)
 			collected += page.hits.map(\.item.item.catalogMetadata.id)
 			cursor = page.cursor
@@ -396,7 +449,9 @@ final class SearchTests: OfflinerTestCase {
 			var downloadsList: [Download] = []
 			for await download in downloads {
 				downloadsList.append(download)
-				if downloadsList.count == expectedDownloads { break }
+				if downloadsList.count == expectedDownloads {
+					break
+				}
 			}
 
 			await withTaskGroup(of: Void.self) { group in
@@ -404,8 +459,12 @@ final class SearchTests: OfflinerTestCase {
 					let events = download.events
 					group.addTask {
 						for await event in events {
-							if case .state(.completed) = event { break }
-							if case .state(.failed) = event { break }
+							if case .state(.completed) = event {
+								break
+							}
+							if case .state(.failed) = event {
+								break
+							}
 						}
 					}
 				}

--- a/Tests/OfflinerTests/TestFakes.swift
+++ b/Tests/OfflinerTests/TestFakes.swift
@@ -1,9 +1,9 @@
-@testable import Offliner
 import AVFoundation
 import Foundation
+@testable import Offliner
 import TidalAPI
 
-// MARK: - Backend Client Fakes
+// MARK: - StubOfflineApiClient
 
 final class StubOfflineApiClient: OfflineApiClientProtocol {
 	struct RecordedItem {
@@ -152,7 +152,9 @@ final class StubOfflineApiClient: OfflineApiClientProtocol {
 		type: OfflineCollectionType,
 		cursor: String?
 	) async throws -> (collections: [OfflineCollection], cursor: String?) {
-		guard !pendingCollectionsPages.isEmpty else { return ([], nil) }
+		guard !pendingCollectionsPages.isEmpty else {
+			return ([], nil)
+		}
 		return pendingCollectionsPages.removeFirst()
 	}
 
@@ -166,6 +168,8 @@ final class StubOfflineApiClient: OfflineApiClientProtocol {
 		return pendingCollection
 	}
 }
+
+// MARK: - FailingOfflineApiClient
 
 final class FailingOfflineApiClient: OfflineApiClientProtocol {
 	func addItem(type: ResourceType, id: String) async throws {
@@ -184,6 +188,8 @@ final class FailingOfflineApiClient: OfflineApiClientProtocol {
 		throw FakeError.backendFailed
 	}
 }
+
+// MARK: - FailOnUpdateToInProgressOfflineApiClient
 
 actor FailOnUpdateToInProgressOfflineApiClient: OfflineApiClientProtocol {
 	private let stub = StubOfflineApiClient()
@@ -221,6 +227,8 @@ actor FailOnUpdateToInProgressOfflineApiClient: OfflineApiClientProtocol {
 	}
 }
 
+// MARK: - FailOnUpdateToCompletedOfflineApiClient
+
 final class FailOnUpdateToCompletedOfflineApiClient: OfflineApiClientProtocol {
 	private let stub = StubOfflineApiClient()
 
@@ -244,6 +252,8 @@ final class FailOnUpdateToCompletedOfflineApiClient: OfflineApiClientProtocol {
 	}
 }
 
+// MARK: - FailOnGetTasksOfflineApiClient
+
 final class FailOnGetTasksOfflineApiClient: OfflineApiClientProtocol {
 	func addItem(type: ResourceType, id: String) async throws {}
 
@@ -256,7 +266,7 @@ final class FailOnGetTasksOfflineApiClient: OfflineApiClientProtocol {
 	func updateTask(taskId: String, state: Download.State) async throws {}
 }
 
-// MARK: - Artwork Downloader Fakes
+// MARK: - SucceedingArtworkDownloader
 
 final class SucceedingArtworkDownloader: ArtworkDownloaderProtocol {
 	func downloadArtwork(for artwork: ArtworksResourceObject?) async throws -> URL? {
@@ -267,11 +277,15 @@ final class SucceedingArtworkDownloader: ArtworkDownloaderProtocol {
 	}
 }
 
+// MARK: - FailingArtworkDownloader
+
 final class FailingArtworkDownloader: ArtworkDownloaderProtocol {
 	func downloadArtwork(for artwork: ArtworksResourceObject?) async throws -> URL? {
 		throw FakeError.artworkDownloadFailed
 	}
 }
+
+// MARK: - SuspendingArtworkDownloader
 
 actor SuspendingArtworkDownloader: ArtworkDownloaderProtocol {
 	private var startedContinuation: CheckedContinuation<Void, Never>?
@@ -310,7 +324,7 @@ actor SuspendingArtworkDownloader: ArtworkDownloaderProtocol {
 	}
 }
 
-// MARK: - Media Downloader Fakes
+// MARK: - SucceedingMediaDownloader
 
 final class SucceedingMediaDownloader: MediaDownloaderProtocol {
 	var progressValues: [Double] = []
@@ -339,6 +353,8 @@ final class SucceedingMediaDownloader: MediaDownloaderProtocol {
 	}
 }
 
+// MARK: - FailingMediaDownloader
+
 final class FailingMediaDownloader: MediaDownloaderProtocol {
 	func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void) {}
 
@@ -352,6 +368,8 @@ final class FailingMediaDownloader: MediaDownloaderProtocol {
 		throw FakeError.downloadFailed
 	}
 }
+
+// MARK: - SuspendingMediaDownloader
 
 actor SuspendingMediaDownloader: MediaDownloaderProtocol {
 	private var startedContinuation: CheckedContinuation<Void, Never>?
@@ -399,7 +417,7 @@ actor SuspendingMediaDownloader: MediaDownloaderProtocol {
 	}
 }
 
-// MARK: - Manifest Fetcher Fakes
+// MARK: - SucceedingTrackManifestFetcher
 
 final class SucceedingTrackManifestFetcher: TrackManifestFetcherProtocol {
 	var audioFormats: [AudioFormat] = [.heaacv1]
@@ -413,6 +431,8 @@ final class SucceedingTrackManifestFetcher: TrackManifestFetcherProtocol {
 	}
 }
 
+// MARK: - SucceedingVideoManifestFetcher
+
 final class SucceedingVideoManifestFetcher: VideoManifestFetcherProtocol {
 	func fetchVideoManifest(videoId: String) async throws -> ManifestFetchResult {
 		ManifestFetchResult(
@@ -423,7 +443,7 @@ final class SucceedingVideoManifestFetcher: VideoManifestFetcherProtocol {
 	}
 }
 
-// MARK: - Errors
+// MARK: - FakeError
 
 enum FakeError: Error {
 	case backendFailed


### PR DESCRIPTION
## What
Format-only pass over the whole Offliner module (sources + tests) with the pre-commit-pinned SwiftFormat 0.54.6. No functional changes — `git diff -w` noise only (wrapping, trailing commas, whitespace).

## Why
`main` is not clean under the pinned SwiftFormat, so any Offliner PR touching these files absorbs unrelated formatting churn from the pre-commit hook. Landing the churn once here keeps every subsequent PR in the TM-1573 stack reviewable at its true size.

## Stack
This stack replaces the monolithic #413 with reviewable slices. Each PR targets the previous one; merge in order.

1. #438 Format Offliner module (this PR, targets `main`)
2. #439 Player decoupling + offline playback asset API
3. #440 watchOS 10 enablement + media download modernization
4. #441 Installation-scoped storage + reset lifecycle
5. #442 Backend task-state ingestion
6. #443 Resource state API
7. #444 Download queue observation

The final tree of #444 is byte-identical to the trimmed reference of the #413 feature (simulator scaffolding, preview-manifest rejection, and corrupt-asset replacement scheduling were cut as not needed by the Watch client; they can land as small follow-ups if wanted).

## Testing
`xcodebuild test -scheme Offliner -destination platform=macOS` — all tests pass at every layer of the stack (80 → 100 → 112 tests as suites are added).