### PR TITLE
TM-1573: Decouple Offliner from Player and add offline playback asset API

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -163,7 +163,6 @@ let package = Package(
 				.GRDB,
 				.tidalAPI,
 				.auth,
-				.player,
 			],
 			exclude: [
 				"README.md",

--- a/Sources/Offliner/Internal/OfflineStore.swift
+++ b/Sources/Offliner/Internal/OfflineStore.swift
@@ -262,7 +262,7 @@ final class OfflineStore {
 		return item
 	}
 
-	func getPlayableMediaItem(mediaType: OfflineMediaItemType, resourceId: String) async throws -> PlayableOfflineMediaItem? {
+	func getPlaybackAsset(mediaType: OfflineMediaItemType, resourceId: String) async throws -> OfflinePlaybackAsset? {
 		let row = try await databaseQueue.read { database in
 			try Row.fetchOne(
 				database,
@@ -282,7 +282,7 @@ final class OfflineStore {
 		let playbackMetadataJson: String? = row["playback_metadata"]
 
 		var renewals: [BookmarkRenewal] = []
-		let item = try PlayableOfflineMediaItem(
+		let item = try OfflinePlaybackAsset(
 			playbackMetadata: playbackMetadataJson.map { try OfflineMediaItem.PlaybackMetadata.deserialize($0) },
 			mediaURL: Self.resolveBookmark(row, column: "media_bookmark", renewals: &renewals),
 			licenseURL: Self.resolveBookmarkIfPresent(row, column: "license_bookmark", renewals: &renewals)

--- a/Sources/Offliner/OfflinePlaybackAVAsset.swift
+++ b/Sources/Offliner/OfflinePlaybackAVAsset.swift
@@ -1,0 +1,108 @@
+import AVFoundation
+import Foundation
+
+// MARK: - OfflinePlaybackAVAssetError
+
+/// An error encountered while preparing a stored asset for AVFoundation playback.
+enum OfflinePlaybackAVAssetError: Error, Equatable {
+	case storedLicenseNotFound(URL)
+	case storedLicenseUnreadable(URL)
+}
+
+// MARK: - OfflinePlaybackAVAsset
+
+/// An AVFoundation asset prepared for offline playback.
+///
+/// This object owns the URL asset and, for protected media, the FairPlay content-key session, delegate, delegate queue,
+/// and stored license data. Retain this object for as long as any `AVPlayerItem` created from `urlAsset` is queued or
+/// playing. `AVPlayerItem` does not retain this playback preparation context for you.
+public final class OfflinePlaybackAVAsset {
+	public let urlAsset: AVURLAsset
+
+	private let contentKeySession: AVContentKeySession?
+	private let contentKeySessionDelegate: StoredOfflineLicenseDelegate?
+	private let contentKeyDelegateQueue: DispatchQueue?
+
+	var usesStoredLicense: Bool {
+		contentKeySession != nil
+	}
+
+	init(playbackAsset: OfflinePlaybackAsset) throws {
+		let urlAsset = AVURLAsset(url: playbackAsset.mediaURL)
+		guard let licenseURL = playbackAsset.licenseURL else {
+			self.urlAsset = urlAsset
+			contentKeySession = nil
+			contentKeySessionDelegate = nil
+			contentKeyDelegateQueue = nil
+			return
+		}
+
+		var isDirectory: ObjCBool = false
+		guard FileManager.default.fileExists(atPath: licenseURL.path, isDirectory: &isDirectory) else {
+			throw OfflinePlaybackAVAssetError.storedLicenseNotFound(licenseURL)
+		}
+		guard !isDirectory.boolValue else {
+			throw OfflinePlaybackAVAssetError.storedLicenseUnreadable(licenseURL)
+		}
+
+		let license: Data
+		do {
+			license = try Data(contentsOf: licenseURL)
+		} catch {
+			throw OfflinePlaybackAVAssetError.storedLicenseUnreadable(licenseURL)
+		}
+		guard !license.isEmpty else {
+			throw OfflinePlaybackAVAssetError.storedLicenseUnreadable(licenseURL)
+		}
+
+		let delegate = StoredOfflineLicenseDelegate(license: license)
+		let delegateQueue = DispatchQueue(label: "com.tidal.offliner.stored-license")
+		let session = AVContentKeySession(keySystem: .fairPlayStreaming)
+		session.setDelegate(delegate, queue: delegateQueue)
+		session.addContentKeyRecipient(urlAsset)
+
+		self.urlAsset = urlAsset
+		contentKeySession = session
+		contentKeySessionDelegate = delegate
+		contentKeyDelegateQueue = delegateQueue
+	}
+}
+
+// MARK: - StoredOfflineLicenseDelegate
+
+private final class StoredOfflineLicenseDelegate: NSObject, AVContentKeySessionDelegate {
+	private let license: Data
+
+	init(license: Data) {
+		self.license = license
+	}
+
+	func contentKeySession(
+		_ session: AVContentKeySession,
+		didProvide keyRequest: AVContentKeyRequest
+	) {
+		do {
+			#if os(iOS)
+				try keyRequest.respondByRequestingPersistableContentKeyRequestAndReturnError()
+			#else
+				try keyRequest.respondByRequestingPersistableContentKeyRequest()
+			#endif
+		} catch {
+			keyRequest.processContentKeyResponseError(error)
+		}
+	}
+
+	func contentKeySession(
+		_ session: AVContentKeySession,
+		didProvide keyRequest: AVPersistableContentKeyRequest
+	) {
+		let response = AVContentKeyResponse(fairPlayStreamingKeyResponseData: license)
+		keyRequest.processContentKeyResponse(response)
+	}
+
+	func contentKeySession(
+		_ session: AVContentKeySession,
+		contentKeyRequest keyRequest: AVContentKeyRequest,
+		didFailWithError error: Error
+	) {}
+}

--- a/Sources/Offliner/Offliner.swift
+++ b/Sources/Offliner/Offliner.swift
@@ -1,6 +1,5 @@
 import Foundation
 import GRDB
-import Player
 
 // MARK: - Offliner
 
@@ -129,6 +128,31 @@ public final class Offliner {
 		}
 
 		return items
+	}
+
+	/// Returns the locally playable asset for an offlined track or video.
+	///
+	/// File bookmarks are resolved only for playback so enumerating offline content remains fast. If a stored file can no
+	/// longer be resolved, this method returns `nil`.
+	public func getOfflinePlaybackAsset(
+		mediaType: OfflineMediaItemType,
+		resourceId: ResourceId
+	) async -> OfflinePlaybackAsset? {
+		try? await offlineStore.getPlaybackAsset(mediaType: mediaType, resourceId: resourceId.stringValue)
+	}
+
+	/// Returns an AVFoundation asset prepared for unprotected or stored-license playback.
+	///
+	/// Retain the returned object for the entire lifetime of every `AVPlayerItem` made from its `urlAsset`, including while
+	/// queued. If stored playback files or license preparation cannot be resolved, this returns `nil`.
+	public func getOfflinePlaybackAVAsset(
+		mediaType: OfflineMediaItemType,
+		resourceId: ResourceId
+	) async -> OfflinePlaybackAVAsset? {
+		guard let playbackAsset = await getOfflinePlaybackAsset(mediaType: mediaType, resourceId: resourceId) else {
+			return nil
+		}
+		return try? OfflinePlaybackAVAsset(playbackAsset: playbackAsset)
 	}
 
 	public func getOfflineCollection(
@@ -411,28 +435,6 @@ public final class Offliner {
 	}
 }
 
-// MARK: OfflineItemProvider
-
-extension Offliner: OfflineItemProvider {
-	public func get(productType: ProductType, productId: String) async -> OfflinePlaybackItem? {
-		let mediaType: OfflineMediaItemType
-		switch productType {
-		case .TRACK: mediaType = .tracks
-		case .VIDEO: mediaType = .videos
-		case .UC: return nil
-		}
-
-		do {
-			return try await offlineStore.getPlayableMediaItem(mediaType: mediaType, resourceId: productId)
-				.map { OfflinePlaybackItem($0, productType: productType) }
-		} catch {
-			Task { try? await download(mediaType: mediaType, resourceId: .identifier(productId)) }
-		}
-
-		return nil
-	}
-}
-
 // MARK: - Internal Mappings
 
 extension OfflineMediaItemType {
@@ -451,20 +453,5 @@ extension OfflineCollectionType {
 		case .playlists: .playlist
 		case .userCollectionTracks: .userCollectionTracks
 		}
-	}
-}
-
-// MARK: - OfflinePlaybackItem from PlayableOfflineMediaItem
-
-private extension OfflinePlaybackItem {
-	init(_ item: PlayableOfflineMediaItem, productType: ProductType) {
-		self.init(
-			mediaURL: item.mediaURL,
-			licenseURL: item.licenseURL,
-			format: item.playbackMetadata?.format.rawValue,
-			albumReplayGain: item.playbackMetadata?.albumNormalizationData?.replayGain,
-			albumPeakAmplitude: item.playbackMetadata?.albumNormalizationData?.peakAmplitude,
-			productType: productType
-		)
 	}
 }

--- a/Sources/Offliner/README.md
+++ b/Sources/Offliner/README.md
@@ -161,7 +161,7 @@ Retrieve a specific offline media item:
 
 ```swift
 if let track = try await offliner.getOfflineMediaItem(mediaType: .tracks, resourceId: "track-id") {
-    // Access mediaURL, licenseURL, artworkURL, catalogMetadata, and playbackMetadata
+    // Access artworkURL, catalogMetadata, and playbackMetadata without resolving playback files
 }
 ```
 
@@ -322,11 +322,85 @@ Removal requests are registered with the backend and task processing is triggere
 
 ## Offline Playback
 
-Offliner conforms to `OfflineItemProvider` (from the Player module), so it can be used directly as the offline content source for the Player:
+Offliner exposes a Player-independent playback asset lookup. The lookup resolves the stored media and license file bookmarks only when playback is requested:
 
 ```swift
-let item = await offliner.get(productType: .TRACK, productId: "track-id")
-// Returns an OfflinePlaybackItem with mediaURL, licenseURL, format, and normalization data
+let asset = await offliner.getOfflinePlaybackAsset(
+    mediaType: .tracks,
+    resourceId: .identifier("track-id")
+)
+// Returns mediaURL, licenseURL, and playback metadata, or nil when no playable asset is stored.
+```
+
+On watchOS, do not create a plain `AVURLAsset` from `mediaURL` when `licenseURL` is present. Prepare the asset through
+Offliner so protected downloads receive their persisted FairPlay license:
+
+```swift
+import AVFoundation
+import Offliner
+
+final class QueuedOfflinePlayback {
+    // Retain this wrapper for the entire lifetime of playerItem, including while it is queued.
+    let preparedAsset: OfflinePlaybackAVAsset
+    let playerItem: AVPlayerItem
+
+    init(preparedAsset: OfflinePlaybackAVAsset) {
+        self.preparedAsset = preparedAsset
+        playerItem = AVPlayerItem(asset: preparedAsset.urlAsset)
+    }
+}
+
+guard let preparedAsset = await offliner.getOfflinePlaybackAVAsset(
+    mediaType: .tracks,
+    resourceId: .identifier("track-id")
+) else {
+    // The item is unavailable locally.
+    return
+}
+
+let queuedPlayback = QueuedOfflinePlayback(preparedAsset: preparedAsset)
+player.insert(queuedPlayback.playerItem, after: nil)
+// Keep queuedPlayback alive until its playerItem has been removed from the queue.
+```
+
+`getOfflinePlaybackAVAsset` is the supported watchOS lookup. `OfflinePlaybackAVAsset` creates no content-key session for
+unprotected media. For protected media it loads the stored
+license, creates an `AVContentKeySession(.fairPlayStreaming)`, installs the stored-license delegate, and registers its
+`urlAsset` as the content-key recipient. If preparation fails, the lookup returns `nil`.
+Real FairPlay playback remains part of TM-1574 device validation.
+
+Offliner has no dependency on the Player module because Player does not support watchOS. Consumers that use Player can declare the `OfflineItemProvider` conformance in a target that links both products:
+
+```swift
+import Offliner
+import Player
+
+extension Offliner: @retroactive OfflineItemProvider {
+    public func get(productType: ProductType, productId: String) async -> OfflinePlaybackItem? {
+        let mediaType: OfflineMediaItemType
+        switch productType {
+        case .TRACK: mediaType = .tracks
+        case .VIDEO: mediaType = .videos
+        case .UC: return nil
+        }
+
+        guard let asset = await getOfflinePlaybackAsset(
+            mediaType: mediaType,
+            resourceId: .identifier(productId)
+        ) else {
+            return nil
+        }
+
+        return OfflinePlaybackItem(
+            mediaURL: asset.mediaURL,
+            licenseURL: asset.licenseURL,
+            format: asset.playbackMetadata?.format.rawValue,
+            albumReplayGain: asset.playbackMetadata?.albumNormalizationData?.replayGain,
+            albumPeakAmplitude: asset.playbackMetadata?.albumNormalizationData?.peakAmplitude,
+            productType: productType
+        )
+    }
+}
 ```
 
 ---

--- a/Sources/Offliner/Types.swift
+++ b/Sources/Offliner/Types.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Player
 
 // MARK: - OfflineMediaItemType
 
@@ -79,12 +78,22 @@ public struct OfflineMediaItem {
 	public let artworkURL: URL?
 }
 
-// MARK: - PlayableOfflineMediaItem
+// MARK: - OfflinePlaybackAsset
 
-struct PlayableOfflineMediaItem {
-	let playbackMetadata: OfflineMediaItem.PlaybackMetadata?
-	let mediaURL: URL
-	let licenseURL: URL?
+public struct OfflinePlaybackAsset {
+	public let playbackMetadata: OfflineMediaItem.PlaybackMetadata?
+	public let mediaURL: URL
+	public let licenseURL: URL?
+
+	public init(
+		playbackMetadata: OfflineMediaItem.PlaybackMetadata?,
+		mediaURL: URL,
+		licenseURL: URL?
+	) {
+		self.playbackMetadata = playbackMetadata
+		self.mediaURL = mediaURL
+		self.licenseURL = licenseURL
+	}
 }
 
 // MARK: - OfflineCollectionState

--- a/Tests/OfflinerTests/CollectionItemsTests.swift
+++ b/Tests/OfflinerTests/CollectionItemsTests.swift
@@ -125,7 +125,10 @@ final class CollectionItemsTests: OfflinerTestCase {
 		backend.enqueueTasks(tasks)
 		try await runAllTasks(offliner, backend: backend, expectedDownloads: 3)
 
-		let storedPlayableItem = await offliner.get(productType: .TRACK, productId: "track-2")
+		let storedPlayableItem = await offliner.getOfflinePlaybackAsset(
+			mediaType: .tracks,
+			resourceId: .identifier("track-2")
+		)
 		let mediaURL = try XCTUnwrap(storedPlayableItem?.mediaURL)
 		try FileManager.default.removeItem(at: mediaURL)
 
@@ -136,7 +139,10 @@ final class CollectionItemsTests: OfflinerTestCase {
 		)
 
 		XCTAssertEqual(page.items.map(\.item.catalogMetadata.id), ["track-1", "track-2", "track-3"])
-		let playableItem = await offliner.get(productType: .TRACK, productId: "track-2")
+		let playableItem = await offliner.getOfflinePlaybackAsset(
+			mediaType: .tracks,
+			resourceId: .identifier("track-2")
+		)
 		XCTAssertNil(playableItem)
 	}
 

--- a/Tests/OfflinerTests/MediaItemDownloadTests.swift
+++ b/Tests/OfflinerTests/MediaItemDownloadTests.swift
@@ -136,7 +136,10 @@ final class MediaItemDownloadTests: OfflinerTestCase {
 
 		let firstItem = try await offliner.getOfflineMediaItem(mediaType: .tracks, resourceId: .identifier("track-123"))
 		let firstItemUnwrapped = try XCTUnwrap(firstItem)
-		let firstPlayableItem = await offliner.get(productType: .TRACK, productId: "track-123")
+		let firstPlayableItem = await offliner.getOfflinePlaybackAsset(
+			mediaType: .tracks,
+			resourceId: .identifier("track-123")
+		)
 		let firstMediaURL = try XCTUnwrap(firstPlayableItem?.mediaURL)
 		let firstArtworkURL = try XCTUnwrap(firstItemUnwrapped.artworkURL)
 		XCTAssertTrue(FileManager.default.fileExists(atPath: firstMediaURL.path))
@@ -147,7 +150,10 @@ final class MediaItemDownloadTests: OfflinerTestCase {
 
 		let secondItem = try await offliner.getOfflineMediaItem(mediaType: .tracks, resourceId: .identifier("track-123"))
 		let secondItemUnwrapped = try XCTUnwrap(secondItem)
-		let secondPlayableItem = await offliner.get(productType: .TRACK, productId: "track-123")
+		let secondPlayableItem = await offliner.getOfflinePlaybackAsset(
+			mediaType: .tracks,
+			resourceId: .identifier("track-123")
+		)
 		let secondMediaURL = try XCTUnwrap(secondPlayableItem?.mediaURL)
 		let secondArtworkURL = try XCTUnwrap(secondItemUnwrapped.artworkURL)
 

--- a/Tests/OfflinerTests/OfflinePlaybackAVAssetTests.swift
+++ b/Tests/OfflinerTests/OfflinePlaybackAVAssetTests.swift
@@ -1,0 +1,112 @@
+import AVFoundation
+import Foundation
+@testable import Offliner
+import XCTest
+
+final class OfflinePlaybackAVAssetTests: OfflinerTestCase {
+	func testUnprotectedAssetUsesPlainURLAsset() throws {
+		let mediaURL = tempDir.appendingPathComponent("media.movpkg")
+		let preparedAsset = try OfflinePlaybackAVAsset(playbackAsset: playbackAsset(
+			mediaURL: mediaURL,
+			licenseURL: nil
+		))
+
+		XCTAssertEqual(preparedAsset.urlAsset.url, mediaURL)
+		XCTAssertFalse(preparedAsset.usesStoredLicense)
+	}
+
+	func testProtectedAssetRetainsStoredLicenseContext() throws {
+		#if targetEnvironment(simulator)
+			throw XCTSkip("AVContentKeySession FairPlay construction is unavailable on simulators")
+		#else
+			let mediaURL = tempDir.appendingPathComponent("media.movpkg")
+			let licenseURL = tempDir.appendingPathComponent("license.key")
+			try Data([0x01, 0x02, 0x03]).write(to: licenseURL)
+
+			let preparedAsset = try OfflinePlaybackAVAsset(playbackAsset: playbackAsset(
+				mediaURL: mediaURL,
+				licenseURL: licenseURL
+			))
+
+			XCTAssertEqual(preparedAsset.urlAsset.url, mediaURL)
+			XCTAssertTrue(preparedAsset.usesStoredLicense)
+		#endif
+	}
+
+	func testProtectedAssetRejectsMissingStoredLicense() {
+		let licenseURL = tempDir.appendingPathComponent("missing.key")
+
+		XCTAssertThrowsError(try OfflinePlaybackAVAsset(playbackAsset: playbackAsset(
+			mediaURL: tempDir.appendingPathComponent("media.movpkg"),
+			licenseURL: licenseURL
+		))) { error in
+			XCTAssertEqual(error as? OfflinePlaybackAVAssetError, .storedLicenseNotFound(licenseURL))
+		}
+	}
+
+	func testProtectedAssetRejectsUnreadableStoredLicense() throws {
+		let licenseURL = tempDir.appendingPathComponent("license.key", isDirectory: true)
+		try FileManager.default.createDirectory(at: licenseURL, withIntermediateDirectories: true)
+
+		XCTAssertThrowsError(try OfflinePlaybackAVAsset(playbackAsset: playbackAsset(
+			mediaURL: tempDir.appendingPathComponent("media.movpkg"),
+			licenseURL: licenseURL
+		))) { error in
+			XCTAssertEqual(error as? OfflinePlaybackAVAssetError, .storedLicenseUnreadable(licenseURL))
+		}
+	}
+
+	func testProtectedAssetRejectsEmptyStoredLicense() throws {
+		let licenseURL = tempDir.appendingPathComponent("license.key")
+		try Data().write(to: licenseURL)
+
+		XCTAssertThrowsError(try OfflinePlaybackAVAsset(playbackAsset: playbackAsset(
+			mediaURL: tempDir.appendingPathComponent("media.movpkg"),
+			licenseURL: licenseURL
+		))) { error in
+			XCTAssertEqual(error as? OfflinePlaybackAVAssetError, .storedLicenseUnreadable(licenseURL))
+		}
+	}
+
+	func testPreparedLookupReturnsNilForCorruptStoredLicense() async throws {
+		let offliner = createOffliner(
+			offlineApiClient: StubOfflineApiClient(),
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SuspendingMediaDownloader()
+		)
+		let mediaURL = tempDir.appendingPathComponent("track.movpkg")
+		let licenseURL = tempDir.appendingPathComponent("track.key")
+		try Data("media".utf8).write(to: mediaURL)
+		try Data().write(to: licenseURL)
+		let store = OfflineStore(lastDatabaseQueue)
+		try store.storeMediaItem(StoreItemTaskResult(
+			resourceType: OfflineMediaItemType.tracks.rawValue,
+			resourceId: "track-id",
+			catalogMetadata: .track(.mock(id: "track-id")),
+			playbackMetadata: nil,
+			collectionResourceType: OfflineCollectionType.albums.rawValue,
+			collectionResourceId: "album-id",
+			volume: 1,
+			position: 1,
+			addedAt: nil,
+			mediaURL: mediaURL,
+			licenseURL: licenseURL,
+			artworkURL: nil
+		))
+
+		let preparedAsset = await offliner.getOfflinePlaybackAVAsset(
+			mediaType: .tracks,
+			resourceId: .identifier("track-id")
+		)
+
+		XCTAssertNil(preparedAsset)
+	}
+
+	private func playbackAsset(mediaURL: URL, licenseURL: URL?) -> OfflinePlaybackAsset {
+		OfflinePlaybackAsset(
+			playbackMetadata: nil,
+			mediaURL: mediaURL,
+			licenseURL: licenseURL
+		)
+	}
+}

--- a/Tests/OfflinerTests/RemoveTests.swift
+++ b/Tests/OfflinerTests/RemoveTests.swift
@@ -40,7 +40,10 @@ final class RemoveTests: OfflinerTestCase {
 
 		let storedItemOptional = try await offliner.getOfflineMediaItem(mediaType: .tracks, resourceId: .identifier("track-123"))
 		let storedItem = try XCTUnwrap(storedItemOptional)
-		let playableItem = await offliner.get(productType: .TRACK, productId: "track-123")
+		let playableItem = await offliner.getOfflinePlaybackAsset(
+			mediaType: .tracks,
+			resourceId: .identifier("track-123")
+		)
 		let mediaURL = try XCTUnwrap(playableItem?.mediaURL)
 		let artworkURL = try XCTUnwrap(storedItem.artworkURL)
 		XCTAssertTrue(FileManager.default.fileExists(atPath: mediaURL.path))


### PR DESCRIPTION
## What
- Removes Offliner's dependency on the Player module (`Package.swift` target deps).
- Replaces the Player-typed `OfflineItemProvider` integration with a Player-independent public API:
  - `OfflinePlaybackAsset` (public struct: playback metadata + media/license URLs)
  - `Offliner.getOfflinePlaybackAsset(mediaType:resourceId:)`
  - `Offliner.getOfflinePlaybackAVAsset(...)` — prepared `AVURLAsset` lookup with stored-license validation (returns `nil` for corrupt licenses instead of vending an unplayable asset)
- README documents the new lookup and how apps keep Player integration via a `@retroactive OfflineItemProvider` conformance on the app side.

## Why
The Watch client consumes offline playback through `getOfflinePlaybackAVAsset`/`OfflinePlaybackAsset` without linking Player. Decoupling is also what makes the next PR's watchOS platform enablement possible, since Player does not build for watchOS.

## Stack
PR 2/7 of the TM-1573 stack replacing #413. Targets the format-only base PR #438. Next: watchOS enablement.

## Testing
`xcodebuild test -scheme Offliner -destination platform=macOS` — 80 tests, 0 failures. Existing tests using the removed `OfflineItemProvider` API converted to the new lookup.