### PR TITLE
TM-1573: Enable watchOS 10 and modernize media downloads

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.8
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import class Foundation.ProcessInfo
@@ -15,7 +15,7 @@ let package = Package(
 		.iOS(.v15),
 		.macOS(.v12),
 		.tvOS(.v15),
-		.watchOS(.v7),
+		.watchOS(.v10),
 	],
 	products: [
 		.library(

--- a/Sources/Offliner/Internal/MediaDownloader.swift
+++ b/Sources/Offliner/Internal/MediaDownloader.swift
@@ -78,24 +78,20 @@ final class MediaDownloader: NSObject, MediaDownloaderProtocol {
 
 		return try await withCheckedThrowingContinuation { continuation in
 			queue.async {
-				guard let task = self.session.makeAssetDownloadTask(
-					asset: asset,
-					assetTitle: title,
-					assetArtworkData: nil,
-					options: nil
-				) else {
-					continuation.resume(throwing: MediaDownloaderError.failedToCreateTask)
-					return
-				}
+				let downloadConfiguration = AVAssetDownloadConfiguration(asset: asset, title: title)
+				let task = self.session.makeAssetDownloadTask(downloadConfiguration: downloadConfiguration)
 
 				let activeDownload = ActiveDownload(
 					duration: duration,
-					continuation: continuation,
-					onProgress: onProgress
+					continuation: continuation
 				)
 
 				task.taskDescription = taskId
 				task.priority = 1.0
+
+				activeDownload.progressObservation = task.progress.observe(\.fractionCompleted) { progress, _ in
+					Task { await onProgress(progress.fractionCompleted) }
+				}
 
 				self.activeDownloads[task.taskIdentifier] = activeDownload
 				task.resume()
@@ -115,12 +111,29 @@ extension MediaDownloader: AVAssetDownloadDelegate {
 		didFinishDownloadingTo location: URL
 	) {
 		Self.logger.debug("didFinishDownloadingTo called [task: \(assetDownloadTask.taskDescription ?? "?", privacy: .public)]")
+		recordDownloadedLocation(location, for: assetDownloadTask, deleteIfOrphaned: true)
+	}
 
+	@available(iOS 18.0, macOS 14.0, watchOS 10.0, *)
+	func urlSession(
+		_ session: URLSession,
+		assetDownloadTask: AVAssetDownloadTask,
+		willDownloadTo location: URL
+	) {
+		Self.logger.debug("willDownloadTo called [task: \(assetDownloadTask.taskDescription ?? "?", privacy: .public)]")
+		recordDownloadedLocation(location, for: assetDownloadTask, deleteIfOrphaned: false)
+	}
+
+	private func recordDownloadedLocation(
+		_ location: URL,
+		for assetDownloadTask: AVAssetDownloadTask,
+		deleteIfOrphaned: Bool
+	) {
 		guard let activeDownload = activeDownloads[assetDownloadTask.taskIdentifier] else {
-			Self.logger
-				.debug("orphaned didFinishDownloadingTo called [task: \(assetDownloadTask.taskDescription ?? "?", privacy: .public)]")
-
-			try? FileStorage.delete(url: location)
+			Self.logger.debug("orphaned download location [task: \(assetDownloadTask.taskDescription ?? "?", privacy: .public)]")
+			if deleteIfOrphaned {
+				try? FileStorage.delete(url: location)
+			}
 			return
 		}
 
@@ -143,6 +156,8 @@ extension MediaDownloader: AVAssetDownloadDelegate {
 			return
 		}
 
+		activeDownload.progressObservation?.invalidate()
+
 		if let error {
 			try? activeDownload.downloadedLocation.map(FileStorage.delete)
 			activeDownload.continuation.resume(throwing: error)
@@ -162,22 +177,6 @@ extension MediaDownloader: AVAssetDownloadDelegate {
 		activeDownload.continuation.resume(returning: result)
 	}
 
-	func urlSession(
-		_ session: URLSession,
-		assetDownloadTask: AVAssetDownloadTask,
-		didLoad timeRange: CMTimeRange,
-		totalTimeRangesLoaded loadedTimeRanges: [NSValue],
-		timeRangeExpectedToLoad: CMTimeRange
-	) {
-		let loaded = loadedTimeRanges.reduce(0.0) { $0 + CMTimeGetSeconds($1.timeRangeValue.duration) }
-		let expected = CMTimeGetSeconds(timeRangeExpectedToLoad.duration)
-		let progress = expected > 0 ? loaded / expected : 0
-
-		if let onProgress = activeDownloads[assetDownloadTask.taskIdentifier]?.onProgress {
-			Task { await onProgress(progress) }
-		}
-	}
-
 	func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
 		Self.logger.debug("urlSessionDidFinishEvents forBackgroundURLSession")
 		DispatchQueue.main.async { [weak self] in
@@ -192,25 +191,22 @@ extension MediaDownloader: AVAssetDownloadDelegate {
 private final class ActiveDownload {
 	let duration: Int
 	let continuation: CheckedContinuation<MediaDownloadResult, Error>
-	let onProgress: @Sendable (Double) async -> Void
 
 	var downloadedLocation: URL?
+	var progressObservation: NSKeyValueObservation?
 
 	init(
 		duration: Int,
-		continuation: CheckedContinuation<MediaDownloadResult, Error>,
-		onProgress: @escaping @Sendable (Double) async -> Void
+		continuation: CheckedContinuation<MediaDownloadResult, Error>
 	) {
 		self.duration = duration
 		self.continuation = continuation
-		self.onProgress = onProgress
 	}
 }
 
 // MARK: - MediaDownloaderError
 
 enum MediaDownloaderError: Error {
-	case failedToCreateTask
 	case noDownloadedFile
 	case manifestNotFound
 }

--- a/Sources/Offliner/README.md
+++ b/Sources/Offliner/README.md
@@ -403,6 +403,10 @@ extension Offliner: @retroactive OfflineItemProvider {
 }
 ```
 
+## Platform Support
+
+Offliner supports iOS 15+, macOS 12+, and watchOS 10+. Its shared download pipeline uses `AVAssetDownloadConfiguration`, KVO progress observation, and the platform-appropriate asset location delegate callback.
+
 ---
 
 ## Architecture


### PR DESCRIPTION
## What
- `Package.swift`: swift-tools-version 5.9 and `.watchOS(.v10)` platform.
- `MediaDownloader`: migrates to watch-compatible AVFoundation download APIs:
  - `AVAssetDownloadConfiguration(asset:title:)` + `makeAssetDownloadTask(downloadConfiguration:)` (non-optional; removes the `failedToCreateTask` path)
  - Progress via KVO on `task.progress.fractionCompleted` (replaces the iOS-only `didLoad timeRange` delegate)
  - `willDownloadTo` delegate (iOS 18/macOS 14/watchOS 10) to record the destination early
- README gains a Platform Support section.

## Why
The legacy `AVAssetDownloadTask` creation and time-range progress APIs are unavailable on watchOS. These replacements are the minimal API surface that builds and runs on watchOS 10 while keeping identical behavior on iOS/macOS.

Verified: `xcodebuild build -scheme Offliner -destination 'generic/platform=watchOS Simulator'` — BUILD SUCCEEDED.

## Stack
PR 3/7 of the TM-1573 stack replacing #413. Next: installation-scoped storage + reset lifecycle.

## Testing
`xcodebuild test -scheme Offliner -destination platform=macOS` — all tests pass; watchOS simulator build verified.