### PR TITLE
TM-1573: Add installation-scoped storage and local-only reset lifecycle

### DIFF
--- a/Sources/Offliner/Internal/ArtworkDownloader.swift
+++ b/Sources/Offliner/Internal/ArtworkDownloader.swift
@@ -11,8 +11,10 @@ protocol ArtworkDownloaderProtocol {
 
 final class ArtworkDownloader: ArtworkDownloaderProtocol {
 	private let urlSession: URLSession
+	private let fileStorage: FileStorage
 
-	init(urlSession: URLSession = .shared) {
+	init(fileStorage: FileStorage, urlSession: URLSession = .shared) {
+		self.fileStorage = fileStorage
 		self.urlSession = urlSession
 	}
 
@@ -42,7 +44,8 @@ final class ArtworkDownloader: ArtworkDownloaderProtocol {
 		let fileExtension = imageURL.pathExtension.isEmpty ? "jpg" : imageURL.pathExtension
 		let filename = "\(UUID().uuidString).\(fileExtension)"
 
-		return try FileStorage.move(from: tempURL, subdirectory: "Artworks", filename: filename)
+		try Task.checkCancellation()
+		return try fileStorage.move(from: tempURL, subdirectory: "Artworks", filename: filename)
 	}
 }
 

--- a/Sources/Offliner/Internal/FileStorage.swift
+++ b/Sources/Offliner/Internal/FileStorage.swift
@@ -2,15 +2,29 @@ import Foundation
 
 // MARK: - FileStorage
 
-enum FileStorage {
-	static func store(_ data: Data, subdirectory: String, filename: String) throws -> URL {
+final class FileStorage {
+	let rootDirectory: URL
+	private let writeLock = NSLock()
+	private var acceptsWrites = true
+
+	init(rootDirectory: URL) {
+		self.rootDirectory = rootDirectory
+	}
+
+	func store(_ data: Data, subdirectory: String, filename: String) throws -> URL {
+		writeLock.lock()
+		defer { writeLock.unlock() }
+		try ensureAcceptsWrites()
 		let dir = try directory(for: subdirectory)
 		let url = dir.appendingPathComponent(filename)
 		try data.write(to: url, options: .atomic)
 		return url
 	}
 
-	static func move(from source: URL, subdirectory: String, filename: String) throws -> URL {
+	func move(from source: URL, subdirectory: String, filename: String) throws -> URL {
+		writeLock.lock()
+		defer { writeLock.unlock() }
+		try ensureAcceptsWrites()
 		let dir = try directory(for: subdirectory)
 		let destination = dir.appendingPathComponent(filename)
 		_ = try FileManager.default.replaceItemAt(destination, withItemAt: source)
@@ -32,12 +46,20 @@ enum FileStorage {
 		try delete(url: url)
 	}
 
-	private static func directory(for subdirectory: String) throws -> URL {
-		let appSupportURLs = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
-		guard let appSupportDirectory = appSupportURLs.first else {
-			throw FileStorageError.noApplicationSupportDirectory
+	func invalidateWrites() {
+		writeLock.lock()
+		acceptsWrites = false
+		writeLock.unlock()
+	}
+
+	private func ensureAcceptsWrites() throws {
+		guard acceptsWrites else {
+			throw OfflinerLifecycleError.reset
 		}
-		let directory = appSupportDirectory.appendingPathComponent("Offliner/\(subdirectory)", isDirectory: true)
+	}
+
+	private func directory(for subdirectory: String) throws -> URL {
+		let directory = rootDirectory.appendingPathComponent(subdirectory, isDirectory: true)
 		try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
 		return directory
 	}

--- a/Sources/Offliner/Internal/LicenseDownloader.swift
+++ b/Sources/Offliner/Internal/LicenseDownloader.swift
@@ -14,15 +14,23 @@ struct LicenseDownloadResult {
 
 actor LicenseDownloader {
 	private let httpClient: HttpClient
+	private let fileStorage: FileStorage
 	private let queue = DispatchQueue(label: "com.tidal.offliner.license-downloader")
 	private var certificate: Data?
 	private var certificateTask: Task<Data, Error>?
+	private var activeDownloads: [UUID: ActiveLicenseDownload] = [:]
+	private var isCancelled = false
 
-	init() {
+	init(fileStorage: FileStorage) {
 		httpClient = HttpClient()
+		self.fileStorage = fileStorage
 	}
 
 	func downloadLicense(drmData: DrmData?) async throws -> LicenseDownloadResult? {
+		try Task.checkCancellation()
+		guard !isCancelled else {
+			throw CancellationError()
+		}
 		guard let keyIdentifier = drmData?.initData?.first,
 		      let certificateURLString = drmData?.certificateUrl,
 		      let certificateURL = URL(string: certificateURLString),
@@ -37,22 +45,46 @@ actor LicenseDownloader {
 		let delegate = ActiveLicenseDownload(
 			certificate: certificate,
 			httpClient: httpClient,
-			licenseURL: licenseURL
+			licenseURL: licenseURL,
+			fileStorage: fileStorage
 		)
+		let downloadId = UUID()
+		activeDownloads[downloadId] = delegate
 
-		let storedLicenseURL: URL = try await withCheckedThrowingContinuation { continuation in
-			self.queue.async {
-				delegate.setContinuation(continuation)
-				contentKeySession.setDelegate(delegate, queue: self.queue)
-				contentKeySession.processContentKeyRequest(
-					withIdentifier: keyIdentifier,
-					initializationData: nil,
-					options: nil
-				)
+		let storedLicenseURL: URL
+		do {
+			storedLicenseURL = try await withTaskCancellationHandler {
+				try await withCheckedThrowingContinuation { continuation in
+					self.queue.async {
+						delegate.setContinuation(continuation)
+						contentKeySession.setDelegate(delegate, queue: self.queue)
+						contentKeySession.processContentKeyRequest(
+							withIdentifier: keyIdentifier,
+							initializationData: nil,
+							options: nil
+						)
+					}
+				}
+			} onCancel: {
+				delegate.cancel()
 			}
+		} catch {
+			activeDownloads.removeValue(forKey: downloadId)
+			throw error
 		}
+		activeDownloads.removeValue(forKey: downloadId)
 
 		return LicenseDownloadResult(contentKeySession: contentKeySession, licenseURL: storedLicenseURL)
+	}
+
+	func cancelAll() {
+		isCancelled = true
+		certificateTask?.cancel()
+		certificateTask = nil
+		for download in activeDownloads.values {
+			download.cancel()
+		}
+		activeDownloads.removeAll()
 	}
 
 	private func getCertificate(url: URL) async throws -> Data {
@@ -88,17 +120,25 @@ private final class ActiveLicenseDownload: NSObject {
 	let certificate: Data
 	let httpClient: HttpClient
 	let licenseURL: URL
+	let fileStorage: FileStorage
 	private let continuationLock = NSLock()
 	private var continuation: CheckedContinuation<URL, Error>?
+	private var isCancelled = false
 
-	init(certificate: Data, httpClient: HttpClient, licenseURL: URL) {
+	init(certificate: Data, httpClient: HttpClient, licenseURL: URL, fileStorage: FileStorage) {
 		self.certificate = certificate
 		self.httpClient = httpClient
 		self.licenseURL = licenseURL
+		self.fileStorage = fileStorage
 	}
 
 	func setContinuation(_ continuation: CheckedContinuation<URL, Error>) {
 		continuationLock.lock()
+		guard !isCancelled else {
+			continuationLock.unlock()
+			continuation.resume(throwing: CancellationError())
+			return
+		}
 		self.continuation = continuation
 		continuationLock.unlock()
 	}
@@ -117,6 +157,15 @@ private final class ActiveLicenseDownload: NSObject {
 		}
 
 		continuation.resume(throwing: error)
+	}
+
+	func cancel() {
+		continuationLock.lock()
+		isCancelled = true
+		let continuation = continuation
+		self.continuation = nil
+		continuationLock.unlock()
+		continuation?.resume(throwing: CancellationError())
 	}
 
 	private func takeContinuation() -> CheckedContinuation<URL, Error>? {
@@ -158,7 +207,8 @@ extension ActiveLicenseDownload: AVContentKeySessionDelegate {
 				let license = try await fetchLicense(spc: spc)
 				let persistableKey = try keyRequest.persistableContentKey(fromKeyVendorResponse: license)
 
-				let url = try FileStorage.store(
+				try Task.checkCancellation()
+				let url = try fileStorage.store(
 					persistableKey,
 					subdirectory: "Licenses",
 					filename: "\(UUID().uuidString).key"

--- a/Sources/Offliner/Internal/MediaDownloader.swift
+++ b/Sources/Offliner/Internal/MediaDownloader.swift
@@ -21,24 +21,30 @@ protocol MediaDownloaderProtocol {
 		onProgress: @escaping @Sendable (Double) async -> Void
 	) async throws -> MediaDownloadResult
 
-	func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void)
+	func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void) -> Bool
+	func cancelAll() async
 }
 
 // MARK: - MediaDownloader
 
 final class MediaDownloader: NSObject, MediaDownloaderProtocol {
 	private static let logger = Logger(subsystem: "com.tidal.sdk.offliner", category: "MediaDownloader")
-	static let backgroundSessionIdentifier = "com.tidal.offliner.download.session"
+	let backgroundSessionIdentifier: String
 
 	private let queue: DispatchQueue
+	private let fileStorage: FileStorage
 	private var session: AVAssetDownloadURLSession!
 	private var activeDownloads: [Int: ActiveDownload] = [:]
 	private var backgroundCompletionHandler: (() -> Void)?
+	private let cancellationLock = NSLock()
+	private var isCancelled = false
 
 	var orphanedTaskHandler: ((String?) -> Void)?
 
-	init(configuration: Configuration) {
+	init(configuration: Configuration, backgroundSessionIdentifier: String, fileStorage: FileStorage) {
 		queue = DispatchQueue(label: "com.tidal.offliner.media-downloader", qos: .userInitiated)
+		self.backgroundSessionIdentifier = backgroundSessionIdentifier
+		self.fileStorage = fileStorage
 
 		super.init()
 
@@ -47,19 +53,34 @@ final class MediaDownloader: NSObject, MediaDownloaderProtocol {
 		delegateQueue.maxConcurrentOperationCount = 1
 
 		session = AVAssetDownloadURLSession(
-			configuration: URLSessionConfiguration.background(withIdentifier: Self.backgroundSessionIdentifier),
+			configuration: URLSessionConfiguration.background(withIdentifier: backgroundSessionIdentifier),
 			assetDownloadDelegate: self,
 			delegateQueue: delegateQueue
 		)
 	}
 
-	func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void) {
+	func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void) -> Bool {
+		guard identifier == backgroundSessionIdentifier else {
+			return false
+		}
 		DispatchQueue.main.async {
-			guard identifier == Self.backgroundSessionIdentifier else {
-				return
-			}
 			self.backgroundCompletionHandler = completionHandler
 		}
+		return true
+	}
+
+	func cancelAll() async {
+		invalidate()
+		let tasks = await session.allTasks
+		for task in tasks {
+			task.cancel()
+		}
+	}
+
+	private func invalidate() {
+		cancellationLock.lock()
+		isCancelled = true
+		cancellationLock.unlock()
 	}
 
 	func download(
@@ -75,9 +96,17 @@ final class MediaDownloader: NSObject, MediaDownloaderProtocol {
 		licenseDownloadResult?.contentKeySession.addContentKeyRecipient(asset)
 
 		let duration = try await Int(CMTimeGetSeconds(asset.load(.duration)))
+		try Task.checkCancellation()
 
 		return try await withCheckedThrowingContinuation { continuation in
 			queue.async {
+				self.cancellationLock.lock()
+				let isCancelled = self.isCancelled
+				self.cancellationLock.unlock()
+				guard !isCancelled else {
+					continuation.resume(throwing: CancellationError())
+					return
+				}
 				let downloadConfiguration = AVAssetDownloadConfiguration(asset: asset, title: title)
 				let task = self.session.makeAssetDownloadTask(downloadConfiguration: downloadConfiguration)
 

--- a/Sources/Offliner/Internal/OfflineStore.swift
+++ b/Sources/Offliner/Internal/OfflineStore.swift
@@ -5,6 +5,8 @@ import GRDB
 
 final class OfflineStore {
 	private let databaseQueue: DatabaseQueue
+	private let writeLock = NSLock()
+	private var acceptsWrites = true
 
 	static func searchKey(_ value: String) -> String {
 		value.lowercased().folding(options: .diacriticInsensitive, locale: Locale(identifier: "en_US_POSIX"))
@@ -25,21 +27,14 @@ final class OfflineStore {
 		return try DatabaseQueue(path: path, configuration: configuration)
 	}
 
-	static func url() throws -> URL {
-		let appSupportURLs = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
-		guard let appSupportDirectory = appSupportURLs.first else {
-			throw FileStorageError.noApplicationSupportDirectory
-		}
-		let directory = appSupportDirectory.appendingPathComponent("Offliner", isDirectory: true)
-		try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-		return directory.appendingPathComponent("offline.sqlite")
-	}
-
 	init(_ databaseQueue: DatabaseQueue) {
 		self.databaseQueue = databaseQueue
 	}
 
 	func storeMediaItem(_ result: StoreItemTaskResult) throws {
+		writeLock.lock()
+		defer { writeLock.unlock() }
+		try ensureAcceptsWritesLocked()
 		let catalogMetadataJson = try result.catalogMetadata.serialize()
 		let playbackMetadataJson = try result.playbackMetadata?.serialize()
 
@@ -121,6 +116,9 @@ final class OfflineStore {
 	}
 
 	func storeCollection(_ result: StoreCollectionTaskResult) throws {
+		writeLock.lock()
+		defer { writeLock.unlock() }
+		try ensureAcceptsWritesLocked()
 		let catalogMetadataJson = try result.catalogMetadata.serialize()
 		let artworkBookmark = try result.artworkURL.map { try Self.makeBookmark(for: $0) }
 
@@ -152,6 +150,9 @@ final class OfflineStore {
 	}
 
 	func deleteCollection(resourceType: String, resourceId: String) throws {
+		writeLock.lock()
+		defer { writeLock.unlock() }
+		try ensureAcceptsWritesLocked()
 		var bookmarksToDelete: [Data] = []
 
 		try databaseQueue.inTransaction { database in
@@ -179,6 +180,9 @@ final class OfflineStore {
 		fromCollection collectionType: String,
 		collectionId: String
 	) throws {
+		writeLock.lock()
+		defer { writeLock.unlock() }
+		try ensureAcceptsWritesLocked()
 		var bookmarksToDelete: [Data] = []
 
 		try databaseQueue.inTransaction { database in
@@ -754,6 +758,36 @@ final class OfflineStore {
 		return ["media_bookmark", "license_bookmark", "artwork_bookmark"].compactMap { row?[$0] as Data? }
 	}
 
+	func invalidateWrites() {
+		writeLock.lock()
+		acceptsWrites = false
+		writeLock.unlock()
+	}
+
+	func allBookmarks() throws -> [Data] {
+		try databaseQueue.read { database in
+			let rows = try Row.fetchAll(
+				database,
+				sql: "SELECT media_bookmark, license_bookmark, artwork_bookmark FROM offline_item"
+			)
+			return rows.flatMap { row in
+				["media_bookmark", "license_bookmark", "artwork_bookmark"].compactMap { row[$0] as Data? }
+			}
+		}
+	}
+
+	private func ensureAcceptsWritesLocked() throws {
+		guard acceptsWrites else {
+			throw OfflinerLifecycleError.reset
+		}
+	}
+
+	private func ensureAcceptsWrites() throws {
+		writeLock.lock()
+		defer { writeLock.unlock() }
+		try ensureAcceptsWritesLocked()
+	}
+
 	private func deleteFiles(for bookmarks: [Data]) {
 		for bookmarkData in bookmarks {
 			try? FileStorage.delete(bookmark: bookmarkData)
@@ -1061,6 +1095,7 @@ extension OfflineStore {
 		guard !renewals.isEmpty else {
 			return
 		}
+		try ensureAcceptsWrites()
 
 		let chunkSize = 300
 

--- a/Sources/Offliner/Internal/OfflinerStorage.swift
+++ b/Sources/Offliner/Internal/OfflinerStorage.swift
@@ -1,0 +1,94 @@
+import CryptoKit
+import Foundation
+import GRDB
+
+final class OfflinerStorage {
+	private static let legacyResetLock = NSLock()
+	private static let rootName = "Offliner"
+	private static let accountsName = "Accounts"
+	private static let legacyMigrationMarker = ".account-scoped-storage-v1"
+
+	let rootDirectory: URL
+	let databaseQueue: DatabaseQueue
+	let offlineStore: OfflineStore
+	let fileStorage: FileStorage
+	let backgroundSessionIdentifier: String
+
+	init(installationId: String, baseDirectory: URL? = nil) throws {
+		let baseDirectory = try baseDirectory ?? Self.applicationSupportDirectory()
+		let offlinerRoot = baseDirectory.appendingPathComponent(Self.rootName, isDirectory: true)
+		let scope = Self.scope(for: installationId)
+		rootDirectory = offlinerRoot
+			.appendingPathComponent(Self.accountsName, isDirectory: true)
+			.appendingPathComponent(scope, isDirectory: true)
+		try FileManager.default.createDirectory(at: rootDirectory, withIntermediateDirectories: true)
+		try Self.migrateLegacyStorageIfNeeded(at: offlinerRoot, to: rootDirectory, scope: scope)
+
+		databaseQueue = try OfflineStore.makeDatabaseQueue(
+			path: rootDirectory.appendingPathComponent("offline.sqlite").path
+		)
+		try Migrations.run(databaseQueue)
+		offlineStore = OfflineStore(databaseQueue)
+		fileStorage = FileStorage(rootDirectory: rootDirectory.appendingPathComponent("Artifacts", isDirectory: true))
+		backgroundSessionIdentifier = "com.tidal.offliner.download.\(scope.prefix(32))"
+	}
+
+	func reset() throws {
+		let bookmarks = (try? offlineStore.allBookmarks()) ?? []
+		for bookmark in bookmarks {
+			try? FileStorage.delete(bookmark: bookmark)
+		}
+		try databaseQueue.close()
+		try? FileManager.default.removeItem(at: rootDirectory)
+	}
+
+	func invalidateWrites() {
+		offlineStore.invalidateWrites()
+		fileStorage.invalidateWrites()
+	}
+
+	private static func applicationSupportDirectory() throws -> URL {
+		guard let directory = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
+			throw FileStorageError.noApplicationSupportDirectory
+		}
+		return directory
+	}
+
+	private static func scope(for installationId: String) -> String {
+		SHA256.hash(data: Data(installationId.utf8)).map { String(format: "%02x", $0) }.joined()
+	}
+
+	private static func migrateLegacyStorageIfNeeded(at root: URL, to accountRoot: URL, scope: String) throws {
+		legacyResetLock.lock()
+		defer { legacyResetLock.unlock() }
+
+		try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+		let marker = root.appendingPathComponent(legacyMigrationMarker)
+		guard !FileManager.default.fileExists(atPath: marker.path) else {
+			return
+		}
+
+		for name in ["offline.sqlite", "offline.sqlite-shm", "offline.sqlite-wal"] {
+			let source = root.appendingPathComponent(name)
+			let destination = accountRoot.appendingPathComponent(name)
+			if FileManager.default.fileExists(atPath: source.path),
+			   !FileManager.default.fileExists(atPath: destination.path)
+			{
+				try FileManager.default.moveItem(at: source, to: destination)
+			}
+		}
+
+		let artifactsRoot = accountRoot.appendingPathComponent("Artifacts", isDirectory: true)
+		try FileManager.default.createDirectory(at: artifactsRoot, withIntermediateDirectories: true)
+		for name in ["Artworks", "Licenses"] {
+			let source = root.appendingPathComponent(name, isDirectory: true)
+			let destination = artifactsRoot.appendingPathComponent(name, isDirectory: true)
+			if FileManager.default.fileExists(atPath: source.path),
+			   !FileManager.default.fileExists(atPath: destination.path)
+			{
+				try FileManager.default.moveItem(at: source, to: destination)
+			}
+		}
+		try Data(scope.utf8).write(to: marker, options: .atomic)
+	}
+}

--- a/Sources/Offliner/Internal/TaskRunner.swift
+++ b/Sources/Offliner/Internal/TaskRunner.swift
@@ -19,6 +19,8 @@ actor TaskRunner {
 
 	private let offlineApiClient: OfflineApiClientProtocol
 	private let network: Network
+	private let mediaDownloader: MediaDownloaderProtocol
+	private let licenseDownloader: LicenseDownloader
 
 	private var pendingTasks: [InternalTask] = []
 	private var runningTasks: [InternalTask] = []
@@ -26,6 +28,7 @@ actor TaskRunner {
 
 	private var processTask: Task<Void, Never>?
 	private var rerunRequested = false
+	private var isShutdown = false
 
 	private(set) var currentDownloads: [Download] = []
 	private var downloadsContinuation: AsyncStream<Download>.Continuation?
@@ -47,6 +50,8 @@ actor TaskRunner {
 		self.offlineApiClient = offlineApiClient
 		allowDownloadsOnExpensiveNetworks = configuration.allowDownloadsOnExpensiveNetworks
 		network = Network()
+		self.mediaDownloader = mediaDownloader
+		self.licenseDownloader = licenseDownloader
 
 		let (stream, continuation) = AsyncStream<Download>.makeStream()
 		newDownloads = stream
@@ -86,6 +91,9 @@ actor TaskRunner {
 	}
 
 	func run() {
+		guard !isShutdown else {
+			return
+		}
 		guard processTask == nil else {
 			rerunRequested = true
 			return
@@ -101,6 +109,9 @@ actor TaskRunner {
 	}
 
 	func setAllowDownloadsOnExpensiveNetworks(_ allowed: Bool) {
+		guard !isShutdown else {
+			return
+		}
 		allowDownloadsOnExpensiveNetworks = allowed
 		if allowed {
 			run()
@@ -108,13 +119,47 @@ actor TaskRunner {
 	}
 
 	func hasCurrentDownload(relatedTo collectionType: OfflineCollectionType, resourceId: ResourceId) -> Bool {
+		guard !isShutdown else {
+			return false
+		}
 		let collection = OfflineCollectionReference(collectionType: collectionType, resourceId: resourceId)
 		return pendingTasks.contains { $0.isDownloadTask(for: collection) } ||
 			runningTasks.contains { $0.isDownloadTask(for: collection) }
 	}
 
+	func shutdown() async {
+		guard !isShutdown else {
+			if let processTask {
+				await processTask.value
+			}
+			return
+		}
+
+		isShutdown = true
+		rerunRequested = false
+		let task = processTask
+		task?.cancel()
+		await mediaDownloader.cancelAll()
+		await licenseDownloader.cancelAll()
+		await task?.value
+		pendingTasks.removeAll()
+		runningTasks.removeAll()
+		taskIds.removeAll()
+		currentDownloads.removeAll()
+		downloadsContinuation?.finish()
+		downloadsContinuation = nil
+	}
+
 	private func refresh() async throws {
+		try Task.checkCancellation()
+		guard !isShutdown else {
+			return
+		}
 		let (tasks, _) = try await offlineApiClient.getTasks(cursor: nil)
+		try Task.checkCancellation()
+		guard !isShutdown else {
+			return
+		}
 
 		for task in tasks where taskIds.insert(task.id).inserted {
 			let pendingTask = handle(task)
@@ -139,18 +184,25 @@ actor TaskRunner {
 	}
 
 	private func process() async {
+		guard !isShutdown, !Task.isCancelled else {
+			return
+		}
 		if pendingTasks.count < Self.refreshThreshold {
 			try? await refresh()
 		}
 
 		await withTaskGroup(of: Void.self) { group in
-			for _ in 0 ..< Self.maxConcurrentTasks {
+			for _ in 0 ..< Self.maxConcurrentTasks where !Task.isCancelled && !isShutdown {
 				if let task = getTask() {
 					group.addTask { await self.start(task) }
 				}
 			}
 
 			for await _ in group {
+				guard !Task.isCancelled, !isShutdown else {
+					group.cancelAll()
+					continue
+				}
 				if pendingTasks.count < Self.refreshThreshold {
 					try? await refresh()
 				}
@@ -163,6 +215,9 @@ actor TaskRunner {
 	}
 
 	private func getTask() -> InternalTask? {
+		guard !isShutdown, !Task.isCancelled else {
+			return nil
+		}
 		let runningKeys = Set(runningTasks.map(\.concurrencyKey))
 
 		guard let index = pendingTasks.firstIndex(where: { !runningKeys.contains($0.concurrencyKey) }) else {
@@ -175,8 +230,17 @@ actor TaskRunner {
 	}
 
 	private func start(_ task: InternalTask) async {
+		guard !isShutdown, !Task.isCancelled else {
+			finish(task)
+			return
+		}
 		while !allowDownloadsOnExpensiveNetworks, await !(network.isInexpensive) {
-			try? await Task.sleep(nanoseconds: 1_000_000_000)
+			do {
+				try await Task.sleep(nanoseconds: 1_000_000_000)
+			} catch {
+				finish(task)
+				return
+			}
 		}
 
 		do {
@@ -192,9 +256,20 @@ actor TaskRunner {
 
 		do {
 			try await task.run()
+			try Task.checkCancellation()
+			guard !isShutdown else {
+				throw CancellationError()
+			}
 			await task.download?.updateState(.completed)
 			try? await offlineApiClient.updateTask(taskId: task.id, state: .completed)
+		} catch is CancellationError {
+			finish(task)
+			return
 		} catch {
+			guard !isShutdown, !Task.isCancelled else {
+				finish(task)
+				return
+			}
 			Self.logger.error("Task \(task.id, privacy: .public) failed: \(error, privacy: .public)")
 			await task.download?.updateState(.failed)
 			try? await offlineApiClient.updateTask(taskId: task.id, state: .failed)

--- a/Sources/Offliner/Offliner.swift
+++ b/Sources/Offliner/Offliner.swift
@@ -8,10 +8,14 @@ public final class Offliner {
 
 	private let offlineApiClient: OfflineApiClientProtocol
 	private let offlineStore: OfflineStore
+	private let storage: OfflinerStorage
 	private let taskRunner: TaskRunner
 	private let mediaDownloader: MediaDownloaderProtocol
 	private let collectionDownloadStatePollInterval: UInt64
 	private var trackManifestFetcher: TrackManifestFetcherProtocol
+	private let lifecycleLock = NSLock()
+	private var isReset = false
+	private var resetTask: Task<Void, Error>?
 
 	public var audioFormats: [AudioFormat] {
 		didSet {
@@ -20,6 +24,9 @@ public final class Offliner {
 	}
 
 	public func setAllowDownloadsOnExpensiveNetworks(_ allowed: Bool) async {
+		guard isActive else {
+			return
+		}
 		await taskRunner.setAllowDownloadsOnExpensiveNetworks(allowed)
 	}
 
@@ -33,24 +40,34 @@ public final class Offliner {
 		}
 	}
 
-	public func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void) {
-		mediaDownloader.handleBackgroundURLSessionEvents(identifier: identifier, completionHandler: completionHandler)
+	@discardableResult
+	public func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void) -> Bool {
+		guard isActive else {
+			return false
+		}
+		return mediaDownloader.handleBackgroundURLSessionEvents(
+			identifier: identifier,
+			completionHandler: completionHandler
+		)
 	}
 
 	public init(installationId: String, configuration: Configuration) throws {
-		let databaseQueue = try OfflineStore.makeDatabaseQueue(path: OfflineStore.url().path)
-		try Migrations.run(databaseQueue)
-
-		let offlineStore = OfflineStore(databaseQueue)
+		let storage = try OfflinerStorage(installationId: installationId)
+		let offlineStore = storage.offlineStore
 		let offlineApiClient = OfflineApiClient(installationId: installationId)
-		let artworkDownloader = ArtworkDownloader()
-		let mediaDownloader = MediaDownloader(configuration: configuration)
-		let licenseDownloader = LicenseDownloader()
+		let artworkDownloader = ArtworkDownloader(fileStorage: storage.fileStorage)
+		let mediaDownloader = MediaDownloader(
+			configuration: configuration,
+			backgroundSessionIdentifier: storage.backgroundSessionIdentifier,
+			fileStorage: storage.fileStorage
+		)
+		let licenseDownloader = LicenseDownloader(fileStorage: storage.fileStorage)
 		let trackManifestFetcher = TrackManifestFetcher(audioFormats: configuration.audioFormats)
 		let videoManifestFetcher = VideoManifestFetcher()
 
 		self.offlineApiClient = offlineApiClient
 		self.offlineStore = offlineStore
+		self.storage = storage
 		self.mediaDownloader = mediaDownloader
 		collectionDownloadStatePollInterval = Self.defaultCollectionDownloadStatePollInterval
 		self.trackManifestFetcher = trackManifestFetcher
@@ -67,11 +84,17 @@ public final class Offliner {
 		)
 
 		mediaDownloader.orphanedTaskHandler = { [weak self] taskId in
-			guard let self, let taskId else {
+			guard let self, isActive, let taskId else {
 				return
 			}
 			Task {
+				guard self.isActive else {
+					return
+				}
 				try? await self.offlineApiClient.updateTask(taskId: taskId, state: .failed)
+				guard self.isActive else {
+					return
+				}
 				await self.run()
 			}
 		}
@@ -79,17 +102,20 @@ public final class Offliner {
 
 	init(
 		configuration: Configuration = Configuration(),
+		storage: OfflinerStorage,
 		offlineApiClient: OfflineApiClientProtocol,
-		offlineStore: OfflineStore,
 		artworkDownloader: ArtworkDownloaderProtocol,
 		mediaDownloader: MediaDownloaderProtocol,
-		licenseDownloader: LicenseDownloader = LicenseDownloader(),
+		licenseDownloader: LicenseDownloader? = nil,
 		trackManifestFetcher: TrackManifestFetcherProtocol,
 		videoManifestFetcher: VideoManifestFetcherProtocol,
 		collectionDownloadStatePollInterval: UInt64 = Offliner.defaultCollectionDownloadStatePollInterval
 	) {
+		let offlineStore = storage.offlineStore
+		let licenseDownloader = licenseDownloader ?? LicenseDownloader(fileStorage: storage.fileStorage)
 		self.offlineApiClient = offlineApiClient
 		self.offlineStore = offlineStore
+		self.storage = storage
 		self.mediaDownloader = mediaDownloader
 		self.collectionDownloadStatePollInterval = collectionDownloadStatePollInterval
 		self.trackManifestFetcher = trackManifestFetcher
@@ -107,16 +133,46 @@ public final class Offliner {
 	}
 
 	public func run() async {
+		guard isActive else {
+			return
+		}
 		await taskRunner.run()
+	}
+
+	/// Permanently invalidates this instance and removes only its installation-scoped local offline data.
+	///
+	/// This operation does not enqueue backend removals. Create a new `Offliner` after reset, including when signing in again
+	/// with the same installation identifier.
+	public func reset() async throws {
+		try await resetOperation().value
+	}
+
+	private func resetOperation() -> Task<Void, Error> {
+		lifecycleLock.lock()
+		defer { lifecycleLock.unlock() }
+		if let resetTask {
+			return resetTask
+		}
+
+		isReset = true
+		storage.invalidateWrites()
+		let task = Task { [taskRunner, storage] in
+			await taskRunner.shutdown()
+			try storage.reset()
+		}
+		resetTask = task
+		return task
 	}
 
 	// MARK: - Offline Content
 
 	public func getOfflineMediaItem(mediaType: OfflineMediaItemType, resourceId: ResourceId) async throws -> OfflineMediaItem? {
-		try await offlineStore.getMediaItem(mediaType: mediaType, resourceId: resourceId.stringValue)
+		try ensureActive()
+		return try await offlineStore.getMediaItem(mediaType: mediaType, resourceId: resourceId.stringValue)
 	}
 
 	public func getOfflineMediaItems(mediaType: OfflineMediaItemType) async throws -> [OfflineMediaItem] {
+		try ensureActive()
 		let (items, failures) = try await offlineStore.getMediaItems(mediaType: mediaType)
 
 		if !failures.isEmpty {
@@ -138,7 +194,10 @@ public final class Offliner {
 		mediaType: OfflineMediaItemType,
 		resourceId: ResourceId
 	) async -> OfflinePlaybackAsset? {
-		try? await offlineStore.getPlaybackAsset(mediaType: mediaType, resourceId: resourceId.stringValue)
+		guard isActive else {
+			return nil
+		}
+		return try? await offlineStore.getPlaybackAsset(mediaType: mediaType, resourceId: resourceId.stringValue)
 	}
 
 	/// Returns an AVFoundation asset prepared for unprotected or stored-license playback.
@@ -159,7 +218,10 @@ public final class Offliner {
 		collectionType: OfflineCollectionType,
 		resourceId: ResourceId
 	) -> AsyncStream<OfflineCollection?> {
-		AsyncStream { continuation in
+		guard isActive else {
+			return AsyncStream { $0.finish() }
+		}
+		return AsyncStream { continuation in
 			let task = Task {
 				let local = try? await offlineStore.getCollection(
 					collectionType: collectionType,
@@ -184,7 +246,10 @@ public final class Offliner {
 		collectionType: OfflineCollectionType,
 		cursor: String? = nil
 	) -> AsyncStream<Set<OfflineCollection>> {
-		AsyncStream { continuation in
+		guard isActive else {
+			return AsyncStream { $0.finish() }
+		}
+		return AsyncStream { continuation in
 			let task = Task {
 				let local = await (try? offlineStore.getCollections(collectionType: collectionType)) ?? []
 				var collections = Set(local)
@@ -213,6 +278,16 @@ public final class Offliner {
 		}
 	}
 
+	/// Returns a finite, error-preserving snapshot of locally stored collections.
+	///
+	/// This method does not access the network, so stored content remains available while offline.
+	public func getStoredOfflineCollections(
+		collectionType: OfflineCollectionType
+	) async throws -> Set<OfflineCollection> {
+		try ensureActive()
+		return try await Set(offlineStore.getCollections(collectionType: collectionType))
+	}
+
 	/// Streams collection-level offline availability.
 	///
 	/// The stream emits a fast initial value from local storage and active in-memory downloads, then continues polling for
@@ -224,7 +299,10 @@ public final class Offliner {
 		collectionType: OfflineCollectionType,
 		resourceId: ResourceId
 	) -> AsyncStream<OfflineCollectionDownloadState> {
-		AsyncStream { continuation in
+		guard isActive else {
+			return AsyncStream { $0.finish() }
+		}
+		return AsyncStream { continuation in
 			let task = Task {
 				var lastState: OfflineCollectionDownloadState?
 				var consecutiveDownloadedObservations = 0
@@ -255,9 +333,9 @@ public final class Offliner {
 				continuation.yield(initialState)
 				lastState = initialState
 
-				while !Task.isCancelled {
+				while !Task.isCancelled, isActive {
 					try? await Task.sleep(nanoseconds: collectionDownloadStatePollInterval)
-					guard !Task.isCancelled else {
+					guard !Task.isCancelled, isActive else {
 						break
 					}
 
@@ -279,7 +357,8 @@ public final class Offliner {
 		collectionType: OfflineCollectionType,
 		resourceId: ResourceId
 	) async throws -> Int {
-		try await offlineStore.countCollectionItems(collectionType: collectionType, resourceId: resourceId.stringValue)
+		try ensureActive()
+		return try await offlineStore.countCollectionItems(collectionType: collectionType, resourceId: resourceId.stringValue)
 	}
 
 	public func getOfflineCollectionItems(
@@ -289,6 +368,7 @@ public final class Offliner {
 		sort: OfflineCollectionItemSort? = nil,
 		after cursor: String? = nil
 	) async throws -> OfflineCollectionItemsPage {
+		try ensureActive()
 		let resourceId = resourceId.stringValue
 
 		let (page, failures): (OfflineCollectionItemsPage, [FailedOfflineItem])
@@ -346,6 +426,7 @@ public final class Offliner {
 		limit: Int = 20,
 		after cursor: String? = nil
 	) async throws -> OfflineCollectionSearchPage {
+		try ensureActive()
 		let (page, failures) = try await offlineStore.searchCollectionItems(
 			collectionType: collectionType,
 			resourceId: resourceId.stringValue,
@@ -374,34 +455,40 @@ public final class Offliner {
 		collectionType: OfflineCollectionType,
 		resourceId: ResourceId
 	) async throws -> AudioFormat? {
-		try await offlineStore.getAudioFormatOfCollection(collectionType: collectionType, resourceId: resourceId.stringValue)
+		try ensureActive()
+		return try await offlineStore.getAudioFormatOfCollection(collectionType: collectionType, resourceId: resourceId.stringValue)
 	}
 
 	public func getCollectionDuration(
 		collectionType: OfflineCollectionType,
 		resourceId: ResourceId
 	) async throws -> Int {
-		try await offlineStore.getCollectionDuration(collectionType: collectionType, resourceId: resourceId.stringValue)
+		try ensureActive()
+		return try await offlineStore.getCollectionDuration(collectionType: collectionType, resourceId: resourceId.stringValue)
 	}
 
 	// MARK: - Download/Remove
 
 	public func download(mediaType: OfflineMediaItemType, resourceId: ResourceId) async throws {
+		try ensureActive()
 		try await offlineApiClient.addItem(type: mediaType.toResourceType, id: resourceId.stringValue)
 		await taskRunner.run()
 	}
 
 	public func download(collectionType: OfflineCollectionType, resourceId: ResourceId) async throws {
+		try ensureActive()
 		try await offlineApiClient.addItem(type: collectionType.toResourceType, id: resourceId.stringValue)
 		await taskRunner.run()
 	}
 
 	public func remove(mediaType: OfflineMediaItemType, resourceId: ResourceId) async throws {
+		try ensureActive()
 		try await offlineApiClient.removeItem(type: mediaType.toResourceType, id: resourceId.stringValue)
 		await taskRunner.run()
 	}
 
 	public func remove(collectionType: OfflineCollectionType, resourceId: ResourceId) async throws {
+		try ensureActive()
 		try await offlineApiClient.removeItem(type: collectionType.toResourceType, id: resourceId.stringValue)
 		// Optimistically update local availability; the remove task performs the same idempotent cleanup.
 		try? offlineStore.deleteCollection(
@@ -432,6 +519,18 @@ public final class Offliner {
 		resourceId: ResourceId
 	) -> String {
 		collectionType == .userCollectionTracks ? ResourceId.me.stringValue : resourceId.stringValue
+	}
+
+	private var isActive: Bool {
+		lifecycleLock.lock()
+		defer { lifecycleLock.unlock() }
+		return !isReset
+	}
+
+	private func ensureActive() throws {
+		guard isActive else {
+			throw OfflinerLifecycleError.reset
+		}
 	}
 }
 

--- a/Sources/Offliner/README.md
+++ b/Sources/Offliner/README.md
@@ -189,6 +189,32 @@ let allAlbums = try await offliner.getOfflineCollections(collectionType: .albums
 let allPlaylists = try await offliner.getOfflineCollections(collectionType: .playlists)
 ```
 
+For a finite, local-only snapshot that preserves database errors and works without a network connection, use:
+
+```swift
+let storedAlbums = try await offliner.getStoredOfflineCollections(collectionType: .albums)
+let storedPlaylists = try await offliner.getStoredOfflineCollections(collectionType: .playlists)
+```
+
+The existing streams continue to combine local state with pending backend inventory for compatibility.
+
+### Logout and Installation Changes
+
+Offline databases, artwork, licenses, media bookmarks, and background download sessions are isolated by the
+`installationId` passed to `Offliner`. Before discarding an instance during logout or an installation/account change,
+reset it and await completion:
+
+```swift
+try await offliner.reset()
+```
+
+Reset is local-only: it cancels and awaits ongoing work, removes that installation's local data and artifacts, and does
+not enqueue backend removals. A reset instance is permanently invalid; create a new `Offliner` for the next session.
+
+When upgrading from an SDK version that used the original unscoped store, the first installation initialized after the
+upgrade claims and migrates that existing database and its artwork/license directories into installation-scoped
+storage. Its persisted bookmarks are retained and renewed when needed.
+
 ### Collection Items (Paginated)
 
 Get items within a collection using cursor-based pagination:

--- a/Sources/Offliner/Types.swift
+++ b/Sources/Offliner/Types.swift
@@ -221,6 +221,13 @@ public enum OfflineCollectionItemSort: Hashable {
 	case dateAdded(direction: SortDirection)
 }
 
+// MARK: - OfflinerLifecycleError
+
+/// An error produced when an operation is attempted on an Offliner instance after it has been reset.
+public enum OfflinerLifecycleError: Error {
+	case reset
+}
+
 // MARK: - OfflineCollectionItem
 
 public struct OfflineCollectionItem {

--- a/Tests/OfflinerTests/GetCollectionsStreamTests.swift
+++ b/Tests/OfflinerTests/GetCollectionsStreamTests.swift
@@ -2,6 +2,25 @@
 import XCTest
 
 final class GetCollectionsStreamTests: OfflinerTestCase {
+	func testStoredCollectionsSnapshotIsLocalOnlyAndPreservesDatabaseErrors() async throws {
+		let offliner = createOffliner(
+			offlineApiClient: FailingOfflineApiClient(),
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+
+		let collections = try await offliner.getStoredOfflineCollections(collectionType: .albums)
+		XCTAssertTrue(collections.isEmpty)
+		try await lastDatabaseQueue.write { database in
+			try database.drop(table: "offline_item")
+		}
+
+		do {
+			_ = try await offliner.getStoredOfflineCollections(collectionType: .albums)
+			XCTFail("Expected the local database error to be preserved")
+		} catch {}
+	}
+
 	func testGetOfflineCollectionEmitsLocalThenBackendPending() async throws {
 		let backend = StubOfflineApiClient()
 		let offliner = createOffliner(

--- a/Tests/OfflinerTests/OfflinerLifecycleTests.swift
+++ b/Tests/OfflinerTests/OfflinerLifecycleTests.swift
@@ -1,0 +1,187 @@
+@testable import Offliner
+import XCTest
+
+final class OfflinerLifecycleTests: OfflinerTestCase {
+	func testBackgroundSessionEventHandlingReturnsDownloaderDecision() {
+		let mediaDownloader = SucceedingMediaDownloader()
+		mediaDownloader.handlesBackgroundSessionEvents = true
+		let offliner = createOffliner(
+			offlineApiClient: FailingOfflineApiClient(),
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: mediaDownloader
+		)
+
+		let handled = offliner.handleBackgroundURLSessionEvents(identifier: "matching-session") {}
+
+		XCTAssertTrue(handled)
+		XCTAssertEqual(mediaDownloader.backgroundSessionIdentifiers, ["matching-session"])
+	}
+
+	func testBackgroundSessionEventHandlingRejectsResetInstance() async throws {
+		let mediaDownloader = SucceedingMediaDownloader()
+		mediaDownloader.handlesBackgroundSessionEvents = true
+		let offliner = createOffliner(
+			offlineApiClient: FailingOfflineApiClient(),
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: mediaDownloader
+		)
+		try await offliner.reset()
+
+		let handled = offliner.handleBackgroundURLSessionEvents(identifier: "matching-session") {}
+
+		XCTAssertFalse(handled)
+		XCTAssertTrue(mediaDownloader.backgroundSessionIdentifiers.isEmpty)
+	}
+
+	func testInstallationIdsHaveIsolatedCollectionsAndBackgroundSessions() async throws {
+		let firstBackend = StubOfflineApiClient()
+		let first = createOffliner(
+			installationId: "installation-a",
+			offlineApiClient: firstBackend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+		try await first.download(collectionType: .albums, resourceId: .identifier("album-a"))
+		await firstBackend.waitForTasksToComplete()
+
+		let second = createOffliner(
+			installationId: "installation-b",
+			offlineApiClient: FailingOfflineApiClient(),
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+
+		let firstCollections = try await first.getStoredOfflineCollections(collectionType: .albums)
+		let secondCollections = try await second.getStoredOfflineCollections(collectionType: .albums)
+		XCTAssertEqual(firstCollections.count, 1)
+		XCTAssertTrue(secondCollections.isEmpty)
+
+		let firstStorage = try OfflinerStorage(installationId: "installation-a", baseDirectory: tempDir)
+		let secondStorage = try OfflinerStorage(installationId: "installation-b", baseDirectory: tempDir)
+		XCTAssertNotEqual(firstStorage.rootDirectory, secondStorage.rootDirectory)
+		XCTAssertNotEqual(firstStorage.backgroundSessionIdentifier, secondStorage.backgroundSessionIdentifier)
+		XCTAssertLessThanOrEqual(firstStorage.backgroundSessionIdentifier.count, 64)
+	}
+
+	func testResetIsLocalOnlyRemovesArtifactsAndPermanentlyInvalidatesInstance() async throws {
+		let backend = StubOfflineApiClient()
+		let offliner = createOffliner(
+			installationId: "installation-a",
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+		try await offliner.download(mediaType: .tracks, resourceId: .identifier("track-a"))
+		await backend.waitForTasksToComplete()
+		let playbackAsset = await offliner.getOfflinePlaybackAsset(mediaType: .tracks, resourceId: .identifier("track-a"))
+		let asset = try XCTUnwrap(playbackAsset)
+		XCTAssertTrue(FileManager.default.fileExists(atPath: asset.mediaURL.path))
+		let removedItemCount = backend.removedItems.count
+
+		try await offliner.reset()
+
+		XCTAssertFalse(FileManager.default.fileExists(atPath: asset.mediaURL.path))
+		XCTAssertEqual(backend.removedItems.count, removedItemCount)
+		do {
+			_ = try await offliner.getStoredOfflineCollections(collectionType: .albums)
+			XCTFail("Expected reset instance to reject reads")
+		} catch OfflinerLifecycleError.reset {}
+
+		let replacement = createOffliner(
+			installationId: "installation-a",
+			offlineApiClient: FailingOfflineApiClient(),
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+		let collections = try await replacement.getStoredOfflineCollections(collectionType: .albums)
+		let mediaItem = try await replacement.getOfflineMediaItem(mediaType: .tracks, resourceId: .identifier("track-a"))
+		XCTAssertTrue(collections.isEmpty)
+		XCTAssertNil(mediaItem)
+	}
+
+	func testStaleInFlightDownloadCannotRepopulateAfterResetStarts() async throws {
+		let backend = StubOfflineApiClient()
+		let mediaDownloader = SuspendingMediaDownloader(resumesOnCancel: false)
+		let offliner = createOffliner(
+			installationId: "installation-a",
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: mediaDownloader
+		)
+
+		try await offliner.download(mediaType: .tracks, resourceId: .identifier("track-a"))
+		await mediaDownloader.waitUntilStarted()
+		let reset = Task { try await offliner.reset() }
+		await mediaDownloader.waitUntilCancelled()
+		await mediaDownloader.complete()
+		try await reset.value
+
+		let replacement = createOffliner(
+			installationId: "installation-a",
+			offlineApiClient: FailingOfflineApiClient(),
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+		let mediaItem = try await replacement.getOfflineMediaItem(mediaType: .tracks, resourceId: .identifier("track-a"))
+		XCTAssertNil(mediaItem)
+	}
+
+	func testLegacyStorageMigratesToFirstInstallation() async throws {
+		let legacyRoot = tempDir.appendingPathComponent("Offliner", isDirectory: true)
+		try FileManager.default.createDirectory(at: legacyRoot, withIntermediateDirectories: true)
+		let legacyArtworkDirectory = legacyRoot.appendingPathComponent("Artworks", isDirectory: true)
+		try FileManager.default.createDirectory(at: legacyArtworkDirectory, withIntermediateDirectories: true)
+		let artworkURL = legacyArtworkDirectory.appendingPathComponent("album.jpg")
+		try Data("artwork".utf8).write(to: artworkURL)
+		let legacyLicenseDirectory = legacyRoot.appendingPathComponent("Licenses", isDirectory: true)
+		try FileManager.default.createDirectory(at: legacyLicenseDirectory, withIntermediateDirectories: true)
+		let licenseURL = legacyLicenseDirectory.appendingPathComponent("track.key")
+		try Data("license".utf8).write(to: licenseURL)
+		let mediaURL = tempDir.appendingPathComponent("track.movpkg")
+		try Data("media".utf8).write(to: mediaURL)
+
+		let legacyDatabase = try OfflineStore.makeDatabaseQueue(path: legacyRoot.appendingPathComponent("offline.sqlite").path)
+		try Migrations.run(legacyDatabase)
+		let legacyStore = OfflineStore(legacyDatabase)
+		try legacyStore.storeCollection(StoreCollectionTaskResult(
+			resourceType: .albums,
+			resourceId: "album-a",
+			catalogMetadata: .album(.mock(id: "album-a")),
+			artworkURL: artworkURL
+		))
+		try legacyStore.storeMediaItem(StoreItemTaskResult(
+			resourceType: OfflineMediaItemType.tracks.rawValue,
+			resourceId: "track-a",
+			catalogMetadata: .track(.mock(id: "track-a")),
+			playbackMetadata: .mock(),
+			collectionResourceType: OfflineCollectionType.albums.rawValue,
+			collectionResourceId: "album-a",
+			volume: 1,
+			position: 1,
+			addedAt: nil,
+			mediaURL: mediaURL,
+			licenseURL: licenseURL,
+			artworkURL: artworkURL
+		))
+		try legacyDatabase.close()
+
+		let storage = try OfflinerStorage(installationId: "installation-a", baseDirectory: tempDir)
+		let collections = try await storage.offlineStore.getCollections(collectionType: .albums)
+		let migratedCollection = try XCTUnwrap(collections.first)
+		let migratedArtworkURL = try XCTUnwrap(migratedCollection.artworkURL)
+		let storedPlaybackAsset = try await storage.offlineStore.getPlaybackAsset(mediaType: .tracks, resourceId: "track-a")
+		let playbackAsset = try XCTUnwrap(storedPlaybackAsset)
+		let migratedLicenseURL = try XCTUnwrap(playbackAsset.licenseURL)
+
+		XCTAssertEqual(collections.map(\.catalogMetadata.id), ["album-a"])
+		XCTAssertTrue(FileManager.default.fileExists(atPath: migratedArtworkURL.path))
+		XCTAssertTrue(FileManager.default.fileExists(atPath: playbackAsset.mediaURL.path))
+		XCTAssertTrue(FileManager.default.fileExists(atPath: migratedLicenseURL.path))
+		XCTAssertFalse(FileManager.default.fileExists(atPath: legacyRoot.appendingPathComponent("offline.sqlite").path))
+		XCTAssertTrue(FileManager.default.fileExists(atPath: storage.rootDirectory.appendingPathComponent("offline.sqlite").path))
+		XCTAssertTrue(FileManager.default.fileExists(
+			atPath: storage.rootDirectory
+				.appendingPathComponent("Artifacts/Artworks/album.jpg").path
+		))
+	}
+}

--- a/Tests/OfflinerTests/OfflinerTestCase.swift
+++ b/Tests/OfflinerTests/OfflinerTestCase.swift
@@ -5,6 +5,7 @@ import XCTest
 class OfflinerTestCase: XCTestCase {
 	var tempDir: URL!
 	var lastDatabaseQueue: DatabaseQueue!
+	private var offliners: [Offliner] = []
 
 	override func setUp() {
 		super.setUp()
@@ -12,38 +13,39 @@ class OfflinerTestCase: XCTestCase {
 		try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
 	}
 
-	override func tearDown() {
+	override func tearDown() async throws {
+		for offliner in offliners {
+			try? await offliner.reset()
+		}
+		offliners.removeAll()
 		if let tempDir {
 			try? FileManager.default.removeItem(at: tempDir)
 		}
-		super.tearDown()
+		try await super.tearDown()
 	}
 
 	func createOffliner(
+		installationId: String = UUID().uuidString,
 		offlineApiClient: OfflineApiClientProtocol,
 		artworkDownloader: ArtworkDownloaderProtocol,
 		mediaDownloader: MediaDownloaderProtocol,
 		trackManifestFetcher: TrackManifestFetcherProtocol = SucceedingTrackManifestFetcher(),
-		videoManifestFetcher: VideoManifestFetcherProtocol = SucceedingVideoManifestFetcher(),
-		collectionDownloadStatePollInterval: UInt64 = 1_000_000_000
+		videoManifestFetcher: VideoManifestFetcherProtocol = SucceedingVideoManifestFetcher()
 	) -> Offliner {
-		let dbPath = tempDir.appendingPathComponent("test-\(UUID().uuidString).sqlite").path
 		// swiftlint:disable:next force_try
-		let databaseQueue = try! OfflineStore.makeDatabaseQueue(path: dbPath)
-		// swiftlint:disable:next force_try
-		try! Migrations.run(databaseQueue)
-		lastDatabaseQueue = databaseQueue
-		let offlineStore = OfflineStore(databaseQueue)
+		let storage = try! OfflinerStorage(installationId: installationId, baseDirectory: tempDir)
+		lastDatabaseQueue = storage.databaseQueue
 
-		return Offliner(
+		let offliner = Offliner(
+			storage: storage,
 			offlineApiClient: offlineApiClient,
-			offlineStore: offlineStore,
 			artworkDownloader: artworkDownloader,
 			mediaDownloader: mediaDownloader,
 			trackManifestFetcher: trackManifestFetcher,
-			videoManifestFetcher: videoManifestFetcher,
-			collectionDownloadStatePollInterval: collectionDownloadStatePollInterval
+			videoManifestFetcher: videoManifestFetcher
 		)
+		offliners.append(offliner)
+		return offliner
 	}
 
 	func downloadAndWaitForCompletion(_ offliner: Offliner) async throws {

--- a/Tests/OfflinerTests/TestFakes.swift
+++ b/Tests/OfflinerTests/TestFakes.swift
@@ -328,8 +328,15 @@ actor SuspendingArtworkDownloader: ArtworkDownloaderProtocol {
 
 final class SucceedingMediaDownloader: MediaDownloaderProtocol {
 	var progressValues: [Double] = []
+	var handlesBackgroundSessionEvents = false
+	private(set) var backgroundSessionIdentifiers: [String] = []
 
-	func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void) {}
+	func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void) -> Bool {
+		backgroundSessionIdentifiers.append(identifier)
+		return handlesBackgroundSessionEvents
+	}
+
+	func cancelAll() async {}
 
 	func download(
 		taskId: String,
@@ -356,7 +363,8 @@ final class SucceedingMediaDownloader: MediaDownloaderProtocol {
 // MARK: - FailingMediaDownloader
 
 final class FailingMediaDownloader: MediaDownloaderProtocol {
-	func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void) {}
+	func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void) -> Bool { false }
+	func cancelAll() async {}
 
 	func download(
 		taskId: String,
@@ -373,10 +381,41 @@ final class FailingMediaDownloader: MediaDownloaderProtocol {
 
 actor SuspendingMediaDownloader: MediaDownloaderProtocol {
 	private var startedContinuation: CheckedContinuation<Void, Never>?
+	private var cancelledContinuation: CheckedContinuation<Void, Never>?
 	private var resultContinuation: CheckedContinuation<MediaDownloadResult, Error>?
 	private var started = false
+	private var cancelled = false
+	private let resumesOnCancel: Bool
 
-	nonisolated func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void) {}
+	init(resumesOnCancel: Bool = true) {
+		self.resumesOnCancel = resumesOnCancel
+	}
+
+	nonisolated func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void) -> Bool {
+		false
+	}
+
+	func cancelAll() {
+		cancelled = true
+		cancelledContinuation?.resume()
+		cancelledContinuation = nil
+		guard resumesOnCancel else {
+			return
+		}
+		let continuation = resultContinuation
+		resultContinuation = nil
+		continuation?.resume(throwing: CancellationError())
+	}
+
+	func waitUntilCancelled() async {
+		if cancelled {
+			return
+		}
+
+		await withCheckedContinuation { continuation in
+			cancelledContinuation = continuation
+		}
+	}
 
 	func waitUntilStarted() async {
 		if started {


### PR DESCRIPTION
## What
- `OfflinerStorage`/`FileStorage`: storage rooted per app installation (with migration of pre-existing unscoped data), replacing the static shared URL.
- `Offliner.reset()`: local-only teardown — invalidates writes, cancels media/license downloads (`cancelAll`), shuts down the task runner, deletes files and the database. A reset instance permanently rejects API calls with `OfflinerLifecycleError.reset`; all public API is guarded by `ensureActive()`.
- `OfflineStore`: write lock + `acceptsWrites` gate so in-flight task completions cannot resurrect rows/files mid-reset.
- `Offliner.getStoredOfflineCollections(collectionType:)`: finite, error-preserving local snapshot (no network) — used by the Watch client for library rendering while offline.
- README: getStoredOfflineCollections + "Logout and Installation Changes" documentation.

## Why
The account-safe requirement: on logout/user switch the Watch client calls `reset()` and recreates Offliner; scoped storage guarantees a new installation never sees a previous user's downloads. The Watch client calls `getStoredOfflineCollections` (3 call sites) and `reset` (2 call sites).

⚠️ **Legacy storage migration is load-bearing**: Offliner has shipped on iOS with unscoped storage, so released installations have downloads at the old path. The migration moves that data into the installation scope on first launch — without it, existing users' downloads would be orphaned (invisible but still consuming disk). Review the migration path carefully with released-data upgrade scenarios in mind.

## Stack
PR 4/7 of the TM-1573 stack replacing #413. Next: backend task-state ingestion.

## Testing
`xcodebuild test -scheme Offliner -destination platform=macOS` — all tests pass, including new `OfflinerLifecycleTests` and `GetCollectionsStreamTests`.