### PR TITLE
TM-1573: Ingest backend task states with pagination and skip terminal tasks

### DIFF
--- a/Sources/Offliner/Internal/OfflineApiClient.swift
+++ b/Sources/Offliner/Internal/OfflineApiClient.swift
@@ -16,6 +16,7 @@ enum ResourceType {
 
 struct StoreTrackTask {
 	let id: String
+	let state: Download.State
 	let track: TracksResourceObject
 	let album: AlbumsResourceObject?
 	let artists: [ArtistsResourceObject]
@@ -28,6 +29,7 @@ struct StoreTrackTask {
 
 	init(
 		id: String,
+		state: Download.State = .pending,
 		track: TracksResourceObject,
 		album: AlbumsResourceObject? = nil,
 		artists: [ArtistsResourceObject],
@@ -39,6 +41,7 @@ struct StoreTrackTask {
 		addedAt: Date? = nil
 	) {
 		self.id = id
+		self.state = state
 		self.track = track
 		self.album = album
 		self.artists = artists
@@ -55,6 +58,7 @@ struct StoreTrackTask {
 
 struct StoreVideoTask {
 	let id: String
+	let state: Download.State
 	let video: VideosResourceObject
 	let artists: [ArtistsResourceObject]
 	let artwork: ArtworksResourceObject?
@@ -66,6 +70,7 @@ struct StoreVideoTask {
 
 	init(
 		id: String,
+		state: Download.State = .pending,
 		video: VideosResourceObject,
 		artists: [ArtistsResourceObject],
 		artwork: ArtworksResourceObject?,
@@ -76,6 +81,7 @@ struct StoreVideoTask {
 		addedAt: Date? = nil
 	) {
 		self.id = id
+		self.state = state
 		self.video = video
 		self.artists = artists
 		self.artwork = artwork
@@ -91,6 +97,7 @@ struct StoreVideoTask {
 
 struct StoreAlbumTask {
 	let id: String
+	var state: Download.State = .pending
 	let album: AlbumsResourceObject
 	let artists: [ArtistsResourceObject]
 	let artwork: ArtworksResourceObject?
@@ -100,6 +107,7 @@ struct StoreAlbumTask {
 
 struct StorePlaylistTask {
 	let id: String
+	var state: Download.State = .pending
 	let playlist: PlaylistsResourceObject
 	let artwork: ArtworksResourceObject?
 }
@@ -108,6 +116,7 @@ struct StorePlaylistTask {
 
 struct StoreUserCollectionTracksTask {
 	let id: String
+	var state: Download.State = .pending
 	let resourceId: String
 }
 
@@ -115,6 +124,7 @@ struct StoreUserCollectionTracksTask {
 
 struct RemoveItemTask {
 	let id: String
+	var state: Download.State = .pending
 	let resourceType: String
 	let resourceId: String
 	let collectionResourceType: String
@@ -125,8 +135,28 @@ struct RemoveItemTask {
 
 struct RemoveCollectionTask {
 	let id: String
+	var state: Download.State = .pending
 	let resourceType: String
 	let resourceId: String
+}
+
+// MARK: - InternalOfflineResourceAction
+
+enum InternalOfflineResourceAction: String, Sendable {
+	case store
+	case remove
+}
+
+// MARK: - TerminalOfflineTask
+
+struct TerminalOfflineTask {
+	let id: String
+	let state: Download.State
+	let action: InternalOfflineResourceAction
+	let resourceType: String
+	let resourceId: String
+	let collectionResourceType: String?
+	let collectionResourceId: String?
 }
 
 // MARK: - OfflineTask
@@ -139,6 +169,7 @@ enum OfflineTask {
 	case storeUserCollectionTracks(StoreUserCollectionTracksTask)
 	case removeItem(RemoveItemTask)
 	case removeCollection(RemoveCollectionTask)
+	case terminal(TerminalOfflineTask)
 
 	var id: String {
 		switch self {
@@ -149,6 +180,28 @@ enum OfflineTask {
 		case let .storeUserCollectionTracks(task): task.id
 		case let .removeItem(task): task.id
 		case let .removeCollection(task): task.id
+		case let .terminal(task): task.id
+		}
+	}
+
+	var state: Download.State {
+		switch self {
+		case let .storeTrack(task): task.state
+		case let .storeVideo(task): task.state
+		case let .storeAlbum(task): task.state
+		case let .storePlaylist(task): task.state
+		case let .storeUserCollectionTracks(task): task.state
+		case let .removeItem(task): task.state
+		case let .removeCollection(task): task.state
+		case let .terminal(task): task.state
+		}
+	}
+
+	var action: InternalOfflineResourceAction {
+		switch self {
+		case .storeTrack, .storeVideo, .storeAlbum, .storePlaylist, .storeUserCollectionTracks: .store
+		case .removeItem, .removeCollection: .remove
+		case let .terminal(task): task.action
 		}
 	}
 }
@@ -374,6 +427,17 @@ private extension OfflineTasksResourceObject {
 		let includedItem = includedItems.get(type: itemData.type, id: itemData.id)
 		let includedCollection = collectionData.flatMap { includedItems.get(type: $0.type, id: $0.id) }
 		let addedAt = includedCollection?.playlistItemAddedAt(for: itemData)
+		if attributes.state == .failed || attributes.state == .completed {
+			return .terminal(TerminalOfflineTask(
+				id: id,
+				state: attributes.state.downloadState,
+				action: attributes.action == .store ? .store : .remove,
+				resourceType: itemData.type,
+				resourceId: itemData.id,
+				collectionResourceType: collectionData?.type,
+				collectionResourceId: collectionData?.id
+			))
+		}
 
 		switch attributes.action {
 		case .store:
@@ -385,23 +449,32 @@ private extension OfflineTasksResourceObject {
 				return StoreVideoTask(self, attributes: attributes, item: includedItem, collectionData: collectionData, addedAt: addedAt)
 					.map { .storeVideo($0) }
 			case "albums":
-				return StoreAlbumTask(self, item: includedItem)
+				return StoreAlbumTask(self, attributes: attributes, item: includedItem)
 					.map { .storeAlbum($0) }
 			case "playlists":
-				return StorePlaylistTask(self, item: includedItem)
+				return StorePlaylistTask(self, attributes: attributes, item: includedItem)
 					.map { .storePlaylist($0) }
 			case "userCollectionTracks":
-				return .storeUserCollectionTracks(StoreUserCollectionTracksTask(id: id, resourceId: itemData.id))
+				return .storeUserCollectionTracks(StoreUserCollectionTracksTask(
+					id: id,
+					state: attributes.state.downloadState,
+					resourceId: itemData.id
+				))
 			default:
 				return nil
 			}
 		case .remove:
 			switch itemData.type {
 			case "tracks", "videos":
-				return RemoveItemTask(self, itemData: itemData, collectionData: collectionData)
+				return RemoveItemTask(self, attributes: attributes, itemData: itemData, collectionData: collectionData)
 					.map { .removeItem($0) }
 			case "albums", "playlists", "userCollectionTracks":
-				return .removeCollection(RemoveCollectionTask(id: id, resourceType: itemData.type, resourceId: itemData.id))
+				return .removeCollection(RemoveCollectionTask(
+					id: id,
+					state: attributes.state.downloadState,
+					resourceType: itemData.type,
+					resourceId: itemData.id
+				))
 			default:
 				return nil
 			}
@@ -638,6 +711,7 @@ private extension StoreTrackTask {
 		}
 		self.init(
 			id: resourceObject.id,
+			state: attributes.state.downloadState,
 			track: track,
 			album: item.albumObject,
 			artists: item.artistObjects,
@@ -664,6 +738,7 @@ private extension StoreVideoTask {
 		}
 		self.init(
 			id: resourceObject.id,
+			state: attributes.state.downloadState,
 			video: video,
 			artists: item.artistObjects,
 			artwork: item.artworkObject,
@@ -677,26 +752,29 @@ private extension StoreVideoTask {
 }
 
 private extension StoreAlbumTask {
-	init?(_ resourceObject: OfflineTasksResourceObject, item: IncludedItem?) {
+	init?(_ resourceObject: OfflineTasksResourceObject, attributes: OfflineTasksAttributes, item: IncludedItem?) {
 		guard let item, case let .album(album) = item.resource else {
 			return nil
 		}
 		self.init(id: resourceObject.id, album: album, artists: item.artistObjects, artwork: item.artworkObject)
+		state = attributes.state.downloadState
 	}
 }
 
 private extension StorePlaylistTask {
-	init?(_ resourceObject: OfflineTasksResourceObject, item: IncludedItem?) {
+	init?(_ resourceObject: OfflineTasksResourceObject, attributes: OfflineTasksAttributes, item: IncludedItem?) {
 		guard let item, case let .playlist(playlist) = item.resource else {
 			return nil
 		}
 		self.init(id: resourceObject.id, playlist: playlist, artwork: item.artworkObject)
+		state = attributes.state.downloadState
 	}
 }
 
 private extension RemoveItemTask {
 	init?(
 		_ resourceObject: OfflineTasksResourceObject,
+		attributes: OfflineTasksAttributes,
 		itemData: OfflineTasksItemResourceIdentifier,
 		collectionData: OfflineTasksCollectionResourceIdentifier?
 	) {
@@ -710,5 +788,17 @@ private extension RemoveItemTask {
 			collectionResourceType: collectionData.type,
 			collectionResourceId: collectionData.id
 		)
+		state = attributes.state.downloadState
+	}
+}
+
+private extension OfflineTasksAttributes.State {
+	var downloadState: Download.State {
+		switch self {
+		case .pending: .pending
+		case .inProgress: .inProgress
+		case .failed: .failed
+		case .completed: .completed
+		}
 	}
 }

--- a/Sources/Offliner/Internal/TaskRunner.swift
+++ b/Sources/Offliner/Internal/TaskRunner.swift
@@ -155,20 +155,27 @@ actor TaskRunner {
 		guard !isShutdown else {
 			return
 		}
-		let (tasks, _) = try await offlineApiClient.getTasks(cursor: nil)
-		try Task.checkCancellation()
-		guard !isShutdown else {
-			return
-		}
-
-		for task in tasks where taskIds.insert(task.id).inserted {
-			let pendingTask = handle(task)
-			pendingTasks.append(pendingTask)
-			if let download = pendingTask.download {
-				currentDownloads.append(download)
-				downloadsContinuation?.yield(download)
+		var cursor: String?
+		repeat {
+			let page = try await offlineApiClient.getTasks(cursor: cursor)
+			try Task.checkCancellation()
+			guard !isShutdown else {
+				return
 			}
-		}
+
+			for task in page.tasks where taskIds.insert(task.id).inserted {
+				guard task.state == .pending || task.state == .inProgress else {
+					continue
+				}
+				let pendingTask = handle(task)
+				pendingTasks.append(pendingTask)
+				if let download = pendingTask.download {
+					currentDownloads.append(download)
+					downloadsContinuation?.yield(download)
+				}
+			}
+			cursor = page.cursor
+		} while cursor != nil
 	}
 
 	private func handle(_ offlineTask: OfflineTask) -> InternalTask {
@@ -180,6 +187,7 @@ actor TaskRunner {
 		case let .storeUserCollectionTracks(task): storeUserCollectionTracksHandler.handle(task)
 		case let .removeItem(task): removeItemHandler.handle(task)
 		case let .removeCollection(task): removeCollectionHandler.handle(task)
+		case .terminal: preconditionFailure("Terminal offline tasks are never executed")
 		}
 	}
 


### PR DESCRIPTION
## What
- `OfflineApiClient`: task parsing now carries `state: Download.State` and an internal store/remove action on every task; failed/completed backend tasks parse into a new `TerminalOfflineTask` case instead of being dropped.
- `TaskRunner.refresh()`: follows the backend cursor through all pages (previously first page only) and skips non-pending/non-in-progress tasks instead of re-executing them.

## Why
Foundation for the resource-state API in the next PR: knowing a task's backend state (including terminal outcomes) is what lets Offliner report queued/downloading/failed per resource and recover state after relaunch. Pagination ensures a large backlog (e.g. a big album queued on the phone) is fully visible to the watch.

## Stack
PR 5/7 of the TM-1573 stack replacing #413. Next: resource state API.

## Testing
`xcodebuild test -scheme Offliner -destination platform=macOS` — all tests pass.