### PR TITLE
TM-1573: Add persisted offline resource state tracking and getOfflineResourceState API

### DIFF
--- a/Sources/Offliner/Internal/OfflineApiClient.swift
+++ b/Sources/Offliner/Internal/OfflineApiClient.swift
@@ -140,13 +140,6 @@ struct RemoveCollectionTask {
 	let resourceId: String
 }
 
-// MARK: - InternalOfflineResourceAction
-
-enum InternalOfflineResourceAction: String, Sendable {
-	case store
-	case remove
-}
-
 // MARK: - TerminalOfflineTask
 
 struct TerminalOfflineTask {
@@ -202,6 +195,40 @@ enum OfflineTask {
 		case .storeTrack, .storeVideo, .storeAlbum, .storePlaylist, .storeUserCollectionTracks: .store
 		case .removeItem, .removeCollection: .remove
 		case let .terminal(task): task.action
+		}
+	}
+
+	var resourceKeys: Set<OfflineResourceKey> {
+		switch self {
+		case let .storeTrack(task):
+			return [
+				OfflineResourceKey(resourceType: OfflineMediaItemType.tracks.rawValue, resourceId: task.track.id),
+				OfflineResourceKey(resourceType: task.collectionResourceType, resourceId: task.collectionResourceId),
+			]
+		case let .storeVideo(task):
+			return [
+				OfflineResourceKey(resourceType: OfflineMediaItemType.videos.rawValue, resourceId: task.video.id),
+				OfflineResourceKey(resourceType: task.collectionResourceType, resourceId: task.collectionResourceId),
+			]
+		case let .storeAlbum(task):
+			return [OfflineResourceKey(resourceType: OfflineCollectionType.albums.rawValue, resourceId: task.album.id)]
+		case let .storePlaylist(task):
+			return [OfflineResourceKey(resourceType: OfflineCollectionType.playlists.rawValue, resourceId: task.playlist.id)]
+		case let .storeUserCollectionTracks(task):
+			return [OfflineResourceKey(resourceType: OfflineCollectionType.userCollectionTracks.rawValue, resourceId: task.resourceId)]
+		case let .removeItem(task):
+			return [
+				OfflineResourceKey(resourceType: task.resourceType, resourceId: task.resourceId),
+				OfflineResourceKey(resourceType: task.collectionResourceType, resourceId: task.collectionResourceId),
+			]
+		case let .removeCollection(task):
+			return [OfflineResourceKey(resourceType: task.resourceType, resourceId: task.resourceId)]
+		case let .terminal(task):
+			var resources = Set([OfflineResourceKey(resourceType: task.resourceType, resourceId: task.resourceId)])
+			if let collectionType = task.collectionResourceType, let collectionId = task.collectionResourceId {
+				resources.insert(OfflineResourceKey(resourceType: collectionType, resourceId: collectionId))
+			}
+			return resources
 		}
 	}
 }

--- a/Sources/Offliner/Internal/OfflineStore.swift
+++ b/Sources/Offliner/Internal/OfflineStore.swift
@@ -31,6 +31,56 @@ final class OfflineStore {
 		self.databaseQueue = databaseQueue
 	}
 
+	func getResourceOperation(resourceType: String, resourceId: String) throws -> StoredResourceOperation? {
+		try databaseQueue.read { database in
+			try Row.fetchOne(
+				database,
+				sql: "SELECT action, state FROM offline_resource_operation WHERE resource_type = ? AND resource_id = ?",
+				arguments: [resourceType, resourceId]
+			).flatMap { row in
+				guard let action = InternalOfflineResourceAction(rawValue: row["action"]),
+				      let state = OfflineResourceState(storageValue: row["state"]) else { return nil }
+				return StoredResourceOperation(action: action, state: state)
+			}
+		}
+	}
+
+	func setResourceOperation(
+		resourceType: String,
+		resourceId: String,
+		action: InternalOfflineResourceAction,
+		state: OfflineResourceState
+	) throws {
+		writeLock.lock()
+		defer { writeLock.unlock() }
+		try ensureAcceptsWritesLocked()
+		try databaseQueue.write { database in
+			try database.execute(
+				sql: """
+				INSERT INTO offline_resource_operation (resource_type, resource_id, action, state)
+				VALUES (?, ?, ?, ?)
+				ON CONFLICT (resource_type, resource_id) DO UPDATE SET
+					action = excluded.action,
+					state = excluded.state,
+					updated_at = CURRENT_TIMESTAMP
+				""",
+				arguments: [resourceType, resourceId, action.rawValue, state.storageValue]
+			)
+		}
+	}
+
+	func deleteResourceOperation(resourceType: String, resourceId: String) throws {
+		writeLock.lock()
+		defer { writeLock.unlock() }
+		try ensureAcceptsWritesLocked()
+		try databaseQueue.write { database in
+			try database.execute(
+				sql: "DELETE FROM offline_resource_operation WHERE resource_type = ? AND resource_id = ?",
+				arguments: [resourceType, resourceId]
+			)
+		}
+	}
+
 	func storeMediaItem(_ result: StoreItemTaskResult) throws {
 		writeLock.lock()
 		defer { writeLock.unlock() }

--- a/Sources/Offliner/Internal/ResourceStateTracker.swift
+++ b/Sources/Offliner/Internal/ResourceStateTracker.swift
@@ -1,0 +1,301 @@
+import Foundation
+
+// MARK: - InternalOfflineResourceAction
+
+enum InternalOfflineResourceAction: String, Sendable {
+	case store
+	case remove
+
+	var publicAction: OfflineResourceAction {
+		switch self {
+		case .store: .download
+		case .remove: .remove
+		}
+	}
+}
+
+// MARK: - StoredResourceOperation
+
+struct StoredResourceOperation: Sendable {
+	let action: InternalOfflineResourceAction
+	let state: OfflineResourceState
+}
+
+// MARK: - OfflineResourceKey
+
+struct OfflineResourceKey: Hashable, Sendable {
+	let resourceType: String
+	let resourceId: String
+
+	init(_ resource: OfflineResource) {
+		switch resource {
+		case let .media(type, resourceId):
+			self.init(resourceType: type.rawValue, resourceId: resourceId)
+		case let .collection(type, resourceId):
+			self.init(
+				resourceType: type.rawValue,
+				resourceId: type == .userCollectionTracks ? ResourceId.me.stringValue : resourceId
+			)
+		}
+	}
+
+	init(resourceType: String, resourceId: String) {
+		self.resourceType = resourceType
+		self.resourceId = resourceType == OfflineCollectionType.userCollectionTracks.rawValue
+			? ResourceId.me.stringValue
+			: resourceId
+	}
+
+	var publicResource: OfflineResource? {
+		if let type = OfflineMediaItemType(rawValue: resourceType) {
+			return .media(type: type, resourceId: resourceId)
+		}
+		return publicCollection
+	}
+
+	var publicCollection: OfflineResource? {
+		guard let type = OfflineCollectionType(rawValue: resourceType) else {
+			return nil
+		}
+		return .collection(type: type, resourceId: resourceId)
+	}
+}
+
+// MARK: - ResourceStateTracker
+
+actor ResourceStateTracker {
+	private struct TaskState {
+		let action: InternalOfflineResourceAction
+		var state: OfflineResourceState
+		let resources: Set<OfflineResourceKey>
+	}
+
+	private let offlineStore: OfflineStore
+	private var taskStates: [String: TaskState] = [:]
+	private var transientStates: [OfflineResourceKey: (InternalOfflineResourceAction, OfflineResourceState)] = [:]
+	private var isShutdown = false
+
+	init(offlineStore: OfflineStore) {
+		self.offlineStore = offlineStore
+	}
+
+	func state(for resource: OfflineResourceKey) throws -> OfflineResourceState? {
+		guard !isShutdown else {
+			return nil
+		}
+		if let state = effectiveState(for: resource) {
+			return state
+		}
+		return try offlineStore.getResourceOperation(
+			resourceType: resource.resourceType,
+			resourceId: resource.resourceId
+		)?.state
+	}
+
+	func begin(_ action: InternalOfflineResourceAction, for resource: OfflineResourceKey) throws -> Bool {
+		guard !isShutdown else {
+			return false
+		}
+		let activeTasks = taskStates.values.filter { $0.resources.contains(resource) && $0.state.isActiveOperation }
+		if let activeTask = activeTasks.max(by: { $0.state.priority < $1.state.priority }) {
+			if activeTask.action == action {
+				return false
+			}
+			throw OfflineResourceOperationError.conflictingOperationInProgress(currentState: activeTask.state)
+		}
+		let current: OfflineResourceState? = if let state = effectiveState(for: resource) {
+			state
+		} else {
+			try offlineStore.getResourceOperation(
+				resourceType: resource.resourceType,
+				resourceId: resource.resourceId
+			)?.state
+		}
+
+		if let current {
+			switch (action, current) {
+			case (.store, .queued), (.store, .downloading), (.remove, .removing):
+				return false
+			case (.store, .removing), (.remove, .queued), (.remove, .downloading):
+				throw OfflineResourceOperationError.conflictingOperationInProgress(currentState: current)
+			default:
+				break
+			}
+		}
+		taskStates = taskStates.filter { _, task in
+			!task.resources.contains(resource) || task.state.isActiveOperation
+		}
+
+		let state: OfflineResourceState = action == .store ? .queued : .removing
+		transientStates[resource] = (action, state)
+		do {
+			try offlineStore.setResourceOperation(
+				resourceType: resource.resourceType,
+				resourceId: resource.resourceId,
+				action: action,
+				state: state
+			)
+		} catch {
+			transientStates.removeValue(forKey: resource)
+			try? offlineStore.deleteResourceOperation(resourceType: resource.resourceType, resourceId: resource.resourceId)
+			throw error
+		}
+		return true
+	}
+
+	func registrationFailed(_ action: InternalOfflineResourceAction, for resource: OfflineResourceKey) {
+		transientStates[resource] = (action, .failed(action: action.publicAction))
+		persistEffectiveOperation(for: resource)
+	}
+
+	func resolve(_ resource: OfflineResourceKey, state: OfflineResourceState) {
+		guard !isShutdown else {
+			return
+		}
+		transientStates[resource] = (.store, state)
+		try? offlineStore.deleteResourceOperation(resourceType: resource.resourceType, resourceId: resource.resourceId)
+	}
+
+	func record(
+		taskId: String,
+		action: InternalOfflineResourceAction,
+		state: OfflineResourceState,
+		resources: Set<OfflineResourceKey>
+	) throws {
+		guard !isShutdown else {
+			return
+		}
+		taskStates[taskId] = TaskState(action: action, state: state, resources: resources)
+		for resource in resources {
+			if let transientState = transientStates[resource],
+			   transientState.0 == action,
+			   !transientState.1.isFailure
+			{
+				transientStates.removeValue(forKey: resource)
+			}
+			persistEffectiveOperation(for: resource)
+		}
+	}
+
+	func update(taskId: String, state: OfflineResourceState) {
+		guard !isShutdown, var task = taskStates[taskId] else {
+			return
+		}
+		task.state = state
+		taskStates[taskId] = task
+		for resource in task.resources {
+			persistEffectiveOperation(for: resource)
+		}
+	}
+
+	func finish(taskId: String, succeeded: Bool) {
+		guard !isShutdown, var task = taskStates[taskId] else {
+			return
+		}
+		if !succeeded {
+			task.state = .failed(action: task.action.publicAction)
+			taskStates[taskId] = task
+			for resource in task.resources {
+				persistEffectiveOperation(for: resource)
+			}
+			return
+		}
+
+		taskStates.removeValue(forKey: taskId)
+		for resource in task.resources {
+			let finalState: OfflineResourceState = task.action == .store ? .downloaded : .notDownloaded
+			if transientStates[resource]?.1.isFailure != true {
+				transientStates[resource] = (task.action, finalState)
+			}
+			persistEffectiveOperation(for: resource)
+		}
+	}
+
+	func shutdown() {
+		guard !isShutdown else {
+			return
+		}
+		isShutdown = true
+		taskStates.removeAll()
+		transientStates.removeAll()
+	}
+
+	private func effectiveState(for resource: OfflineResourceKey) -> OfflineResourceState? {
+		let taskValues = taskStates.values.filter { $0.resources.contains(resource) }.map(\.state)
+		let values = taskValues + [transientStates[resource]?.1].compactMap { $0 }
+		return values.max { $0.priority < $1.priority }
+	}
+
+	private func persistEffectiveOperation(for resource: OfflineResourceKey) {
+		let taskOperations = taskStates.values
+			.filter { $0.resources.contains(resource) && ($0.state.isActiveOperation || $0.state.isFailure) }
+			.map { (action: $0.action, state: $0.state) }
+		let transientOperation = transientStates[resource].flatMap { operation in
+			operation.1.isActiveOperation || operation.1.isFailure ? operation : nil
+		}.map { (action: $0.0, state: $0.1) }
+		let operation = (taskOperations + [transientOperation].compactMap { $0 })
+			.max { $0.state.priority < $1.state.priority }
+
+		if let operation {
+			try? offlineStore.setResourceOperation(
+				resourceType: resource.resourceType,
+				resourceId: resource.resourceId,
+				action: operation.action,
+				state: operation.state
+			)
+		} else {
+			try? offlineStore.deleteResourceOperation(resourceType: resource.resourceType, resourceId: resource.resourceId)
+		}
+	}
+}
+
+extension OfflineResourceState {
+	var isActiveOperation: Bool {
+		switch self {
+		case .queued, .downloading, .removing: true
+		case .notDownloaded, .downloaded, .failed: false
+		}
+	}
+
+	var isFailure: Bool {
+		if case .failed = self {
+			return true
+		}
+		return false
+	}
+
+	var priority: Int {
+		switch self {
+		case .failed: 6
+		case .removing: 5
+		case .downloading: 4
+		case .queued: 3
+		case .downloaded: 2
+		case .notDownloaded: 1
+		}
+	}
+
+	var storageValue: String {
+		switch self {
+		case .notDownloaded: "not_downloaded"
+		case .queued: "queued"
+		case .downloading: "downloading"
+		case .downloaded: "downloaded"
+		case .removing: "removing"
+		case let .failed(action): "failed_\(action.rawValue)"
+		}
+	}
+
+	init?(storageValue: String) {
+		switch storageValue {
+		case "not_downloaded": self = .notDownloaded
+		case "queued": self = .queued
+		case "downloading": self = .downloading
+		case "downloaded": self = .downloaded
+		case "removing": self = .removing
+		case "failed_download": self = .failed(action: .download)
+		case "failed_remove": self = .failed(action: .remove)
+		default: return nil
+		}
+	}
+}

--- a/Sources/Offliner/Internal/Resources/Migrations/V000003_offline_resource_operations.sql
+++ b/Sources/Offliner/Internal/Resources/Migrations/V000003_offline_resource_operations.sql
@@ -1,0 +1,10 @@
+CREATE TABLE offline_resource_operation
+(
+    resource_type TEXT NOT NULL,
+    resource_id   TEXT NOT NULL,
+    action        TEXT NOT NULL,
+    state         TEXT NOT NULL,
+    updated_at    TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (resource_type, resource_id)
+);

--- a/Sources/Offliner/Internal/TaskRunner.swift
+++ b/Sources/Offliner/Internal/TaskRunner.swift
@@ -21,10 +21,12 @@ actor TaskRunner {
 	private let network: Network
 	private let mediaDownloader: MediaDownloaderProtocol
 	private let licenseDownloader: LicenseDownloader
+	private let resourceStateTracker: ResourceStateTracker
 
 	private var pendingTasks: [InternalTask] = []
 	private var runningTasks: [InternalTask] = []
 	private var taskIds: Set<String> = []
+	private var taskActions: [String: InternalOfflineResourceAction] = [:]
 
 	private var processTask: Task<Void, Never>?
 	private var rerunRequested = false
@@ -44,6 +46,7 @@ actor TaskRunner {
 		artworkDownloader: ArtworkDownloaderProtocol,
 		mediaDownloader: MediaDownloaderProtocol,
 		licenseDownloader: LicenseDownloader,
+		resourceStateTracker: ResourceStateTracker,
 		trackManifestFetcher: TrackManifestFetcherProtocol,
 		videoManifestFetcher: VideoManifestFetcherProtocol
 	) {
@@ -52,6 +55,7 @@ actor TaskRunner {
 		network = Network()
 		self.mediaDownloader = mediaDownloader
 		self.licenseDownloader = licenseDownloader
+		self.resourceStateTracker = resourceStateTracker
 
 		let (stream, continuation) = AsyncStream<Download>.makeStream()
 		newDownloads = stream
@@ -127,6 +131,13 @@ actor TaskRunner {
 			runningTasks.contains { $0.isDownloadTask(for: collection) }
 	}
 
+	func synchronizeState() async {
+		guard !isShutdown else {
+			return
+		}
+		try? await refresh()
+	}
+
 	func shutdown() async {
 		guard !isShutdown else {
 			if let processTask {
@@ -145,9 +156,11 @@ actor TaskRunner {
 		pendingTasks.removeAll()
 		runningTasks.removeAll()
 		taskIds.removeAll()
+		taskActions.removeAll()
 		currentDownloads.removeAll()
 		downloadsContinuation?.finish()
 		downloadsContinuation = nil
+		await resourceStateTracker.shutdown()
 	}
 
 	private func refresh() async throws {
@@ -163,7 +176,18 @@ actor TaskRunner {
 				return
 			}
 
-			for task in page.tasks where taskIds.insert(task.id).inserted {
+			for task in page.tasks where !taskIds.contains(task.id) {
+				let state = task.resourceState
+				try await resourceStateTracker.record(
+					taskId: task.id,
+					action: task.action,
+					state: state,
+					resources: task.resourceKeys
+				)
+				guard taskIds.insert(task.id).inserted else {
+					continue
+				}
+				taskActions[task.id] = task.action
 				guard task.state == .pending || task.state == .inProgress else {
 					continue
 				}
@@ -226,9 +250,19 @@ actor TaskRunner {
 		guard !isShutdown, !Task.isCancelled else {
 			return nil
 		}
-		let runningKeys = Set(runningTasks.map(\.concurrencyKey))
-
-		guard let index = pendingTasks.firstIndex(where: { !runningKeys.contains($0.concurrencyKey) }) else {
+		guard let index = pendingTasks.firstIndex(where: { candidate in
+			runningTasks.allSatisfy { running in
+				guard candidate.concurrencyKey != running.concurrencyKey else {
+					return false
+				}
+				let actionsDiffer = taskActions[candidate.id] != taskActions[running.id]
+				guard actionsDiffer else {
+					return true
+				}
+				let includesCollectionWideOperation = candidate.isCollectionWide || running.isCollectionWide
+				return !includesCollectionWideOperation || candidate.resourceKeys.isDisjoint(with: running.resourceKeys)
+			}
+		}) else {
 			return nil
 		}
 
@@ -256,11 +290,14 @@ actor TaskRunner {
 		} catch {
 			Self.logger.error("Failed to mark task \(task.id, privacy: .public) as in progress, skipping it: \(error, privacy: .public)")
 			await task.download?.updateState(.failed)
+			await resourceStateTracker.finish(taskId: task.id, succeeded: false)
 			finish(task)
 			return
 		}
 
 		await task.download?.updateState(.inProgress)
+		let activeState: OfflineResourceState = taskActions[task.id] == .remove ? .removing : .downloading
+		await resourceStateTracker.update(taskId: task.id, state: activeState)
 
 		do {
 			try await task.run()
@@ -270,6 +307,7 @@ actor TaskRunner {
 			}
 			await task.download?.updateState(.completed)
 			try? await offlineApiClient.updateTask(taskId: task.id, state: .completed)
+			await resourceStateTracker.finish(taskId: task.id, succeeded: true)
 		} catch is CancellationError {
 			finish(task)
 			return
@@ -281,6 +319,7 @@ actor TaskRunner {
 			Self.logger.error("Task \(task.id, privacy: .public) failed: \(error, privacy: .public)")
 			await task.download?.updateState(.failed)
 			try? await offlineApiClient.updateTask(taskId: task.id, state: .failed)
+			await resourceStateTracker.finish(taskId: task.id, succeeded: false)
 		}
 
 		finish(task)
@@ -289,6 +328,7 @@ actor TaskRunner {
 	private func finish(_ task: InternalTask) {
 		runningTasks.removeAll { $0 === task }
 		taskIds.remove(task.id)
+		taskActions.removeValue(forKey: task.id)
 		if let download = task.download {
 			currentDownloads.removeAll { $0 === download }
 		}
@@ -343,6 +383,7 @@ protocol InternalTask: AnyObject {
 	var id: String { get }
 	var download: Download? { get }
 	var concurrencyKey: OfflineTaskConcurrencyKey { get }
+	var resourceKeys: Set<OfflineResourceKey> { get }
 	func isDownloadTask(for collection: OfflineCollectionReference) -> Bool
 	func run() async throws
 }
@@ -352,5 +393,34 @@ extension InternalTask {
 
 	func isDownloadTask(for collection: OfflineCollectionReference) -> Bool {
 		download?.relatedCollection == collection
+	}
+
+	var resourceKeys: Set<OfflineResourceKey> {
+		var keys = Set([OfflineResourceKey(
+			resourceType: concurrencyKey.resourceType,
+			resourceId: concurrencyKey.resourceId
+		)])
+		if let collectionType = concurrencyKey.collectionType, let collectionId = concurrencyKey.collectionId {
+			keys.insert(OfflineResourceKey(resourceType: collectionType, resourceId: collectionId))
+		}
+		return keys
+	}
+
+	var isCollectionWide: Bool {
+		OfflineCollectionType(rawValue: concurrencyKey.resourceType) != nil
+	}
+}
+
+private extension OfflineTask {
+	var resourceState: OfflineResourceState {
+		switch (action, state) {
+		case (.store, .pending): .queued
+		case (.store, .inProgress): .downloading
+		case (.store, .failed): .failed(action: .download)
+		case (.store, .completed): .downloaded
+		case (.remove, .pending), (.remove, .inProgress): .removing
+		case (.remove, .failed): .failed(action: .remove)
+		case (.remove, .completed): .notDownloaded
+		}
 	}
 }

--- a/Sources/Offliner/Offliner.swift
+++ b/Sources/Offliner/Offliner.swift
@@ -11,6 +11,7 @@ public final class Offliner {
 	private let storage: OfflinerStorage
 	private let taskRunner: TaskRunner
 	private let mediaDownloader: MediaDownloaderProtocol
+	private let resourceStateTracker: ResourceStateTracker
 	private let collectionDownloadStatePollInterval: UInt64
 	private var trackManifestFetcher: TrackManifestFetcherProtocol
 	private let lifecycleLock = NSLock()
@@ -62,6 +63,7 @@ public final class Offliner {
 			fileStorage: storage.fileStorage
 		)
 		let licenseDownloader = LicenseDownloader(fileStorage: storage.fileStorage)
+		let resourceStateTracker = ResourceStateTracker(offlineStore: offlineStore)
 		let trackManifestFetcher = TrackManifestFetcher(audioFormats: configuration.audioFormats)
 		let videoManifestFetcher = VideoManifestFetcher()
 
@@ -69,6 +71,7 @@ public final class Offliner {
 		self.offlineStore = offlineStore
 		self.storage = storage
 		self.mediaDownloader = mediaDownloader
+		self.resourceStateTracker = resourceStateTracker
 		collectionDownloadStatePollInterval = Self.defaultCollectionDownloadStatePollInterval
 		self.trackManifestFetcher = trackManifestFetcher
 		audioFormats = configuration.audioFormats
@@ -79,6 +82,7 @@ public final class Offliner {
 			artworkDownloader: artworkDownloader,
 			mediaDownloader: mediaDownloader,
 			licenseDownloader: licenseDownloader,
+			resourceStateTracker: resourceStateTracker,
 			trackManifestFetcher: trackManifestFetcher,
 			videoManifestFetcher: videoManifestFetcher
 		)
@@ -113,10 +117,12 @@ public final class Offliner {
 	) {
 		let offlineStore = storage.offlineStore
 		let licenseDownloader = licenseDownloader ?? LicenseDownloader(fileStorage: storage.fileStorage)
+		let resourceStateTracker = ResourceStateTracker(offlineStore: offlineStore)
 		self.offlineApiClient = offlineApiClient
 		self.offlineStore = offlineStore
 		self.storage = storage
 		self.mediaDownloader = mediaDownloader
+		self.resourceStateTracker = resourceStateTracker
 		self.collectionDownloadStatePollInterval = collectionDownloadStatePollInterval
 		self.trackManifestFetcher = trackManifestFetcher
 		audioFormats = configuration.audioFormats
@@ -127,6 +133,7 @@ public final class Offliner {
 			artworkDownloader: artworkDownloader,
 			mediaDownloader: mediaDownloader,
 			licenseDownloader: licenseDownloader,
+			resourceStateTracker: resourceStateTracker,
 			trackManifestFetcher: trackManifestFetcher,
 			videoManifestFetcher: videoManifestFetcher
 		)
@@ -286,6 +293,19 @@ public final class Offliner {
 	) async throws -> Set<OfflineCollection> {
 		try ensureActive()
 		return try await Set(offlineStore.getCollections(collectionType: collectionType))
+	}
+
+	/// Returns the latest operation or local availability state for a media item or collection.
+	///
+	/// Locally persisted queued, removing, and failed operations survive Offliner recreation. A backend refresh is scheduled
+	/// to recover task progress, but a temporary network failure does not hide the locally known state.
+	public func getOfflineResourceState(for resource: OfflineResource) async throws -> OfflineResourceState {
+		try ensureActive()
+		await taskRunner.synchronizeState()
+		if let state = try await resourceStateTracker.state(for: OfflineResourceKey(resource)) {
+			return state
+		}
+		return try await localResourceState(for: resource)
 	}
 
 	/// Streams collection-level offline availability.
@@ -470,32 +490,40 @@ public final class Offliner {
 	// MARK: - Download/Remove
 
 	public func download(mediaType: OfflineMediaItemType, resourceId: ResourceId) async throws {
-		try ensureActive()
-		try await offlineApiClient.addItem(type: mediaType.toResourceType, id: resourceId.stringValue)
-		await taskRunner.run()
+		try await perform(
+			action: .store,
+			resource: .media(type: mediaType, resourceId: resourceId.stringValue),
+			resourceType: mediaType.toResourceType
+		)
 	}
 
 	public func download(collectionType: OfflineCollectionType, resourceId: ResourceId) async throws {
-		try ensureActive()
-		try await offlineApiClient.addItem(type: collectionType.toResourceType, id: resourceId.stringValue)
-		await taskRunner.run()
+		try await perform(
+			action: .store,
+			resource: .collection(type: collectionType, resourceId: resourceId.stringValue),
+			resourceType: collectionType.toResourceType
+		)
 	}
 
 	public func remove(mediaType: OfflineMediaItemType, resourceId: ResourceId) async throws {
-		try ensureActive()
-		try await offlineApiClient.removeItem(type: mediaType.toResourceType, id: resourceId.stringValue)
-		await taskRunner.run()
+		try await perform(
+			action: .remove,
+			resource: .media(type: mediaType, resourceId: resourceId.stringValue),
+			resourceType: mediaType.toResourceType
+		)
 	}
 
 	public func remove(collectionType: OfflineCollectionType, resourceId: ResourceId) async throws {
-		try ensureActive()
-		try await offlineApiClient.removeItem(type: collectionType.toResourceType, id: resourceId.stringValue)
+		try await perform(
+			action: .remove,
+			resource: .collection(type: collectionType, resourceId: resourceId.stringValue),
+			resourceType: collectionType.toResourceType
+		)
 		// Optimistically update local availability; the remove task performs the same idempotent cleanup.
 		try? offlineStore.deleteCollection(
 			resourceType: collectionType.rawValue,
 			resourceId: collectionLocalResourceId(collectionType: collectionType, resourceId: resourceId)
 		)
-		await taskRunner.run()
 	}
 
 	private func offlineCollectionDownloadState(
@@ -512,6 +540,69 @@ public final class Offliner {
 		)
 
 		return localCollection == nil ? .notDownloaded : .downloaded
+	}
+
+	private func perform(
+		action: InternalOfflineResourceAction,
+		resource: OfflineResource,
+		resourceType: ResourceType
+	) async throws {
+		try ensureActive()
+		let key = OfflineResourceKey(resource)
+		let localState = try await localResourceState(for: resource)
+		if let knownState = try await resourceStateTracker.state(for: key) {
+			if action == .store, localState == .downloaded,
+			   knownState == .downloaded || knownState == .failed(action: .remove)
+			{
+				await resourceStateTracker.resolve(key, state: .downloaded)
+				return
+			}
+			if action == .remove, localState == .notDownloaded,
+			   knownState == .notDownloaded || knownState == .failed(action: .download)
+			{
+				await resourceStateTracker.resolve(key, state: .notDownloaded)
+				return
+			}
+			guard try await resourceStateTracker.begin(action, for: key) else {
+				return
+			}
+		} else {
+			if action == .store, localState == .downloaded {
+				return
+			}
+			guard try await resourceStateTracker.begin(action, for: key) else {
+				return
+			}
+		}
+		do {
+			switch action {
+			case .store:
+				try await offlineApiClient.addItem(type: resourceType, id: key.resourceId)
+			case .remove:
+				try await offlineApiClient.removeItem(type: resourceType, id: key.resourceId)
+			}
+		} catch {
+			await resourceStateTracker.registrationFailed(action, for: key)
+			throw error
+		}
+		await taskRunner.run()
+	}
+
+	private func localResourceState(for resource: OfflineResource) async throws -> OfflineResourceState {
+		switch resource {
+		case let .media(mediaType, resourceId):
+			try await offlineStore.getMediaItem(mediaType: mediaType, resourceId: resourceId) == nil
+				? .notDownloaded
+				: .downloaded
+		case let .collection(collectionType, resourceId):
+			try await offlineStore.getCollection(
+				collectionType: collectionType,
+				resourceId: collectionLocalResourceId(
+					collectionType: collectionType,
+					resourceId: .identifier(resourceId)
+				)
+			) == nil ? .notDownloaded : .downloaded
+		}
 	}
 
 	private func collectionLocalResourceId(

--- a/Sources/Offliner/README.md
+++ b/Sources/Offliner/README.md
@@ -116,9 +116,6 @@ for await state in offliner.getOfflineCollectionDownloadState(
 }
 ```
 
-The stream is optimized for view entry and does not poll backend task inventory. Backend-provided per-collection
-activity metadata would be required for authoritative task state after a cold start.
-
 | State | Meaning |
 | --- | --- |
 | `.notDownloaded` | The collection is not locally available, or it is being removed. |
@@ -127,6 +124,27 @@ activity metadata would be required for authoritative task state after a cold st
 
 Removal tasks are not surfaced as `.downloading`; callers can map this state directly to a download button label:
 `Download`, `Downloading...`, and `Downloaded`.
+
+For resource-scoped media and collection state, use the normalized snapshot API:
+
+```swift
+let resource = OfflineResource.collection(type: .albums, resourceId: "album-id")
+let state = try await offliner.getOfflineResourceState(for: resource)
+
+switch state {
+case .notDownloaded, .queued, .downloading, .downloaded, .removing:
+    break
+case .failed(let action):
+    // `action` is `.download` or `.remove` and is the stable retry direction.
+    break
+}
+```
+
+Queued, removing, and failed operation state is stored in the installation-scoped Offliner database and recovered on a
+new `Offliner` instance. Backend task inventory refreshes queued versus active transfer state when connectivity permits;
+a refresh failure does not hide locally stored content or discard the last known operation. Repeating the same active
+request is idempotent. An opposite request while work is queued, downloading, or removing throws
+`OfflineResourceOperationError.conflictingOperationInProgress` so collection removal cannot race its member stores.
 
 #### Tracking Individual Download Progress
 

--- a/Sources/Offliner/Types.swift
+++ b/Sources/Offliner/Types.swift
@@ -2,14 +2,14 @@ import Foundation
 
 // MARK: - OfflineMediaItemType
 
-public enum OfflineMediaItemType: String, Sendable {
+public enum OfflineMediaItemType: String, Sendable, Hashable {
 	case tracks
 	case videos
 }
 
 // MARK: - OfflineCollectionType
 
-public enum OfflineCollectionType: String, Sendable {
+public enum OfflineCollectionType: String, Sendable, Hashable {
 	case albums
 	case playlists
 	case userCollectionTracks
@@ -27,6 +27,42 @@ public enum ResourceId: Sendable {
 		case .me: "me"
 		}
 	}
+}
+
+// MARK: - OfflineResource
+
+/// A stable identity for a resource managed by Offliner.
+public enum OfflineResource: Sendable, Hashable {
+	case media(type: OfflineMediaItemType, resourceId: String)
+	case collection(type: OfflineCollectionType, resourceId: String)
+}
+
+// MARK: - OfflineResourceAction
+
+/// The operation requested for an offline resource.
+public enum OfflineResourceAction: String, Sendable, Hashable {
+	case download
+	case remove
+}
+
+// MARK: - OfflineResourceState
+
+/// The normalized local operation and availability state of an offline resource.
+public enum OfflineResourceState: Sendable, Hashable {
+	case notDownloaded
+	case queued
+	case downloading
+	case downloaded
+	case removing
+	/// The operation failed. The associated action is the stable retry direction.
+	case failed(action: OfflineResourceAction)
+}
+
+// MARK: - OfflineResourceOperationError
+
+public enum OfflineResourceOperationError: Error, Sendable, Equatable {
+	/// The requested action conflicts with an operation already in progress for this resource.
+	case conflictingOperationInProgress(currentState: OfflineResourceState)
 }
 
 // MARK: - OfflineMediaItem

--- a/Tests/OfflinerTests/CollectionDownloadTests.swift
+++ b/Tests/OfflinerTests/CollectionDownloadTests.swift
@@ -155,7 +155,7 @@ final class CollectionDownloadTests: OfflinerTestCase {
 		XCTAssertEqual(state, .notDownloaded)
 	}
 
-	func testRedownloadAlbumDeletesOldArtworkAndStoresNewOne() async throws {
+	func testRepeatedDownloadAlbumIsIdempotentAfterCompletion() async throws {
 		let backend = StubOfflineApiClient()
 		let offliner = createOffliner(
 			offlineApiClient: backend,
@@ -182,9 +182,10 @@ final class CollectionDownloadTests: OfflinerTestCase {
 		let secondCollection = try XCTUnwrap(secondCollectionOptional)
 		let secondArtworkURL = try XCTUnwrap(secondCollection.artworkURL)
 
-		XCTAssertFalse(FileManager.default.fileExists(atPath: firstArtworkURL.path))
+		XCTAssertTrue(FileManager.default.fileExists(atPath: firstArtworkURL.path))
 		XCTAssertTrue(FileManager.default.fileExists(atPath: secondArtworkURL.path))
-		XCTAssertNotEqual(firstArtworkURL, secondArtworkURL)
+		XCTAssertEqual(firstArtworkURL, secondArtworkURL)
+		XCTAssertEqual(backend.addedItems.count, 1)
 	}
 
 	func testDownloadAlbumFailsWhenArtworkDownloadFails() async throws {

--- a/Tests/OfflinerTests/MediaItemDownloadTests.swift
+++ b/Tests/OfflinerTests/MediaItemDownloadTests.swift
@@ -124,9 +124,10 @@ final class MediaItemDownloadTests: OfflinerTestCase {
 		XCTAssertEqual(URL(fileURLWithPath: embeddedPath).standardizedFileURL.path, movedURL.standardizedFileURL.path)
 	}
 
-	func testRedownloadTrackDeletesOldFilesAndStoresNewOnes() async throws {
+	func testRepeatedDownloadTrackIsIdempotentAfterCompletion() async throws {
+		let backend = StubOfflineApiClient()
 		let offliner = createOffliner(
-			offlineApiClient: StubOfflineApiClient(),
+			offlineApiClient: backend,
 			artworkDownloader: SucceedingArtworkDownloader(),
 			mediaDownloader: SucceedingMediaDownloader()
 		)
@@ -146,7 +147,6 @@ final class MediaItemDownloadTests: OfflinerTestCase {
 		XCTAssertTrue(FileManager.default.fileExists(atPath: firstArtworkURL.path))
 
 		try await offliner.download(mediaType: .tracks, resourceId: .identifier("track-123"))
-		try await downloadAndWaitForCompletion(offliner)
 
 		let secondItem = try await offliner.getOfflineMediaItem(mediaType: .tracks, resourceId: .identifier("track-123"))
 		let secondItemUnwrapped = try XCTUnwrap(secondItem)
@@ -157,14 +157,15 @@ final class MediaItemDownloadTests: OfflinerTestCase {
 		let secondMediaURL = try XCTUnwrap(secondPlayableItem?.mediaURL)
 		let secondArtworkURL = try XCTUnwrap(secondItemUnwrapped.artworkURL)
 
-		XCTAssertFalse(FileManager.default.fileExists(atPath: firstMediaURL.path))
-		XCTAssertFalse(FileManager.default.fileExists(atPath: firstArtworkURL.path))
+		XCTAssertTrue(FileManager.default.fileExists(atPath: firstMediaURL.path))
+		XCTAssertTrue(FileManager.default.fileExists(atPath: firstArtworkURL.path))
 
 		XCTAssertTrue(FileManager.default.fileExists(atPath: secondMediaURL.path))
 		XCTAssertTrue(FileManager.default.fileExists(atPath: secondArtworkURL.path))
 
-		XCTAssertNotEqual(firstMediaURL, secondMediaURL)
-		XCTAssertNotEqual(firstArtworkURL, secondArtworkURL)
+		XCTAssertEqual(firstMediaURL, secondMediaURL)
+		XCTAssertEqual(firstArtworkURL, secondArtworkURL)
+		XCTAssertEqual(backend.addedItems.count, 1)
 	}
 
 	func testDownloadTrackFailsWhenMediaDownloadFails() async throws {

--- a/Tests/OfflinerTests/ResourceStateTests.swift
+++ b/Tests/OfflinerTests/ResourceStateTests.swift
@@ -1,0 +1,328 @@
+import GRDB
+@testable import Offliner
+import TidalAPI
+import XCTest
+
+// MARK: - ResourceStateTests
+
+final class ResourceStateTests: OfflinerTestCase {
+	func testRegistrationFailurePreservesDownloadRetryDirection() async throws {
+		let offliner = createOffliner(
+			offlineApiClient: FailingOfflineApiClient(),
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+		let resource = OfflineResource.media(type: .tracks, resourceId: "track-1")
+
+		await XCTAssertThrowsErrorAsync {
+			try await offliner.download(mediaType: .tracks, resourceId: .identifier("track-1"))
+		}
+
+		let state = try await offliner.getOfflineResourceState(for: resource)
+		XCTAssertEqual(state, .failed(action: .download))
+	}
+
+	func testLegacyCollectionStateMapsFailedDownloadToNotDownloaded() async throws {
+		let offliner = createOffliner(
+			offlineApiClient: FailingOfflineApiClient(),
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+		await XCTAssertThrowsErrorAsync {
+			try await offliner.download(collectionType: .albums, resourceId: .identifier("album-1"))
+		}
+
+		let state = await offliner.getOfflineCollectionDownloadState(
+			collectionType: .albums,
+			resourceId: .identifier("album-1")
+		).first()
+		XCTAssertEqual(state, .notDownloaded)
+	}
+
+	func testLegacyCollectionStateMapsFailedRemoveToDownloaded() async throws {
+		let storage = try OfflinerStorage(installationId: "failed-remove", baseDirectory: tempDir)
+		try storage.offlineStore.storeCollection(StoreCollectionTaskResult(
+			resourceType: .albums,
+			resourceId: "album-1",
+			catalogMetadata: .album(.mock(id: "album-1")),
+			artworkURL: nil
+		))
+		let offliner = Offliner(
+			storage: storage,
+			offlineApiClient: FailingOfflineApiClient(),
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader(),
+			trackManifestFetcher: SucceedingTrackManifestFetcher(),
+			videoManifestFetcher: SucceedingVideoManifestFetcher()
+		)
+		await XCTAssertThrowsErrorAsync {
+			try await offliner.remove(collectionType: .albums, resourceId: .identifier("album-1"))
+		}
+		let exactState = try await offliner.getOfflineResourceState(
+			for: .collection(type: .albums, resourceId: "album-1")
+		)
+		XCTAssertEqual(exactState, .failed(action: .remove))
+
+		let state = await offliner.getOfflineCollectionDownloadState(
+			collectionType: .albums,
+			resourceId: .identifier("album-1")
+		).first()
+		XCTAssertEqual(state, .downloaded)
+	}
+
+	func testRepeatedDownloadWhileQueuedRegistersOnlyOnce() async throws {
+		let backend = HoldingOfflineApiClient()
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+
+		try await offliner.download(mediaType: .tracks, resourceId: .identifier("track-1"))
+		try await offliner.download(mediaType: .tracks, resourceId: .identifier("track-1"))
+
+		XCTAssertEqual(backend.addedItems.count, 1)
+		let state = try await offliner.getOfflineResourceState(for: .media(type: .tracks, resourceId: "track-1"))
+		XCTAssertEqual(state, .queued)
+	}
+
+	func testRepeatedRemoveWhileRemovingRegistersOnlyOnce() async throws {
+		let backend = HoldingOfflineApiClient()
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+
+		try await offliner.remove(mediaType: .videos, resourceId: .identifier("video-1"))
+		try await offliner.remove(mediaType: .videos, resourceId: .identifier("video-1"))
+
+		XCTAssertEqual(backend.removedItems.count, 1)
+		let state = try await offliner.getOfflineResourceState(for: .media(type: .videos, resourceId: "video-1"))
+		XCTAssertEqual(state, .removing)
+	}
+
+	func testOppositeOperationsAreRejectedInBothDirections() async throws {
+		let backend = HoldingOfflineApiClient()
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+
+		try await offliner.download(mediaType: .tracks, resourceId: .identifier("track-1"))
+		do {
+			try await offliner.remove(mediaType: .tracks, resourceId: .identifier("track-1"))
+			XCTFail("Expected the queued download to reject removal")
+		} catch let error as OfflineResourceOperationError {
+			XCTAssertEqual(error, .conflictingOperationInProgress(currentState: .queued))
+		}
+
+		try await offliner.remove(mediaType: .videos, resourceId: .identifier("video-1"))
+		do {
+			try await offliner.download(mediaType: .videos, resourceId: .identifier("video-1"))
+			XCTFail("Expected the active removal to reject download")
+		} catch let error as OfflineResourceOperationError {
+			XCTAssertEqual(error, .conflictingOperationInProgress(currentState: .removing))
+		}
+
+		XCTAssertTrue(backend.removedItems.allSatisfy { $0.id != "track-1" })
+		XCTAssertTrue(backend.addedItems.allSatisfy { $0.id != "video-1" })
+	}
+
+	func testQueuedStateRecoversOfflineAfterOfflinerRecreation() async throws {
+		let installationId = "relaunch-installation"
+		let firstBackend = HoldingOfflineApiClient()
+		let first = createOffliner(
+			installationId: installationId,
+			offlineApiClient: firstBackend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+		try await first.download(collectionType: .albums, resourceId: .identifier("album-1"))
+		let persistedState = try await lastDatabaseQueue.read { database in
+			try String.fetchOne(database, sql: "SELECT state FROM offline_resource_operation WHERE resource_id = 'album-1'")
+		}
+		XCTAssertEqual(persistedState, "queued")
+
+		let second = createOffliner(
+			installationId: installationId,
+			offlineApiClient: FailOnGetTasksOfflineApiClient(),
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+
+		let state = try await second.getOfflineResourceState(for: .collection(type: .albums, resourceId: "album-1"))
+		XCTAssertEqual(state, .queued)
+	}
+
+	func testFailedBackendTaskRecoversOnNewOfflinerInstance() async throws {
+		let backend = StubOfflineApiClient()
+		backend.enqueueTasks([.storeAlbum(StoreAlbumTask(
+			id: "failed-album",
+			state: .failed,
+			album: AlbumsResourceObject(id: "album-1", type: "albums"),
+			artists: [],
+			artwork: nil
+		))])
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+
+		await offliner.run()
+		let state = try await offliner.getOfflineResourceState(
+			for: .collection(type: .albums, resourceId: "album-1")
+		)
+		XCTAssertEqual(state, .failed(action: .download))
+	}
+
+	func testExplicitRetrySupersedesFailureGeneration() async throws {
+		let storage = try OfflinerStorage(installationId: "retry-state", baseDirectory: tempDir)
+		let tracker = ResourceStateTracker(offlineStore: storage.offlineStore)
+		let resource = OfflineResourceKey(.media(type: .tracks, resourceId: "track-1"))
+		_ = try await tracker.begin(.store, for: resource)
+		await tracker.registrationFailed(.store, for: resource)
+
+		let retried = try await tracker.begin(.store, for: resource)
+		let state = try await tracker.state(for: resource)
+
+		XCTAssertTrue(retried)
+		XCTAssertEqual(state, .queued)
+	}
+
+	func testCollectionStorePublishesDownloadingRatherThanRemoving() async throws {
+		let backend = StubOfflineApiClient()
+		let artwork = SuspendingArtworkDownloader()
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: artwork,
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+
+		try await offliner.download(collectionType: .albums, resourceId: .identifier("album-1"))
+		await artwork.waitUntilStarted()
+
+		let state = try await offliner.getOfflineResourceState(for: .collection(type: .albums, resourceId: "album-1"))
+		XCTAssertEqual(state, .downloading)
+		await artwork.complete()
+		await backend.waitForTasksToComplete()
+	}
+
+	func testMediaStateTransitionsToDownloaded() async throws {
+		let backend = StubOfflineApiClient()
+		let media = SuspendingMediaDownloader()
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: media
+		)
+		let downloads = offliner.newDownloads
+
+		try await offliner.download(mediaType: .tracks, resourceId: .identifier("track-1"))
+		var iterator = downloads.makeAsyncIterator()
+		let download = await iterator.next()
+		await media.waitUntilStarted()
+
+		XCTAssertNotNil(download)
+		let state = try await offliner.getOfflineResourceState(for: .media(type: .tracks, resourceId: "track-1"))
+		XCTAssertEqual(state, .downloading)
+
+		await media.complete()
+		await backend.waitForTasksToComplete()
+		await assertEventuallyResourceState(
+			offliner,
+			resource: .media(type: .tracks, resourceId: "track-1"),
+			expected: .downloaded
+		)
+	}
+
+	func testCollectionFailureSurvivesLaterSiblingSuccess() async throws {
+		let installationId = "sibling-failure"
+		let backend = StubOfflineApiClient()
+		let media = SelectiveSuspendingMediaDownloader(failingTaskIds: ["failing-track"])
+		let offliner = createOffliner(
+			installationId: installationId,
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: media
+		)
+		backend.enqueueTasks([
+			.storeTrack(storeTrackTask(id: "failing-track", trackId: "track-1", position: 1)),
+			.storeTrack(storeTrackTask(id: "succeeding-track", trackId: "track-2", position: 2)),
+		])
+
+		await offliner.run()
+		await media.waitUntilStarted(count: 2)
+		await assertEventuallyResourceState(
+			offliner,
+			resource: .collection(type: .albums, resourceId: "album-1"),
+			expected: .failed(action: .download)
+		)
+
+		await media.complete(taskId: "succeeding-track")
+		await backend.waitForTasksToComplete()
+		let finalState = try await offliner.getOfflineResourceState(
+			for: .collection(type: .albums, resourceId: "album-1")
+		)
+		XCTAssertEqual(finalState, .failed(action: .download))
+		let persistedState = try await lastDatabaseQueue.read { database in
+			try String.fetchOne(database, sql: "SELECT state FROM offline_resource_operation WHERE resource_id = 'album-1'")
+		}
+		XCTAssertEqual(persistedState, "failed_download")
+
+		let recreated = createOffliner(
+			installationId: installationId,
+			offlineApiClient: FailOnGetTasksOfflineApiClient(),
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+		let recoveredState = try await recreated.getOfflineResourceState(
+			for: .collection(type: .albums, resourceId: "album-1")
+		)
+		XCTAssertEqual(recoveredState, .failed(action: .download))
+	}
+
+	private func storeTrackTask(id: String, trackId: String, position: Int) -> StoreTrackTask {
+		StoreTrackTask(
+			id: id,
+			track: TracksResourceObject(id: trackId, type: "tracks"),
+			artists: [],
+			artwork: nil,
+			collectionResourceType: "albums",
+			collectionResourceId: "album-1",
+			volume: 1,
+			position: position
+		)
+	}
+
+	private func assertEventuallyResourceState(
+		_ offliner: Offliner,
+		resource: OfflineResource,
+		expected: OfflineResourceState,
+		file: StaticString = #filePath,
+		line: UInt = #line
+	) async {
+		for _ in 0 ..< 100 {
+			if let state = try? await offliner.getOfflineResourceState(for: resource), state == expected {
+				return
+			}
+			try? await Task.sleep(nanoseconds: 10_000_000)
+		}
+		XCTFail("Timed out waiting for \(expected)", file: file, line: line)
+	}
+}
+
+private func XCTAssertThrowsErrorAsync(
+	_ expression: () async throws -> Void,
+	file: StaticString = #filePath,
+	line: UInt = #line
+) async {
+	do {
+		try await expression()
+		XCTFail("Expected error", file: file, line: line)
+	} catch {
+		// Expected.
+	}
+}

--- a/Tests/OfflinerTests/TaskConflictTests.swift
+++ b/Tests/OfflinerTests/TaskConflictTests.swift
@@ -60,7 +60,35 @@ final class TaskConflictTests: OfflinerTestCase {
 		await runTask
 	}
 
-	private func storeTrackTask(id: String, trackId: String) -> StoreTrackTask {
+	func testAlbumMemberStoresRunConcurrentlyWhileCollectionRemoveWaits() async throws {
+		let backend = StubOfflineApiClient()
+		let media = SelectiveSuspendingMediaDownloader()
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: media
+		)
+
+		backend.enqueueTasks([
+			.storeTrack(storeTrackTask(id: "store-1", trackId: "track-1", position: 1)),
+			.storeTrack(storeTrackTask(id: "store-2", trackId: "track-2", position: 2)),
+			.removeCollection(RemoveCollectionTask(id: "remove-album", resourceType: "albums", resourceId: "album-1")),
+		])
+
+		await offliner.run()
+		await media.waitUntilStarted(count: 2)
+		try await Task.sleep(nanoseconds: 100_000_000)
+		XCTAssertFalse(backend.completedTaskIds.contains("remove-album"))
+
+		await media.complete(taskId: "store-1")
+		await media.complete(taskId: "store-2")
+		await backend.waitForTasksToComplete()
+
+		XCTAssertEqual(Set(backend.completedTaskIds.prefix(2)), Set(["store-1", "store-2"]))
+		XCTAssertEqual(backend.completedTaskIds.last, "remove-album")
+	}
+
+	private func storeTrackTask(id: String, trackId: String, position: Int = 1) -> StoreTrackTask {
 		StoreTrackTask(
 			id: id,
 			track: TracksResourceObject(id: trackId, type: "tracks"),
@@ -69,7 +97,7 @@ final class TaskConflictTests: OfflinerTestCase {
 			collectionResourceType: "albums",
 			collectionResourceId: "album-1",
 			volume: 1,
-			position: 1
+			position: position
 		)
 	}
 

--- a/Tests/OfflinerTests/TestFakes.swift
+++ b/Tests/OfflinerTests/TestFakes.swift
@@ -266,6 +266,36 @@ final class FailOnGetTasksOfflineApiClient: OfflineApiClientProtocol {
 	func updateTask(taskId: String, state: Download.State) async throws {}
 }
 
+// MARK: - HoldingOfflineApiClient
+
+final class HoldingOfflineApiClient: OfflineApiClientProtocol {
+	private let lock = NSLock()
+	private var addedItemsStorage: [StubOfflineApiClient.RecordedItem] = []
+	private var removedItemsStorage: [StubOfflineApiClient.RecordedItem] = []
+
+	var addedItems: [StubOfflineApiClient.RecordedItem] {
+		lock.withLock { addedItemsStorage }
+	}
+
+	var removedItems: [StubOfflineApiClient.RecordedItem] {
+		lock.withLock { removedItemsStorage }
+	}
+
+	func addItem(type: ResourceType, id: String) async throws {
+		lock.withLock { addedItemsStorage.append(.init(type: type, id: id)) }
+	}
+
+	func removeItem(type: ResourceType, id: String) async throws {
+		lock.withLock { removedItemsStorage.append(.init(type: type, id: id)) }
+	}
+
+	func getTasks(cursor: String?) async throws -> (tasks: [OfflineTask], cursor: String?) {
+		([], nil)
+	}
+
+	func updateTask(taskId: String, state: Download.State) async throws {}
+}
+
 // MARK: - SucceedingArtworkDownloader
 
 final class SucceedingArtworkDownloader: ArtworkDownloaderProtocol {
@@ -391,9 +421,7 @@ actor SuspendingMediaDownloader: MediaDownloaderProtocol {
 		self.resumesOnCancel = resumesOnCancel
 	}
 
-	nonisolated func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void) -> Bool {
-		false
-	}
+	nonisolated func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void) -> Bool { false }
 
 	func cancelAll() {
 		cancelled = true
@@ -452,6 +480,55 @@ actor SuspendingMediaDownloader: MediaDownloaderProtocol {
 			self.startedContinuation = nil
 
 			startedContinuation?.resume()
+		}
+	}
+}
+
+// MARK: - SelectiveSuspendingMediaDownloader
+
+actor SelectiveSuspendingMediaDownloader: MediaDownloaderProtocol {
+	private var startedTaskIds: Set<String> = []
+	private var continuations: [String: CheckedContinuation<MediaDownloadResult, Error>] = [:]
+	private let failingTaskIds: Set<String>
+
+	init(failingTaskIds: Set<String> = []) {
+		self.failingTaskIds = failingTaskIds
+	}
+
+	nonisolated func handleBackgroundURLSessionEvents(identifier: String, completionHandler: @escaping () -> Void) -> Bool { false }
+
+	func cancelAll() {
+		for continuation in continuations.values {
+			continuation.resume(throwing: CancellationError())
+		}
+		continuations.removeAll()
+	}
+
+	func waitUntilStarted(count: Int) async {
+		while startedTaskIds.count < count {
+			await Task.yield()
+		}
+	}
+
+	func complete(taskId: String) {
+		let url = FileManager.default.temporaryDirectory.appendingPathComponent("media-\(taskId)-\(UUID().uuidString).m4a")
+		try? Data("media".utf8).write(to: url)
+		continuations.removeValue(forKey: taskId)?.resume(returning: MediaDownloadResult(duration: 120, mediaLocation: url))
+	}
+
+	func download(
+		taskId: String,
+		manifestURL: URL,
+		licenseDownloadResult: LicenseDownloadResult?,
+		title: String,
+		onProgress: @escaping @Sendable (Double) async -> Void
+	) async throws -> MediaDownloadResult {
+		startedTaskIds.insert(taskId)
+		if failingTaskIds.contains(taskId) {
+			throw FakeError.downloadFailed
+		}
+		return try await withCheckedThrowingContinuation { continuation in
+			continuations[taskId] = continuation
 		}
 	}
 }


### PR DESCRIPTION
## What
- New public API: `Offliner.getOfflineResourceState(for: OfflineResource) -> OfflineResourceState` with public types `OfflineResource`, `OfflineResourceAction`, `OfflineResourceState`, `OfflineResourceOperationError`.
- `ResourceStateTracker` (new actor) + `V000003` migration: queued/removing/failed operations persist in the installation-scoped database and survive Offliner recreation; backend refresh recovers active-transfer state but a network failure never hides locally known state.
- `download`/`remove` now route through a `perform()` gate: repeating the same active request is idempotent (no duplicate backend registration); an opposite request while an operation is queued/downloading/removing throws `conflictingOperationInProgress`.
- Action-aware task concurrency in `TaskRunner`: album member stores may run concurrently, but a collection-wide remove waits for overlapping member operations (and vice versa), so removal cannot race member stores.

## Why
The Watch client renders per-item/per-collection download state via `getOfflineResourceState` (2 call sites) and relies on the idempotency/conflict rules to keep taps on download/remove buttons safe against double-submission and races.

## Stack
PR 6/7 of the TM-1573 stack replacing #413. Next (final): download queue observation.

## Testing
`xcodebuild test -scheme Offliner -destination platform=macOS` — 100 tests, 0 failures, including new `ResourceStateTests`, extended `TaskConflictTests`, and idempotency tests for repeated track/album downloads.