### PR TITLE
TM-1573: Add relaunch-safe aggregate download queue observation with progress

### DIFF
--- a/Sources/Offliner/Download.swift
+++ b/Sources/Offliner/Download.swift
@@ -20,17 +20,20 @@ public actor Download {
 	nonisolated let relatedCollection: OfflineCollectionReference?
 
 	private let continuation: AsyncStream<Event>.Continuation
+	private let progressHandler: (@Sendable (Double) async -> Void)?
 
 	init(
 		title: String,
 		artists: [String],
 		imageURL: URL?,
-		relatedCollection: OfflineCollectionReference? = nil
+		relatedCollection: OfflineCollectionReference? = nil,
+		progressHandler: (@Sendable (Double) async -> Void)? = nil
 	) {
 		self.title = title
 		self.artists = artists
 		self.imageURL = imageURL
 		self.relatedCollection = relatedCollection
+		self.progressHandler = progressHandler
 
 		let (stream, continuation) = AsyncStream<Event>.makeStream()
 		events = stream
@@ -45,7 +48,8 @@ public actor Download {
 		}
 	}
 
-	func updateProgress(_ newProgress: Double) {
+	func updateProgress(_ newProgress: Double) async {
 		continuation.yield(.progress(newProgress))
+		await progressHandler?(newProgress)
 	}
 }

--- a/Sources/Offliner/Internal/Handlers/StoreTrackHandler.swift
+++ b/Sources/Offliner/Internal/Handlers/StoreTrackHandler.swift
@@ -1,4 +1,3 @@
-import AVFoundation
 import Foundation
 import TidalAPI
 
@@ -10,19 +9,22 @@ final class StoreTrackHandler {
 	private let mediaDownloader: MediaDownloaderProtocol
 	private let manifestFetcher: TrackManifestFetcherProtocol
 	private let licenseDownloader: LicenseDownloader
+	private let resourceStateTracker: ResourceStateTracker
 
 	init(
 		offlineStore: OfflineStore,
 		artworkDownloader: ArtworkDownloaderProtocol,
 		mediaDownloader: MediaDownloaderProtocol,
 		manifestFetcher: TrackManifestFetcherProtocol,
-		licenseDownloader: LicenseDownloader
+		licenseDownloader: LicenseDownloader,
+		resourceStateTracker: ResourceStateTracker
 	) {
 		self.offlineStore = offlineStore
 		self.artworkDownloader = artworkDownloader
 		self.mediaDownloader = mediaDownloader
 		self.manifestFetcher = manifestFetcher
 		self.licenseDownloader = licenseDownloader
+		self.resourceStateTracker = resourceStateTracker
 	}
 
 	func handle(_ task: StoreTrackTask) -> InternalTask {
@@ -39,7 +41,10 @@ final class StoreTrackHandler {
 				title: title,
 				artists: artists,
 				imageURL: imageURL,
-				relatedCollection: relatedCollection
+				relatedCollection: relatedCollection,
+				progressHandler: { [resourceStateTracker] progress in
+					await resourceStateTracker.updateProgress(taskId: task.id, progress: progress)
+				}
 			),
 			offlineStore: offlineStore,
 			artworkDownloader: artworkDownloader,

--- a/Sources/Offliner/Internal/Handlers/StoreVideoHandler.swift
+++ b/Sources/Offliner/Internal/Handlers/StoreVideoHandler.swift
@@ -1,4 +1,3 @@
-import AVFoundation
 import Foundation
 import TidalAPI
 
@@ -10,19 +9,22 @@ final class StoreVideoHandler {
 	private let mediaDownloader: MediaDownloaderProtocol
 	private let manifestFetcher: VideoManifestFetcherProtocol
 	private let licenseDownloader: LicenseDownloader
+	private let resourceStateTracker: ResourceStateTracker
 
 	init(
 		offlineStore: OfflineStore,
 		artworkDownloader: ArtworkDownloaderProtocol,
 		mediaDownloader: MediaDownloaderProtocol,
 		manifestFetcher: VideoManifestFetcherProtocol,
-		licenseDownloader: LicenseDownloader
+		licenseDownloader: LicenseDownloader,
+		resourceStateTracker: ResourceStateTracker
 	) {
 		self.offlineStore = offlineStore
 		self.artworkDownloader = artworkDownloader
 		self.mediaDownloader = mediaDownloader
 		self.manifestFetcher = manifestFetcher
 		self.licenseDownloader = licenseDownloader
+		self.resourceStateTracker = resourceStateTracker
 	}
 
 	func handle(_ task: StoreVideoTask) -> InternalTask {
@@ -39,7 +41,10 @@ final class StoreVideoHandler {
 				title: title,
 				artists: artists,
 				imageURL: imageURL,
-				relatedCollection: relatedCollection
+				relatedCollection: relatedCollection,
+				progressHandler: { [resourceStateTracker] progress in
+					await resourceStateTracker.updateProgress(taskId: task.id, progress: progress)
+				}
 			),
 			offlineStore: offlineStore,
 			artworkDownloader: artworkDownloader,

--- a/Sources/Offliner/Internal/OfflineApiClient.swift
+++ b/Sources/Offliner/Internal/OfflineApiClient.swift
@@ -231,6 +231,64 @@ enum OfflineTask {
 			return resources
 		}
 	}
+
+	var downloadQueueTask: DownloadQueueTask? {
+		switch self {
+		case let .storeTrack(task):
+			return DownloadQueueTask(
+				resource: .media(type: .tracks, resourceId: task.track.id),
+				parentCollection: OfflineResourceKey(
+					resourceType: task.collectionResourceType,
+					resourceId: task.collectionResourceId
+				).publicCollection,
+				supportsProgress: true
+			)
+		case let .storeVideo(task):
+			return DownloadQueueTask(
+				resource: .media(type: .videos, resourceId: task.video.id),
+				parentCollection: OfflineResourceKey(
+					resourceType: task.collectionResourceType,
+					resourceId: task.collectionResourceId
+				).publicCollection,
+				supportsProgress: true
+			)
+		case let .storeAlbum(task):
+			return DownloadQueueTask(
+				resource: .collection(type: .albums, resourceId: task.album.id),
+				parentCollection: nil,
+				supportsProgress: false
+			)
+		case let .storePlaylist(task):
+			return DownloadQueueTask(
+				resource: .collection(type: .playlists, resourceId: task.playlist.id),
+				parentCollection: nil,
+				supportsProgress: false
+			)
+		case let .storeUserCollectionTracks(task):
+			return DownloadQueueTask(
+				resource: .collection(type: .userCollectionTracks, resourceId: task.resourceId),
+				parentCollection: nil,
+				supportsProgress: false
+			)
+		case let .terminal(task) where task.action == .store:
+			let resourceKey = OfflineResourceKey(resourceType: task.resourceType, resourceId: task.resourceId)
+			guard let resource = resourceKey.publicResource else {
+				return nil
+			}
+			let parentCollection = task.collectionResourceType.flatMap { type in
+				task.collectionResourceId.flatMap { id in
+					OfflineResourceKey(resourceType: type, resourceId: id).publicCollection
+				}
+			}
+			return DownloadQueueTask(
+				resource: resource,
+				parentCollection: parentCollection,
+				supportsProgress: resourceKey.publicCollection == nil
+			)
+		case .removeItem, .removeCollection, .terminal:
+			return nil
+		}
+	}
 }
 
 // MARK: - OfflineCollectionReference

--- a/Sources/Offliner/Internal/OfflineStore.swift
+++ b/Sources/Offliner/Internal/OfflineStore.swift
@@ -81,6 +81,101 @@ final class OfflineStore {
 		}
 	}
 
+	func getDownloadQueueEntries() throws -> [OfflineDownloadQueueEntry] {
+		try databaseQueue.read { database in
+			try Row.fetchAll(
+				database,
+				sql: """
+				SELECT resource_type, resource_id, parent_collection_type, parent_collection_id, state, progress
+				FROM offline_download_queue
+				ORDER BY resource_type, resource_id
+				"""
+			).compactMap(Self.downloadQueueEntry)
+		}
+	}
+
+	func getDownloadQueueEntry(resourceType: String, resourceId: String) throws -> OfflineDownloadQueueEntry? {
+		try databaseQueue.read { database in
+			try Row.fetchOne(
+				database,
+				sql: """
+				SELECT resource_type, resource_id, parent_collection_type, parent_collection_id, state, progress
+				FROM offline_download_queue
+				WHERE resource_type = ? AND resource_id = ?
+				""",
+				arguments: [resourceType, resourceId]
+			).flatMap(Self.downloadQueueEntry)
+		}
+	}
+
+	func setDownloadQueueEntry(_ entry: OfflineDownloadQueueEntry) throws {
+		let resource = OfflineResourceKey(entry.resource)
+		let parentCollection = entry.parentCollection.map(OfflineResourceKey.init)
+		writeLock.lock()
+		defer { writeLock.unlock() }
+		try ensureAcceptsWritesLocked()
+		try databaseQueue.write { database in
+			try database.execute(
+				sql: """
+				INSERT INTO offline_download_queue \
+				(resource_type, resource_id, parent_collection_type, parent_collection_id, state, progress)
+				VALUES (?, ?, ?, ?, ?, ?)
+				ON CONFLICT (resource_type, resource_id) DO UPDATE SET
+					parent_collection_type = excluded.parent_collection_type,
+					parent_collection_id = excluded.parent_collection_id,
+					state = excluded.state,
+					progress = excluded.progress,
+					updated_at = CURRENT_TIMESTAMP
+				""",
+				arguments: [
+					resource.resourceType,
+					resource.resourceId,
+					parentCollection?.resourceType,
+					parentCollection?.resourceId,
+					entry.state.storageValue,
+					entry.progress,
+				]
+			)
+		}
+	}
+
+	func deleteDownloadQueueEntry(resourceType: String, resourceId: String) throws {
+		writeLock.lock()
+		defer { writeLock.unlock() }
+		try ensureAcceptsWritesLocked()
+		try databaseQueue.write { database in
+			try database.execute(
+				sql: "DELETE FROM offline_download_queue WHERE resource_type = ? AND resource_id = ?",
+				arguments: [resourceType, resourceId]
+			)
+		}
+	}
+
+	private static func downloadQueueEntry(_ row: Row) -> OfflineDownloadQueueEntry? {
+		guard let resource = OfflineResourceKey(
+			resourceType: row["resource_type"],
+			resourceId: row["resource_id"]
+		).publicResource,
+			let state = OfflineDownloadQueueEntry.State(storageValue: row["state"])
+		else {
+			return nil
+		}
+
+		let parentCollection: OfflineResource? = if let parentType: String = row["parent_collection_type"],
+		                                            let parentId: String = row["parent_collection_id"]
+		{
+			OfflineResourceKey(resourceType: parentType, resourceId: parentId).publicCollection
+		} else {
+			nil
+		}
+		return OfflineDownloadQueueEntry(
+			resource: resource,
+			parentCollection: parentCollection,
+			state: state,
+			progress: row["progress"]
+		)
+	}
+
 	func storeMediaItem(_ result: StoreItemTaskResult) throws {
 		writeLock.lock()
 		defer { writeLock.unlock() }
@@ -816,10 +911,7 @@ final class OfflineStore {
 
 	func allBookmarks() throws -> [Data] {
 		try databaseQueue.read { database in
-			let rows = try Row.fetchAll(
-				database,
-				sql: "SELECT media_bookmark, license_bookmark, artwork_bookmark FROM offline_item"
-			)
+			let rows = try Row.fetchAll(database, sql: "SELECT media_bookmark, license_bookmark, artwork_bookmark FROM offline_item")
 			return rows.flatMap { row in
 				["media_bookmark", "license_bookmark", "artwork_bookmark"].compactMap { row[$0] as Data? }
 			}
@@ -1186,5 +1278,25 @@ private extension OfflineMediaItem {
 			playbackMetadata: playbackMetadata,
 			artworkURL: try? OfflineStore.resolveBookmarkIfPresent(row, column: "artwork_bookmark", renewals: &renewals)
 		)
+	}
+}
+
+private extension OfflineDownloadQueueEntry.State {
+	init?(storageValue: String) {
+		switch storageValue {
+		case "queued": self = .queued
+		case "downloading": self = .downloading
+		case "failed_download": self = .failed(action: .download)
+		default: return nil
+		}
+	}
+
+	var storageValue: String {
+		switch self {
+		case .queued: "queued"
+		case .downloading: "downloading"
+		case .failed(.download): "failed_download"
+		case .failed(.remove): "failed_remove"
+		}
 	}
 }

--- a/Sources/Offliner/Internal/ResourceStateTracker.swift
+++ b/Sources/Offliner/Internal/ResourceStateTracker.swift
@@ -61,6 +61,14 @@ struct OfflineResourceKey: Hashable, Sendable {
 	}
 }
 
+// MARK: - DownloadQueueTask
+
+struct DownloadQueueTask: Sendable {
+	let resource: OfflineResource
+	let parentCollection: OfflineResource?
+	let supportsProgress: Bool
+}
+
 // MARK: - ResourceStateTracker
 
 actor ResourceStateTracker {
@@ -70,9 +78,20 @@ actor ResourceStateTracker {
 		let resources: Set<OfflineResourceKey>
 	}
 
+	private struct QueueTaskState {
+		let root: OfflineResourceKey
+		let parentCollection: OfflineResource?
+		var state: OfflineResourceState
+		let supportsProgress: Bool
+		var progress: Double?
+	}
+
 	private let offlineStore: OfflineStore
 	private var taskStates: [String: TaskState] = [:]
+	private var queueTaskStates: [String: QueueTaskState] = [:]
 	private var transientStates: [OfflineResourceKey: (InternalOfflineResourceAction, OfflineResourceState)] = [:]
+	private var queueContinuations: [UUID: AsyncStream<[OfflineDownloadQueueEntry]>.Continuation] = [:]
+	private var lastEmittedQueue: [OfflineDownloadQueueEntry]?
 	private var isShutdown = false
 
 	init(offlineStore: OfflineStore) {
@@ -90,6 +109,29 @@ actor ResourceStateTracker {
 			resourceType: resource.resourceType,
 			resourceId: resource.resourceId
 		)?.state
+	}
+
+	func downloadQueueSnapshot() throws -> [OfflineDownloadQueueEntry] {
+		guard !isShutdown else {
+			return []
+		}
+		return try offlineStore.getDownloadQueueEntries()
+	}
+
+	func observeDownloadQueue() throws -> AsyncStream<[OfflineDownloadQueueEntry]> {
+		guard !isShutdown else {
+			return AsyncStream { $0.finish() }
+		}
+		let initial = try downloadQueueSnapshot()
+		lastEmittedQueue = initial
+		return AsyncStream { continuation in
+			let id = UUID()
+			queueContinuations[id] = continuation
+			continuation.yield(initial)
+			continuation.onTermination = { [weak self] _ in
+				Task { await self?.removeQueueContinuation(id) }
+			}
+		}
 	}
 
 	func begin(_ action: InternalOfflineResourceAction, for resource: OfflineResourceKey) throws -> Bool {
@@ -135,17 +177,42 @@ actor ResourceStateTracker {
 				action: action,
 				state: state
 			)
+			if action == .store, let publicResource = resource.publicResource {
+				queueTaskStates = queueTaskStates.filter { $0.value.root != resource }
+				try offlineStore.setDownloadQueueEntry(OfflineDownloadQueueEntry(
+					resource: publicResource,
+					parentCollection: nil,
+					state: .queued,
+					progress: nil
+				))
+			} else if action == .remove {
+				queueTaskStates = queueTaskStates.filter { $0.value.root != resource }
+				try offlineStore.deleteDownloadQueueEntry(
+					resourceType: resource.resourceType,
+					resourceId: resource.resourceId
+				)
+			}
 		} catch {
 			transientStates.removeValue(forKey: resource)
 			try? offlineStore.deleteResourceOperation(resourceType: resource.resourceType, resourceId: resource.resourceId)
 			throw error
 		}
+		emitDownloadQueueIfChanged()
 		return true
 	}
 
 	func registrationFailed(_ action: InternalOfflineResourceAction, for resource: OfflineResourceKey) {
 		transientStates[resource] = (action, .failed(action: action.publicAction))
 		persistEffectiveOperation(for: resource)
+		if action == .store, let publicResource = resource.publicResource {
+			try? offlineStore.setDownloadQueueEntry(OfflineDownloadQueueEntry(
+				resource: publicResource,
+				parentCollection: nil,
+				state: .failed(action: .download),
+				progress: nil
+			))
+			emitDownloadQueueIfChanged()
+		}
 	}
 
 	func resolve(_ resource: OfflineResourceKey, state: OfflineResourceState) {
@@ -154,13 +221,17 @@ actor ResourceStateTracker {
 		}
 		transientStates[resource] = (.store, state)
 		try? offlineStore.deleteResourceOperation(resourceType: resource.resourceType, resourceId: resource.resourceId)
+		try? offlineStore.deleteDownloadQueueEntry(resourceType: resource.resourceType, resourceId: resource.resourceId)
+		queueTaskStates = queueTaskStates.filter { $0.value.root != resource }
+		emitDownloadQueueIfChanged()
 	}
 
 	func record(
 		taskId: String,
 		action: InternalOfflineResourceAction,
 		state: OfflineResourceState,
-		resources: Set<OfflineResourceKey>
+		resources: Set<OfflineResourceKey>,
+		downloadQueueTask: DownloadQueueTask?
 	) throws {
 		guard !isShutdown else {
 			return
@@ -175,6 +246,9 @@ actor ResourceStateTracker {
 			}
 			persistEffectiveOperation(for: resource)
 		}
+		if action == .store, let downloadQueueTask {
+			try recordDownloadQueueTask(taskId: taskId, state: state, task: downloadQueueTask)
+		}
 	}
 
 	func update(taskId: String, state: OfflineResourceState) {
@@ -186,6 +260,20 @@ actor ResourceStateTracker {
 		for resource in task.resources {
 			persistEffectiveOperation(for: resource)
 		}
+		if var queueTask = queueTaskStates[taskId] {
+			queueTask.state = state
+			queueTaskStates[taskId] = queueTask
+			persistDownloadQueue(root: queueTask.root)
+		}
+	}
+
+	func updateProgress(taskId: String, progress: Double) {
+		guard !isShutdown, var task = queueTaskStates[taskId] else {
+			return
+		}
+		task.progress = min(max(progress, 0), 1)
+		queueTaskStates[taskId] = task
+		persistDownloadQueue(root: task.root)
 	}
 
 	func finish(taskId: String, succeeded: Bool) {
@@ -198,6 +286,11 @@ actor ResourceStateTracker {
 			for resource in task.resources {
 				persistEffectiveOperation(for: resource)
 			}
+			if var queueTask = queueTaskStates[taskId] {
+				queueTask.state = .failed(action: .download)
+				queueTaskStates[taskId] = queueTask
+				persistDownloadQueue(root: queueTask.root)
+			}
 			return
 		}
 
@@ -209,6 +302,12 @@ actor ResourceStateTracker {
 			}
 			persistEffectiveOperation(for: resource)
 		}
+		if var queueTask = queueTaskStates[taskId] {
+			queueTask.state = .downloaded
+			queueTask.progress = queueTask.supportsProgress ? 1 : nil
+			queueTaskStates[taskId] = queueTask
+			persistDownloadQueue(root: queueTask.root)
+		}
 	}
 
 	func shutdown() {
@@ -216,8 +315,14 @@ actor ResourceStateTracker {
 			return
 		}
 		isShutdown = true
+		for continuation in queueContinuations.values {
+			continuation.finish()
+		}
+		queueContinuations.removeAll()
 		taskStates.removeAll()
+		queueTaskStates.removeAll()
 		transientStates.removeAll()
+		lastEmittedQueue = nil
 	}
 
 	private func effectiveState(for resource: OfflineResourceKey) -> OfflineResourceState? {
@@ -246,6 +351,136 @@ actor ResourceStateTracker {
 		} else {
 			try? offlineStore.deleteResourceOperation(resourceType: resource.resourceType, resourceId: resource.resourceId)
 		}
+	}
+
+	private func recordDownloadQueueTask(
+		taskId: String,
+		state: OfflineResourceState,
+		task: DownloadQueueTask
+	) throws {
+		let resource = OfflineResourceKey(task.resource)
+		let parent = task.parentCollection.map(OfflineResourceKey.init)
+		let root: OfflineResourceKey
+		let hasCollectionDownloadIntent = state == .queued
+			|| state == .downloading
+			|| state == .failed(action: .download)
+		if parent == nil, resource.publicCollection != nil, hasCollectionDownloadIntent {
+			root = resource
+			let storedMembers = try offlineStore.getDownloadQueueEntries().filter {
+				$0.parentCollection.map(OfflineResourceKey.init) == resource
+			}
+			for member in storedMembers {
+				let memberKey = OfflineResourceKey(member.resource)
+				try offlineStore.deleteDownloadQueueEntry(
+					resourceType: memberKey.resourceType,
+					resourceId: memberKey.resourceId
+				)
+			}
+			queueTaskStates = queueTaskStates.mapValues { existing in
+				guard existing.parentCollection.map(OfflineResourceKey.init) == resource else {
+					return existing
+				}
+				return QueueTaskState(
+					root: resource,
+					parentCollection: nil,
+					state: existing.state,
+					supportsProgress: existing.supportsProgress,
+					progress: existing.progress
+				)
+			}
+		} else if let parent,
+		          try offlineStore.getDownloadQueueEntry(resourceType: parent.resourceType, resourceId: parent.resourceId) != nil
+		{
+			root = parent
+			if resource != parent {
+				try offlineStore.deleteDownloadQueueEntry(resourceType: resource.resourceType, resourceId: resource.resourceId)
+				queueTaskStates = queueTaskStates.mapValues { existing in
+					guard existing.root == resource else {
+						return existing
+					}
+					return QueueTaskState(
+						root: parent,
+						parentCollection: nil,
+						state: existing.state,
+						supportsProgress: existing.supportsProgress,
+						progress: existing.progress
+					)
+				}
+			}
+		} else if try offlineStore.getDownloadQueueEntry(
+			resourceType: resource.resourceType,
+			resourceId: resource.resourceId
+		) != nil {
+			root = resource
+		} else if let parent {
+			root = parent
+		} else {
+			root = resource
+		}
+
+		queueTaskStates[taskId] = QueueTaskState(
+			root: root,
+			parentCollection: root == resource ? task.parentCollection : nil,
+			state: state,
+			supportsProgress: task.supportsProgress,
+			progress: nil
+		)
+		try persistDownloadQueueThrowing(root: root)
+	}
+
+	private func persistDownloadQueue(root: OfflineResourceKey) {
+		try? persistDownloadQueueThrowing(root: root)
+	}
+
+	private func persistDownloadQueueThrowing(root: OfflineResourceKey) throws {
+		let tasks = queueTaskStates.values.filter { $0.root == root }
+		let failed = tasks.contains { $0.state == .failed(action: .download) }
+		let downloading = tasks.contains { $0.state == .downloading }
+		let queued = tasks.contains { $0.state == .queued }
+		guard failed || downloading || queued else {
+			try offlineStore.deleteDownloadQueueEntry(resourceType: root.resourceType, resourceId: root.resourceId)
+			queueTaskStates = queueTaskStates.filter { $0.value.root != root }
+			emitDownloadQueueIfChanged()
+			return
+		}
+
+		guard let resource = root.publicResource else {
+			return
+		}
+		let state: OfflineDownloadQueueEntry.State = if failed {
+			.failed(action: .download)
+		} else if downloading {
+			.downloading
+		} else {
+			.queued
+		}
+		let progressTasks = tasks.filter(\.supportsProgress)
+		let hasKnownProgress = progressTasks.contains { $0.progress != nil }
+		let progress = hasKnownProgress && !progressTasks.isEmpty
+			? progressTasks.reduce(0) { $0 + ($1.progress ?? 0) } / Double(progressTasks.count)
+			: nil
+		let parentCollection = tasks.lazy.compactMap(\.parentCollection).first
+		try offlineStore.setDownloadQueueEntry(OfflineDownloadQueueEntry(
+			resource: resource,
+			parentCollection: parentCollection,
+			state: state,
+			progress: progress
+		))
+		emitDownloadQueueIfChanged()
+	}
+
+	private func emitDownloadQueueIfChanged() {
+		guard let queue = try? offlineStore.getDownloadQueueEntries(), queue != lastEmittedQueue else {
+			return
+		}
+		lastEmittedQueue = queue
+		for continuation in queueContinuations.values {
+			continuation.yield(queue)
+		}
+	}
+
+	private func removeQueueContinuation(_ id: UUID) {
+		queueContinuations.removeValue(forKey: id)
 	}
 }
 

--- a/Sources/Offliner/Internal/Resources/Migrations/V000004_offline_download_queue.sql
+++ b/Sources/Offliner/Internal/Resources/Migrations/V000004_offline_download_queue.sql
@@ -1,0 +1,12 @@
+CREATE TABLE offline_download_queue
+(
+    resource_type          TEXT NOT NULL,
+    resource_id            TEXT NOT NULL,
+    parent_collection_type TEXT,
+    parent_collection_id   TEXT,
+    state                  TEXT NOT NULL,
+    progress               DOUBLE,
+    updated_at             TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (resource_type, resource_id)
+);

--- a/Sources/Offliner/Internal/TaskRunner.swift
+++ b/Sources/Offliner/Internal/TaskRunner.swift
@@ -66,14 +66,16 @@ actor TaskRunner {
 			artworkDownloader: artworkDownloader,
 			mediaDownloader: mediaDownloader,
 			manifestFetcher: trackManifestFetcher,
-			licenseDownloader: licenseDownloader
+			licenseDownloader: licenseDownloader,
+			resourceStateTracker: resourceStateTracker
 		)
 		storeVideoHandler = StoreVideoHandler(
 			offlineStore: offlineStore,
 			artworkDownloader: artworkDownloader,
 			mediaDownloader: mediaDownloader,
 			manifestFetcher: videoManifestFetcher,
-			licenseDownloader: licenseDownloader
+			licenseDownloader: licenseDownloader,
+			resourceStateTracker: resourceStateTracker
 		)
 		storeAlbumHandler = StoreAlbumHandler(
 			offlineStore: offlineStore,
@@ -112,6 +114,20 @@ actor TaskRunner {
 		}
 	}
 
+	func synchronizeState() async {
+		guard !isShutdown else {
+			return
+		}
+		try? await refresh()
+	}
+
+	func synchronizeDownloadQueue() async throws {
+		guard !isShutdown else {
+			return
+		}
+		try await refresh()
+	}
+
 	func setAllowDownloadsOnExpensiveNetworks(_ allowed: Bool) {
 		guard !isShutdown else {
 			return
@@ -129,13 +145,6 @@ actor TaskRunner {
 		let collection = OfflineCollectionReference(collectionType: collectionType, resourceId: resourceId)
 		return pendingTasks.contains { $0.isDownloadTask(for: collection) } ||
 			runningTasks.contains { $0.isDownloadTask(for: collection) }
-	}
-
-	func synchronizeState() async {
-		guard !isShutdown else {
-			return
-		}
-		try? await refresh()
 	}
 
 	func shutdown() async {
@@ -182,7 +191,8 @@ actor TaskRunner {
 					taskId: task.id,
 					action: task.action,
 					state: state,
-					resources: task.resourceKeys
+					resources: task.resourceKeys,
+					downloadQueueTask: task.downloadQueueTask
 				)
 				guard taskIds.insert(task.id).inserted else {
 					continue

--- a/Sources/Offliner/Offliner.swift
+++ b/Sources/Offliner/Offliner.swift
@@ -308,6 +308,41 @@ public final class Offliner {
 		return try await localResourceState(for: resource)
 	}
 
+	/// Returns the active aggregate download queue after backend task synchronization completes.
+	///
+	/// Collection metadata and member tasks count as one collection entry. Direct media downloads remain separate entries.
+	/// Successful operations disappear; failed downloads remain until explicitly retried, removed, or reset.
+	func getOfflineDownloadQueue() async throws -> [OfflineDownloadQueueEntry] {
+		try ensureActive()
+		try await taskRunner.synchronizeDownloadQueue()
+		return try await resourceStateTracker.downloadQueueSnapshot()
+	}
+
+	/// Observes distinct aggregate download queue snapshots until cancellation or reset.
+	///
+	/// Every subscriber receives its own synchronized initial snapshot and all subsequent broadcasts. An initial backend or
+	/// local persistence failure terminates only that subscriber with the original error.
+	public func observeOfflineDownloadQueue() -> AsyncThrowingStream<[OfflineDownloadQueueEntry], Error> {
+		guard isActive else {
+			return AsyncThrowingStream { $0.finish(throwing: OfflinerLifecycleError.reset) }
+		}
+		return AsyncThrowingStream { continuation in
+			let task = Task {
+				do {
+					try await taskRunner.synchronizeDownloadQueue()
+					for await snapshot in try await resourceStateTracker.observeDownloadQueue() {
+						try Task.checkCancellation()
+						continuation.yield(snapshot)
+					}
+					continuation.finish()
+				} catch {
+					continuation.finish(throwing: error)
+				}
+			}
+			continuation.onTermination = { _ in task.cancel() }
+		}
+	}
+
 	/// Streams collection-level offline availability.
 	///
 	/// The stream emits a fast initial value from local storage and active in-memory downloads, then continues polling for

--- a/Sources/Offliner/README.md
+++ b/Sources/Offliner/README.md
@@ -84,6 +84,29 @@ These methods register the download request with the backend and automatically t
 
 ### Monitoring Downloads
 
+#### Aggregate Download Queue
+
+Use the aggregate queue when the UI needs a relaunch-safe list of queued, active, and failed download operations. The
+stream's initial snapshot waits for backend task synchronization and preserves synchronization or local persistence errors:
+
+```swift
+for try await queue in offliner.observeOfflineDownloadQueue() {
+    for entry in queue {
+        print("\(entry.resource): \(entry.state), progress: \(String(describing: entry.progress))")
+    }
+}
+```
+
+Every observer receives the same synchronized initial snapshot and subsequent distinct snapshots. Collection metadata
+and member tasks are counted once under the top-level collection when their relationship is known. A directly requested
+track or video remains a media entry and may expose its `parentCollection`. `progress` is optional because metadata tasks
+and restored backend tasks may not expose transfer progress.
+
+Queue state is limited to `.queued`, `.downloading`, and `.failed(action: .download)`. A successful operation disappears
+from the active queue. A terminal failure remains available after relaunch until retry, removal, or reset; pass
+`entry.resource` back to the matching media or collection `download(...)` overload to retry. Queue observers are
+independent broadcasts and finish when the Offliner instance is reset.
+
 #### New Downloads Stream
 
 Subscribe to new downloads as they're picked up for processing:

--- a/Sources/Offliner/Types.swift
+++ b/Sources/Offliner/Types.swift
@@ -65,6 +65,41 @@ public enum OfflineResourceOperationError: Error, Sendable, Equatable {
 	case conflictingOperationInProgress(currentState: OfflineResourceState)
 }
 
+// MARK: - OfflineDownloadQueueEntry
+
+/// One top-level download operation in the active Offliner queue.
+///
+/// Collection metadata and member tasks are aggregated into one collection entry when their relationship is known.
+/// A directly requested media item remains a media entry and exposes its related collection separately.
+public struct OfflineDownloadQueueEntry: Sendable, Hashable {
+	public enum State: Sendable, Hashable {
+		case queued
+		case downloading
+		/// A terminal failure. Download queues only expose the `.download` action.
+		case failed(action: OfflineResourceAction)
+	}
+
+	/// The stable top-level resource identity to pass back to `download(...)` when retrying.
+	public let resource: OfflineResource
+	/// The related collection for a directly requested media item, when supplied by the backend task.
+	public let parentCollection: OfflineResource?
+	public let state: State
+	/// Aggregate transfer progress in `0 ... 1`, or `nil` until progress is known.
+	public let progress: Double?
+
+	public init(
+		resource: OfflineResource,
+		parentCollection: OfflineResource?,
+		state: State,
+		progress: Double?
+	) {
+		self.resource = resource
+		self.parentCollection = parentCollection
+		self.state = state
+		self.progress = progress
+	}
+}
+
 // MARK: - OfflineMediaItem
 
 public struct OfflineMediaItem {

--- a/Tests/OfflinerTests/DownloadQueueTests.swift
+++ b/Tests/OfflinerTests/DownloadQueueTests.swift
@@ -1,0 +1,385 @@
+@testable import Offliner
+import TidalAPI
+import XCTest
+
+// MARK: - DownloadQueueTests
+
+final class DownloadQueueTests: OfflinerTestCase {
+	func testSnapshotWaitsForBackendSynchronization() async throws {
+		let backend = BlockingGetTasksOfflineApiClient()
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+		let snapshotTask = Task { try await offliner.getOfflineDownloadQueue() }
+
+		await backend.waitUntilRequested()
+		XCTAssertFalse(snapshotTask.isCancelled)
+		await backend.resume(with: [.storeAlbum(storeAlbumTask(id: "album-task"))])
+
+		let snapshot = try await snapshotTask.value
+		XCTAssertEqual(snapshot, [OfflineDownloadQueueEntry(
+			resource: .collection(type: .albums, resourceId: "album-1"),
+			parentCollection: nil,
+			state: .queued,
+			progress: nil
+		)])
+	}
+
+	func testSnapshotPreservesSynchronizationError() async {
+		let offliner = createOffliner(
+			offlineApiClient: FailOnGetTasksOfflineApiClient(),
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+
+		await XCTAssertThrowsErrorAsync {
+			_ = try await offliner.getOfflineDownloadQueue()
+		}
+	}
+
+	func testObservationBroadcastsDistinctProgressAndCompletionToEverySubscriber() async throws {
+		let backend = StubOfflineApiClient()
+		let media = SucceedingMediaDownloader()
+		media.progressValues = [0.25, 0.25, 0.75]
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: media
+		)
+		var first = offliner.observeOfflineDownloadQueue().makeAsyncIterator()
+		var second = offliner.observeOfflineDownloadQueue().makeAsyncIterator()
+		let firstInitial = try await first.next()
+		let secondInitial = try await second.next()
+		XCTAssertEqual(firstInitial, [])
+		XCTAssertEqual(secondInitial, [])
+
+		try await offliner.download(mediaType: .tracks, resourceId: .identifier("track-1"))
+		let firstQueued = try await first.next()
+		let secondQueued = try await second.next()
+		XCTAssertEqual(firstQueued, secondQueued)
+		XCTAssertEqual(firstQueued?.first?.state, .queued)
+
+		await offliner.run()
+		await backend.waitForTasksToComplete()
+		let firstUpdates = try await collectUntilEmpty(&first)
+		let secondUpdates = try await collectUntilEmpty(&second)
+
+		XCTAssertEqual(firstUpdates, secondUpdates)
+		XCTAssertTrue(firstUpdates.contains { $0.first?.state == .downloading })
+		XCTAssertEqual(firstUpdates.filter { $0.first?.progress == 0.25 }.count, 1)
+		XCTAssertTrue(firstUpdates.contains { $0.first?.progress == 0.75 })
+		XCTAssertEqual(firstUpdates.last, [])
+	}
+
+	func testObservationFinishesOnReset() async throws {
+		let offliner = createOffliner(
+			offlineApiClient: HoldingOfflineApiClient(),
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+		var iterator = offliner.observeOfflineDownloadQueue().makeAsyncIterator()
+		let initial = try await iterator.next()
+		XCTAssertEqual(initial, [])
+
+		try await offliner.reset()
+
+		let afterReset = try await iterator.next()
+		XCTAssertNil(afterReset)
+	}
+
+	func testCancelledObservationFinishesOnlyThatSubscriber() async throws {
+		let backend = HoldingOfflineApiClient()
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+		let started = expectation(description: "subscriber started")
+		let cancelledConsumer = Task {
+			do {
+				for try await _ in offliner.observeOfflineDownloadQueue() {
+					started.fulfill()
+				}
+			} catch is CancellationError {
+				// Expected.
+			}
+		}
+		await fulfillment(of: [started])
+		cancelledConsumer.cancel()
+		try await cancelledConsumer.value
+
+		var remaining = offliner.observeOfflineDownloadQueue().makeAsyncIterator()
+		let initial = try await remaining.next()
+		XCTAssertEqual(initial, [])
+		try await offliner.download(mediaType: .videos, resourceId: .identifier("video-1"))
+		let queued = try await remaining.next()
+		XCTAssertEqual(queued?.first?.resource, .media(type: .videos, resourceId: "video-1"))
+	}
+
+	func testCollectionMetadataAndMembersAggregateAsOneEntry() async throws {
+		let backend = StubOfflineApiClient()
+		backend.enqueueTasks([
+			.storeTrack(storeTrackTask(id: "track-1", trackId: "track-1", position: 1)),
+			.storeTrack(storeTrackTask(id: "track-2", trackId: "track-2", position: 2)),
+			.storeAlbum(storeAlbumTask(id: "album-metadata")),
+		])
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+
+		let snapshot = try await offliner.getOfflineDownloadQueue()
+
+		XCTAssertEqual(snapshot.count, 1)
+		XCTAssertEqual(snapshot.first?.resource, .collection(type: .albums, resourceId: "album-1"))
+		XCTAssertNil(snapshot.first?.parentCollection)
+		XCTAssertEqual(snapshot.first?.state, .queued)
+	}
+
+	func testTerminalCollectionMetadataDoesNotAbsorbStandaloneMedia() async throws {
+		let backend = StubOfflineApiClient()
+		let media = SuspendingMediaDownloader()
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: media
+		)
+		try await offliner.download(mediaType: .tracks, resourceId: .identifier("track-1"))
+		backend.enqueueTasks([.terminal(TerminalOfflineTask(
+			id: "historical-album-metadata",
+			state: .completed,
+			action: .store,
+			resourceType: "albums",
+			resourceId: "stub-album",
+			collectionResourceType: nil,
+			collectionResourceId: nil
+		))])
+		await media.waitUntilStarted()
+
+		let snapshot = try await offliner.getOfflineDownloadQueue()
+
+		XCTAssertEqual(snapshot.count, 1)
+		XCTAssertEqual(snapshot.first?.resource, .media(type: .tracks, resourceId: "track-1"))
+		XCTAssertEqual(snapshot.first?.parentCollection, .collection(type: .albums, resourceId: "stub-album"))
+		XCTAssertEqual(snapshot.first?.state, .downloading)
+	}
+
+	func testCollectionMetadataFailureRemainsInQueue() async throws {
+		let backend = StubOfflineApiClient()
+		backend.enqueueTasks([.storeAlbum(storeAlbumTask(id: "album-metadata"))])
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: FailingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+
+		await offliner.run()
+		await backend.waitForTasksToComplete()
+		let snapshot = try await offliner.getOfflineDownloadQueue()
+
+		XCTAssertEqual(snapshot.count, 1)
+		XCTAssertEqual(snapshot.first?.resource, .collection(type: .albums, resourceId: "album-1"))
+		XCTAssertEqual(snapshot.first?.state, .failed(action: .download))
+	}
+
+	func testFailedCollectionMemberSurvivesLaterSiblingCompletion() async throws {
+		let backend = StubOfflineApiClient()
+		let media = SelectiveSuspendingMediaDownloader(failingTaskIds: ["failing-track"])
+		backend.enqueueTasks([
+			.storeTrack(storeTrackTask(id: "failing-track", trackId: "track-1", position: 1)),
+			.storeTrack(storeTrackTask(id: "succeeding-track", trackId: "track-2", position: 2)),
+		])
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: media
+		)
+
+		await offliner.run()
+		await media.waitUntilStarted(count: 2)
+		await media.complete(taskId: "succeeding-track")
+		await backend.waitForTasksToComplete()
+		let snapshot = try await offliner.getOfflineDownloadQueue()
+
+		XCTAssertEqual(snapshot.count, 1)
+		XCTAssertEqual(snapshot.first?.resource, .collection(type: .albums, resourceId: "album-1"))
+		XCTAssertEqual(snapshot.first?.state, .failed(action: .download))
+	}
+
+	func testStandaloneMediaFailurePersistsAcrossRecreationWithRetryIdentity() async throws {
+		let installationId = "failed-media-queue"
+		let backend = StubOfflineApiClient()
+		var first: Offliner? = try Offliner(
+			storage: OfflinerStorage(installationId: installationId, baseDirectory: tempDir),
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: FailingMediaDownloader(),
+			trackManifestFetcher: SucceedingTrackManifestFetcher(),
+			videoManifestFetcher: SucceedingVideoManifestFetcher()
+		)
+		try await first?.download(mediaType: .tracks, resourceId: .identifier("track-1"))
+		await first?.run()
+		await backend.waitForTasksToComplete()
+		first = nil
+
+		let second = createOffliner(
+			installationId: installationId,
+			offlineApiClient: HoldingOfflineApiClient(),
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+		let snapshot = try await second.getOfflineDownloadQueue()
+
+		XCTAssertEqual(snapshot.count, 1)
+		XCTAssertEqual(snapshot.first?.resource, .media(type: .tracks, resourceId: "track-1"))
+		XCTAssertEqual(snapshot.first?.parentCollection, .collection(type: .albums, resourceId: "stub-album"))
+		XCTAssertEqual(snapshot.first?.state, .failed(action: .download))
+	}
+
+	func testSuccessfulDownloadDisappearsFromQueue() async throws {
+		let backend = StubOfflineApiClient()
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+		try await offliner.download(mediaType: .tracks, resourceId: .identifier("track-1"))
+
+		await offliner.run()
+		await backend.waitForTasksToComplete()
+
+		let snapshot = try await offliner.getOfflineDownloadQueue()
+		XCTAssertEqual(snapshot, [])
+	}
+
+	func testFailedEntryResourceCanBeUsedToRetry() async throws {
+		let backend = FailOnceAddOfflineApiClient()
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+		await XCTAssertThrowsErrorAsync {
+			try await offliner.download(collectionType: .playlists, resourceId: .identifier("playlist-1"))
+		}
+		let failedSnapshot = try await offliner.getOfflineDownloadQueue()
+		let failed = try XCTUnwrap(failedSnapshot.first)
+
+		try await retry(failed.resource, with: offliner)
+
+		let retrySnapshot = try await offliner.getOfflineDownloadQueue()
+		let retried = try XCTUnwrap(retrySnapshot.first)
+		XCTAssertEqual(retried.resource, failed.resource)
+		XCTAssertEqual(retried.state, .queued)
+		let addCallCount = await backend.addCallCount
+		XCTAssertEqual(addCallCount, 2)
+	}
+
+	private func collectUntilEmpty(
+		_ iterator: inout AsyncThrowingStream<[OfflineDownloadQueueEntry], Error>.Iterator
+	) async throws -> [[OfflineDownloadQueueEntry]] {
+		var updates: [[OfflineDownloadQueueEntry]] = []
+		while let snapshot = try await iterator.next() {
+			updates.append(snapshot)
+			if snapshot.isEmpty {
+				return updates
+			}
+		}
+		return updates
+	}
+
+	private func retry(_ resource: OfflineResource, with offliner: Offliner) async throws {
+		switch resource {
+		case let .media(type, resourceId):
+			try await offliner.download(mediaType: type, resourceId: .identifier(resourceId))
+		case let .collection(type, resourceId):
+			try await offliner.download(collectionType: type, resourceId: .identifier(resourceId))
+		}
+	}
+
+	private func storeAlbumTask(id: String) -> StoreAlbumTask {
+		StoreAlbumTask(
+			id: id,
+			album: AlbumsResourceObject(id: "album-1", type: "albums"),
+			artists: [],
+			artwork: nil
+		)
+	}
+
+	private func storeTrackTask(id: String, trackId: String, position: Int) -> StoreTrackTask {
+		StoreTrackTask(
+			id: id,
+			track: TracksResourceObject(id: trackId, type: "tracks"),
+			artists: [],
+			artwork: nil,
+			collectionResourceType: "albums",
+			collectionResourceId: "album-1",
+			volume: 1,
+			position: position
+		)
+	}
+}
+
+// MARK: - BlockingGetTasksOfflineApiClient
+
+private actor BlockingGetTasksOfflineApiClient: OfflineApiClientProtocol {
+	private var requested = false
+	private var requestedContinuation: CheckedContinuation<Void, Never>?
+	private var responseContinuation: CheckedContinuation<(tasks: [OfflineTask], cursor: String?), Never>?
+
+	func addItem(type: ResourceType, id: String) async throws {}
+	func removeItem(type: ResourceType, id: String) async throws {}
+	func updateTask(taskId: String, state: Download.State) async throws {}
+
+	func getTasks(cursor: String?) async throws -> (tasks: [OfflineTask], cursor: String?) {
+		requested = true
+		requestedContinuation?.resume()
+		requestedContinuation = nil
+		return await withCheckedContinuation { responseContinuation = $0 }
+	}
+
+	func waitUntilRequested() async {
+		if requested {
+			return
+		}
+		await withCheckedContinuation { requestedContinuation = $0 }
+	}
+
+	func resume(with tasks: [OfflineTask]) {
+		responseContinuation?.resume(returning: (tasks, nil))
+		responseContinuation = nil
+	}
+}
+
+// MARK: - FailOnceAddOfflineApiClient
+
+private actor FailOnceAddOfflineApiClient: OfflineApiClientProtocol {
+	private(set) var addCallCount = 0
+
+	func addItem(type: ResourceType, id: String) async throws {
+		addCallCount += 1
+		if addCallCount == 1 {
+			throw FakeError.backendFailed
+		}
+	}
+
+	func removeItem(type: ResourceType, id: String) async throws {}
+	func getTasks(cursor: String?) async throws -> (tasks: [OfflineTask], cursor: String?) { ([], nil) }
+	func updateTask(taskId: String, state: Download.State) async throws {}
+}
+
+private func XCTAssertThrowsErrorAsync(
+	_ expression: () async throws -> Void,
+	file: StaticString = #filePath,
+	line: UInt = #line
+) async {
+	do {
+		try await expression()
+		XCTFail("Expected error", file: file, line: line)
+	} catch {
+		// Expected.
+	}
+}


### PR DESCRIPTION
## What
- New public API: `Offliner.observeOfflineDownloadQueue() -> AsyncThrowingStream<[OfflineDownloadQueueEntry], Error>` with public `OfflineDownloadQueueEntry`.
- `ResourceStateTracker` gains the queue half: aggregate snapshots where a collection and its member tasks count as one entry, direct media downloads stay separate entries (with optional `parentCollection`), successful operations disappear, and failures remain until retried/removed/reset.
- `V000004` migration persists queue entries so the queue is relaunch-safe.
- Per-entry transfer progress via `Download.progressHandler` wired from the media downloader through the store handlers.
- Every observer gets its own synchronized initial snapshot (after backend task sync) and subsequent distinct snapshots; streams finish on reset.

## Why
The Watch client's downloads screen is `observeOfflineDownloadQueue` (1 call site) — a relaunch-safe list of queued/active/failed downloads with progress.

## Stack
PR 7/7 — the final slice of the TM-1573 stack replacing #413. With this merged, the stack reproduces the full trimmed feature (verified: zero diff against the reference branch).

## Testing
`xcodebuild test -scheme Offliner -destination platform=macOS` — 112 tests, 0 failures, including new `DownloadQueueTests`.