### PR TITLE
Offliner: Resolve collection download state from the backend inventory

### DIFF
--- a/Sources/Offliner/Internal/TaskRunner.swift
+++ b/Sources/Offliner/Internal/TaskRunner.swift
@@ -21,6 +21,7 @@ actor TaskRunner {
 	private var pendingTasks: [InternalTask] = []
 	private var runningTasks: [InternalTask] = []
 	private var taskIds: Set<String> = []
+	private var collectionObservers: [UUID: (collection: OfflineCollectionReference, continuation: AsyncStream<Void>.Continuation)] = [:]
 
 	private var processTask: Task<Void, Never>?
 	private var rerunRequested = false
@@ -105,10 +106,23 @@ actor TaskRunner {
 		}
 	}
 
-	func hasCurrentDownload(relatedTo collectionType: OfflineCollectionType, resourceId: ResourceId) -> Bool {
+	func collectionEvents(for collection: OfflineCollectionReference) -> AsyncStream<Void> {
+		AsyncStream(bufferingPolicy: .bufferingNewest(1)) { continuation in
+			collectionObservers[UUID()] = (collection, continuation)
+		}
+	}
+
+	func notifyCollectionChanged(collectionType: OfflineCollectionType, resourceId: ResourceId) {
 		let collection = OfflineCollectionReference(collectionType: collectionType, resourceId: resourceId)
-		return pendingTasks.contains { $0.isDownloadTask(for: collection) } ||
-			runningTasks.contains { $0.isDownloadTask(for: collection) }
+		notifyCollectionObservers { $0 == collection }
+	}
+
+	private func notifyCollectionObservers(matching: (OfflineCollectionReference) -> Bool) {
+		for (id, observer) in collectionObservers where matching(observer.collection) {
+			if case .terminated = observer.continuation.yield(()) {
+				collectionObservers.removeValue(forKey: id)
+			}
+		}
 	}
 
 	private func refresh() async throws {
@@ -121,6 +135,7 @@ actor TaskRunner {
 				currentDownloads.append(download)
 				downloadsContinuation?.yield(download)
 			}
+			notifyCollectionObservers { pendingTask.isDownloadTask(for: $0) }
 		}
 	}
 
@@ -207,6 +222,7 @@ actor TaskRunner {
 		if let download = task.download {
 			currentDownloads.removeAll { $0 === download }
 		}
+		notifyCollectionObservers { task.isDownloadTask(for: $0) }
 	}
 }
 

--- a/Sources/Offliner/Offliner.swift
+++ b/Sources/Offliner/Offliner.swift
@@ -5,13 +5,10 @@ import Player
 // MARK: - Offliner
 
 public final class Offliner {
-	static let defaultCollectionDownloadStatePollInterval: UInt64 = 1_000_000_000
-
 	private let offlineApiClient: OfflineApiClientProtocol
 	private let offlineStore: OfflineStore
 	private let taskRunner: TaskRunner
 	private let mediaDownloader: MediaDownloaderProtocol
-	private let collectionDownloadStatePollInterval: UInt64
 	private var trackManifestFetcher: TrackManifestFetcherProtocol
 
 	public var audioFormats: [AudioFormat] {
@@ -53,7 +50,6 @@ public final class Offliner {
 		self.offlineApiClient = offlineApiClient
 		self.offlineStore = offlineStore
 		self.mediaDownloader = mediaDownloader
-		self.collectionDownloadStatePollInterval = Self.defaultCollectionDownloadStatePollInterval
 		self.trackManifestFetcher = trackManifestFetcher
 		self.audioFormats = configuration.audioFormats
 		self.taskRunner = TaskRunner(
@@ -84,13 +80,11 @@ public final class Offliner {
 		mediaDownloader: MediaDownloaderProtocol,
 		licenseDownloader: LicenseDownloader = LicenseDownloader(),
 		trackManifestFetcher: TrackManifestFetcherProtocol,
-		videoManifestFetcher: VideoManifestFetcherProtocol,
-		collectionDownloadStatePollInterval: UInt64 = Offliner.defaultCollectionDownloadStatePollInterval
+		videoManifestFetcher: VideoManifestFetcherProtocol
 	) {
 		self.offlineApiClient = offlineApiClient
 		self.offlineStore = offlineStore
 		self.mediaDownloader = mediaDownloader
-		self.collectionDownloadStatePollInterval = collectionDownloadStatePollInterval
 		self.trackManifestFetcher = trackManifestFetcher
 		self.audioFormats = configuration.audioFormats
 		self.taskRunner = TaskRunner(
@@ -187,58 +181,29 @@ public final class Offliner {
 		}
 	}
 
-	/// Streams collection-level offline availability.
-	///
-	/// The stream emits a fast initial value from local storage and active in-memory downloads, then continues polling for
-	/// later local changes.
-	///
-	/// The stream does not poll backend task inventory. Removal is represented as `.notDownloaded`; `.downloading` is
-	/// reserved for active download/acquisition work already known by this SDK instance.
 	public func getOfflineCollectionDownloadState(
 		collectionType: OfflineCollectionType,
 		resourceId: ResourceId
 	) -> AsyncStream<OfflineCollectionDownloadState> {
 		AsyncStream { continuation in
 			let task = Task {
-				var lastState: OfflineCollectionDownloadState?
-				var consecutiveDownloadedObservations = 0
+				let collection = OfflineCollectionReference(collectionType: collectionType, resourceId: resourceId)
+				let events = await taskRunner.collectionEvents(for: collection)
 
-				func yieldState(_ state: OfflineCollectionDownloadState) {
-					let shouldYield: Bool
+				var lastState = await localDownloadState(collectionType: collectionType, resourceId: resourceId)
+				continuation.yield(lastState)
 
-					// A second downloaded observation avoids transient completion between collection metadata and
-					// collection item tasks.
-					if state == .downloaded {
-						consecutiveDownloadedObservations += 1
-						shouldYield = lastState == .downloaded || consecutiveDownloadedObservations >= 2
-					} else {
-						consecutiveDownloadedObservations = 0
-						shouldYield = true
-					}
-
-					if shouldYield, state != lastState {
-						continuation.yield(state)
+				func emitBackendStateIfChanged() async {
+					if let state = await backendDownloadState(collectionType: collectionType, resourceId: resourceId), state != lastState {
 						lastState = state
+						continuation.yield(state)
 					}
 				}
 
-				let initialState = await offlineCollectionDownloadState(
-					collectionType: collectionType,
-					resourceId: resourceId
-				)
-				continuation.yield(initialState)
-				lastState = initialState
+				await emitBackendStateIfChanged()
 
-				while !Task.isCancelled {
-					try? await Task.sleep(nanoseconds: collectionDownloadStatePollInterval)
-					guard !Task.isCancelled else { break }
-
-					let state = await offlineCollectionDownloadState(
-						collectionType: collectionType,
-						resourceId: resourceId
-					)
-
-					yieldState(state)
+				for await _ in events {
+					await emitBackendStateIfChanged()
 				}
 
 				continuation.finish()
@@ -363,6 +328,7 @@ public final class Offliner {
 
 	public func download(collectionType: OfflineCollectionType, resourceId: ResourceId) async throws {
 		try await offlineApiClient.addItem(type: collectionType.toResourceType, id: resourceId.stringValue)
+		await taskRunner.notifyCollectionChanged(collectionType: collectionType, resourceId: resourceId)
 		await taskRunner.run()
 	}
 
@@ -378,23 +344,38 @@ public final class Offliner {
 			resourceType: collectionType.rawValue,
 			resourceId: collectionLocalResourceId(collectionType: collectionType, resourceId: resourceId)
 		)
+		await taskRunner.notifyCollectionChanged(collectionType: collectionType, resourceId: resourceId)
 		await taskRunner.run()
 	}
 
-	private func offlineCollectionDownloadState(
+	private func localDownloadState(
 		collectionType: OfflineCollectionType,
 		resourceId: ResourceId
 	) async -> OfflineCollectionDownloadState {
-		if await taskRunner.hasCurrentDownload(relatedTo: collectionType, resourceId: resourceId) {
-			return .downloading
-		}
-
 		let localCollection = try? await offlineStore.getCollection(
 			collectionType: collectionType,
 			resourceId: collectionLocalResourceId(collectionType: collectionType, resourceId: resourceId)
 		)
 
 		return localCollection == nil ? .notDownloaded : .downloaded
+	}
+
+	private func backendDownloadState(
+		collectionType: OfflineCollectionType,
+		resourceId: ResourceId
+	) async -> OfflineCollectionDownloadState? {
+		do {
+			let pendingCollection = try await offlineApiClient.getOfflineCollection(
+				type: collectionType,
+				id: resourceId.stringValue
+			)
+
+			return pendingCollection == nil
+				? await localDownloadState(collectionType: collectionType, resourceId: resourceId)
+				: .downloading
+		} catch {
+			return nil
+		}
 	}
 
 	private func collectionLocalResourceId(

--- a/Sources/Offliner/Types.swift
+++ b/Sources/Offliner/Types.swift
@@ -96,19 +96,9 @@ public enum OfflineCollectionState: Hashable {
 
 // MARK: - OfflineCollectionDownloadState
 
-/// Collection-level offline availability for albums, playlists, and user collection tracks.
-///
-/// This state describes whether collection media is available offline or known by this SDK instance to be acquired. It
-/// does not model generic offliner task activity: collection removal is represented as `notDownloaded`, not
-/// `downloading`.
 public enum OfflineCollectionDownloadState: Sendable, Hashable {
-	/// The collection is not locally downloaded, or it is being removed.
 	case notDownloaded
-
-	/// The collection or one of its members has active download/acquisition work known by this SDK instance.
 	case downloading
-
-	/// The collection is locally stored and there is no locally known pending download/acquisition work.
 	case downloaded
 }
 

--- a/Tests/OfflinerTests/CollectionDownloadTests.swift
+++ b/Tests/OfflinerTests/CollectionDownloadTests.swift
@@ -63,7 +63,7 @@ final class CollectionDownloadTests: OfflinerTestCase {
 		XCTAssertEqual(state, .downloaded)
 	}
 
-	func testOfflineCollectionDownloadStateUsesInMemoryCollectionTask() async throws {
+	func testOfflineCollectionDownloadStateReportsBackendPendingWorkWhileTaskRuns() async throws {
 		let backend = StubOfflineApiClient()
 		let artworkDownloader = SuspendingArtworkDownloader()
 		let offliner = createOffliner(
@@ -76,18 +76,18 @@ final class CollectionDownloadTests: OfflinerTestCase {
 		let runTask = Task { await offliner.run() }
 		await artworkDownloader.waitUntilStarted()
 
-		let state = await offliner.getOfflineCollectionDownloadState(
+		let states = await offliner.getOfflineCollectionDownloadState(
 			collectionType: .albums,
 			resourceId: .identifier("album-123")
-		).first()
+		).first(2)
 
-		XCTAssertEqual(state, .downloading)
+		XCTAssertEqual(states, [.notDownloaded, .downloading])
 
 		await artworkDownloader.complete()
 		await runTask.value
 	}
 
-	func testOfflineCollectionDownloadStateUsesCurrentRelatedDownloads() async throws {
+	func testOfflineCollectionDownloadStateReportsBackendPendingWorkForRelatedItemDownloads() async throws {
 		let backend = StubOfflineApiClient()
 		let mediaDownloader = SuspendingMediaDownloader()
 		let offliner = createOffliner(
@@ -105,15 +105,87 @@ final class CollectionDownloadTests: OfflinerTestCase {
 		_ = await downloadIterator.next()
 		await mediaDownloader.waitUntilStarted()
 
-		let state = await offliner.getOfflineCollectionDownloadState(
+		let states = await offliner.getOfflineCollectionDownloadState(
 			collectionType: .albums,
 			resourceId: .identifier("stub-album")
-		).first()
+		).first(2)
 
-		XCTAssertEqual(state, .downloading)
+		XCTAssertEqual(states, [.notDownloaded, .downloading])
 
 		await mediaDownloader.complete()
 		await backend.waitForTasksToComplete()
+	}
+
+	func testOfflineCollectionDownloadStateReportsBackendPendingWorkWithoutLocallyVisibleTasks() async throws {
+		let backend = StubOfflineApiClient()
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+
+		backend.pendingCollection = .mock(
+			catalogMetadata: .album(.mock(id: "album-123")),
+			artworkURL: nil,
+			state: .pending
+		)
+
+		let states = await offliner.getOfflineCollectionDownloadState(
+			collectionType: .albums,
+			resourceId: .identifier("album-123")
+		).first(2)
+
+		XCTAssertEqual(states, [.notDownloaded, .downloading])
+	}
+
+	func testOfflineCollectionDownloadStateFollowsDownloadLifecycle() async throws {
+		let backend = StubOfflineApiClient()
+		let artworkDownloader = SuspendingArtworkDownloader()
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: artworkDownloader,
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+
+		let stream = offliner.getOfflineCollectionDownloadState(
+			collectionType: .albums,
+			resourceId: .identifier("album-123")
+		)
+		var iterator = stream.makeAsyncIterator()
+		let initialState = await iterator.next()
+		XCTAssertEqual(initialState, .notDownloaded)
+
+		try await offliner.download(collectionType: .albums, resourceId: .identifier("album-123"))
+
+		let downloadingState = await iterator.next()
+		XCTAssertEqual(downloadingState, .downloading)
+
+		await artworkDownloader.waitUntilStarted()
+		await artworkDownloader.complete()
+
+		let downloadedState = await iterator.next()
+		XCTAssertEqual(downloadedState, .downloaded)
+	}
+
+	func testOfflineCollectionDownloadStateKeepsLocalStateWhenBackendUnreachable() async throws {
+		let backend = StubOfflineApiClient()
+		let offliner = createOffliner(
+			offlineApiClient: backend,
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SucceedingMediaDownloader()
+		)
+
+		try await offliner.download(collectionType: .albums, resourceId: .identifier("album-123"))
+		await offliner.run()
+		await backend.waitForTasksToComplete()
+		backend.getOfflineCollectionError = FakeError.backendFailed
+
+		let state = await offliner.getOfflineCollectionDownloadState(
+			collectionType: .albums,
+			resourceId: .identifier("album-123")
+		).first()
+
+		XCTAssertEqual(state, .downloaded)
 	}
 
 	func testOfflineCollectionDownloadStateTreatsSdkRemovalAsNotDownloadedImmediately() async throws {

--- a/Tests/OfflinerTests/OfflinerTestCase.swift
+++ b/Tests/OfflinerTests/OfflinerTestCase.swift
@@ -24,8 +24,7 @@ class OfflinerTestCase: XCTestCase {
 		artworkDownloader: ArtworkDownloaderProtocol,
 		mediaDownloader: MediaDownloaderProtocol,
 		trackManifestFetcher: TrackManifestFetcherProtocol = SucceedingTrackManifestFetcher(),
-		videoManifestFetcher: VideoManifestFetcherProtocol = SucceedingVideoManifestFetcher(),
-		collectionDownloadStatePollInterval: UInt64 = 1_000_000_000
+		videoManifestFetcher: VideoManifestFetcherProtocol = SucceedingVideoManifestFetcher()
 	) -> Offliner {
 		let dbPath = tempDir.appendingPathComponent("test-\(UUID().uuidString).sqlite").path
 		// swiftlint:disable:next force_try
@@ -41,8 +40,7 @@ class OfflinerTestCase: XCTestCase {
 			artworkDownloader: artworkDownloader,
 			mediaDownloader: mediaDownloader,
 			trackManifestFetcher: trackManifestFetcher,
-			videoManifestFetcher: videoManifestFetcher,
-			collectionDownloadStatePollInterval: collectionDownloadStatePollInterval
+			videoManifestFetcher: videoManifestFetcher
 		)
 	}
 

--- a/Tests/OfflinerTests/TestFakes.swift
+++ b/Tests/OfflinerTests/TestFakes.swift
@@ -20,6 +20,7 @@ final class StubOfflineApiClient: OfflineApiClientProtocol {
 	var pendingCollectionsPages: [(collections: [OfflineCollection], cursor: String?)] = []
 	var pendingCollection: OfflineCollection?
 	var pendingCollectionResponses: [OfflineCollection?]?
+	var getOfflineCollectionError: Error?
 	private(set) var getOfflineCollectionCallCount = 0
 
 	func enqueueTasks(_ newTasks: [OfflineTask]) {
@@ -158,12 +159,53 @@ final class StubOfflineApiClient: OfflineApiClientProtocol {
 
 	func getOfflineCollection(type: OfflineCollectionType, id: String) async throws -> OfflineCollection? {
 		getOfflineCollectionCallCount += 1
+		if let getOfflineCollectionError {
+			throw getOfflineCollectionError
+		}
 		if var responses = pendingCollectionResponses, !responses.isEmpty {
 			let response = responses.removeFirst()
 			pendingCollectionResponses = responses
 			return response
 		}
-		return pendingCollection
+		if let pendingCollection {
+			return pendingCollection
+		}
+		return derivedPendingCollection(type: type, id: id)
+	}
+
+	private func derivedPendingCollection(type: OfflineCollectionType, id: String) -> OfflineCollection? {
+		guard hasPendingStoreTasks(type: type, id: id) else { return nil }
+
+		let catalogMetadata: OfflineCollection.Metadata
+		switch type {
+		case .albums:
+			catalogMetadata = .album(.mock(id: id))
+		case .playlists:
+			catalogMetadata = .playlist(.mock(id: id))
+		case .userCollectionTracks:
+			catalogMetadata = .userCollectionTracks(id: id)
+		}
+
+		return .mock(catalogMetadata: catalogMetadata, artworkURL: nil, state: .pending)
+	}
+
+	private func hasPendingStoreTasks(type: OfflineCollectionType, id: String) -> Bool {
+		tasks.contains { offlineTask in
+			switch offlineTask {
+			case .storeTrack(let task):
+				return task.collectionResourceType == type.rawValue && task.collectionResourceId == id
+			case .storeVideo(let task):
+				return task.collectionResourceType == type.rawValue && task.collectionResourceId == id
+			case .storeAlbum(let task):
+				return type == .albums && task.album.id == id
+			case .storePlaylist(let task):
+				return type == .playlists && task.playlist.id == id
+			case .storeUserCollectionTracks:
+				return type == .userCollectionTracks
+			case .removeItem, .removeCollection:
+				return false
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## What

Replaces the polling-based `getOfflineCollectionDownloadState` with backend-driven resolution:

- The stream emits the local storage state first (works offline, instant), then a backend-corrected state when the offline inventory is reachable.
- Resolution order: backend reports pending work → `.downloading`; local collection row exists → `.downloaded`; otherwise `.notDownloaded`. If the backend is unreachable, the last emitted state stands.
- `TaskRunner` is trigger-only: when a task related to an observed collection starts or finishes, or the collection is downloaded/removed, it signals the stream to re-resolve against the backend. Its in-memory task list is never used as state truth.

## Why

The in-memory approach can't be correct: the backend queue interleaves tasks from many collections and is paginated, so locally invisible pending work exists behind the first page, and in-memory state doesn't survive restarts. The backend already resolves a collection's pending/stored state transactionally, so asking it directly removes the race conditions entirely instead of papering over them.

This supersedes the approach in #437 (TM-1767).

## How

- `TaskRunner.collectionEvents(for:)` returns an `AsyncStream<Void>` per observed collection; `refresh()`, `finish()`, and `notifyCollectionChanged` yield to matching observers. `bufferingNewest(1)` coalesces event bursts into a single refetch.
- Removed the poll interval, the polling loop, and `hasCurrentDownload`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)