### PR TITLE
TM-1573: Decouple Offliner playback

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -26,6 +26,18 @@ jobs:
       run: |-
         set -o pipefail && swift test --skip PlayerTests | xcbeautify --renderer github-actions
 
+  build-watchos-offliner:
+    name: Build watchOS Offliner
+    runs-on: macos-15
+    steps:
+    - uses: actions/checkout@v4
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: '26.2'
+    - name: Build Offliner for watchOS
+      run: |-
+        set -o pipefail && xcodebuild -scheme 'Offliner' -destination 'generic/platform=watchOS' build -skipPackagePluginValidation CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | xcbeautify --renderer github-actions
+
   run-xcodebuild-tests:
     name: Run xcodebuild Unit Tests
     runs-on: macos-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Player-independent offline playback assets with retained FairPlay preparation for watchOS (Offliner)
+- A watchOS Offliner compilation check in CI
+
+### Changed
+- Raise the package minimum watchOS version from 7 to 10 to match Offliner's AVFoundation download APIs
+- Remove Offliner's dependency on Player; Player consumers now provide their own `OfflineItemProvider` conformance
+
+### Fixed
+- Schedule a replacement download when a stored FairPlay license cannot be prepared for playback (Offliner)
+- Report Offliner download progress on watchOS through `URLSessionTask.progress`
+
 ## [0.12.6] - 2026-08-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A watchOS Offliner compilation check in CI
 
 ### Changed
+- Raise the package Swift tools version from 5.8 to 5.9
 - Raise the package minimum watchOS version from 7 to 10 to match Offliner's AVFoundation download APIs
 - Remove Offliner's dependency on Player; Player consumers now provide their own `OfflineItemProvider` conformance
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.8
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import class Foundation.ProcessInfo
@@ -15,7 +15,7 @@ let package = Package(
 		.iOS(.v15),
 		.macOS(.v12),
 		.tvOS(.v15),
-		.watchOS("10.0"),
+		.watchOS(.v10),
 	],
 	products: [
 		.library(

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
 		.iOS(.v15),
 		.macOS(.v12),
 		.tvOS(.v15),
-		.watchOS(.v7),
+		.watchOS("10.0"),
 	],
 	products: [
 		.library(

--- a/Package.swift
+++ b/Package.swift
@@ -163,7 +163,6 @@ let package = Package(
 				.GRDB,
 				.tidalAPI,
 				.auth,
-				.player,
 			],
 			exclude: [
 				"README.md",

--- a/Sources/Offliner/Internal/MediaDownloader.swift
+++ b/Sources/Offliner/Internal/MediaDownloader.swift
@@ -76,15 +76,8 @@ final class MediaDownloader: NSObject, MediaDownloaderProtocol {
 
 		return try await withCheckedThrowingContinuation { continuation in
 			queue.async {
-				guard let task = self.session.makeAssetDownloadTask(
-					asset: asset,
-					assetTitle: title,
-					assetArtworkData: nil,
-					options: nil
-				) else {
-					continuation.resume(throwing: MediaDownloaderError.failedToCreateTask)
-					return
-				}
+				let downloadConfiguration = AVAssetDownloadConfiguration(asset: asset, title: title)
+				let task = self.session.makeAssetDownloadTask(downloadConfiguration: downloadConfiguration)
 
 				let activeDownload = ActiveDownload(
 					duration: duration,
@@ -94,6 +87,10 @@ final class MediaDownloader: NSObject, MediaDownloaderProtocol {
 
 				task.taskDescription = taskId
 				task.priority = 1.0
+
+				activeDownload.progressObservation = task.progress.observe(\.fractionCompleted, options: [.initial, .new]) { progress, _ in
+					Task { await onProgress(progress.fractionCompleted) }
+				}
 
 				self.activeDownloads[task.taskIdentifier] = activeDownload
 				task.resume()
@@ -156,22 +153,6 @@ extension MediaDownloader: AVAssetDownloadDelegate {
 		activeDownload.continuation.resume(returning: result)
 	}
 
-	func urlSession(
-		_ session: URLSession,
-		assetDownloadTask: AVAssetDownloadTask,
-		didLoad timeRange: CMTimeRange,
-		totalTimeRangesLoaded loadedTimeRanges: [NSValue],
-		timeRangeExpectedToLoad: CMTimeRange
-	) {
-		let loaded = loadedTimeRanges.reduce(0.0) { $0 + CMTimeGetSeconds($1.timeRangeValue.duration) }
-		let expected = CMTimeGetSeconds(timeRangeExpectedToLoad.duration)
-		let progress = expected > 0 ? loaded / expected : 0
-
-		if let onProgress = activeDownloads[assetDownloadTask.taskIdentifier]?.onProgress {
-			Task { await onProgress(progress) }
-		}
-	}
-
 	func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
 		Self.logger.debug("urlSessionDidFinishEvents forBackgroundURLSession")
 		DispatchQueue.main.async { [weak self] in
@@ -189,6 +170,7 @@ private final class ActiveDownload {
 	let onProgress: @Sendable (Double) async -> Void
 
 	var downloadedLocation: URL?
+	var progressObservation: NSKeyValueObservation?
 
 	init(
 		duration: Int,
@@ -204,7 +186,6 @@ private final class ActiveDownload {
 // MARK: - MediaDownloaderError
 
 enum MediaDownloaderError: Error {
-	case failedToCreateTask
 	case noDownloadedFile
 	case manifestNotFound
 }

--- a/Sources/Offliner/Internal/OfflineStore.swift
+++ b/Sources/Offliner/Internal/OfflineStore.swift
@@ -251,7 +251,7 @@ final class OfflineStore {
 		return item
 	}
 
-	func getPlayableMediaItem(mediaType: OfflineMediaItemType, resourceId: String) async throws -> PlayableOfflineMediaItem? {
+	func getPlaybackAsset(mediaType: OfflineMediaItemType, resourceId: String) async throws -> OfflinePlaybackAsset? {
 		let row = try await databaseQueue.read { database in
 			try Row.fetchOne(
 				database,
@@ -269,7 +269,7 @@ final class OfflineStore {
 		let playbackMetadataJson: String? = row["playback_metadata"]
 
 		var renewals: [BookmarkRenewal] = []
-		let item = PlayableOfflineMediaItem(
+		let item = OfflinePlaybackAsset(
 			playbackMetadata: try playbackMetadataJson.map { try OfflineMediaItem.PlaybackMetadata.deserialize($0) },
 			mediaURL: try Self.resolveBookmark(row, column: "media_bookmark", renewals: &renewals),
 			licenseURL: try Self.resolveBookmarkIfPresent(row, column: "license_bookmark", renewals: &renewals)

--- a/Sources/Offliner/OfflinePlaybackAVAsset.swift
+++ b/Sources/Offliner/OfflinePlaybackAVAsset.swift
@@ -1,0 +1,112 @@
+import AVFoundation
+import Foundation
+
+// MARK: - OfflinePlaybackAVAssetError
+
+/// An error encountered while preparing a stored asset for AVFoundation playback.
+enum OfflinePlaybackAVAssetError: Error, Equatable {
+	case storedLicenseNotFound(URL)
+	case storedLicenseUnreadable(URL)
+}
+
+// MARK: - OfflinePlaybackAVAsset
+
+/// An AVFoundation asset prepared for offline playback.
+///
+/// This object owns the URL asset and, for protected media, the FairPlay content-key session, delegate, delegate queue,
+/// and stored license data. Retain this object for as long as any `AVPlayerItem` created from `urlAsset` is queued or
+/// playing. `AVPlayerItem` does not retain this playback preparation context for you. Construction validates that stored
+/// license data exists, is readable, and is non-empty; AVFoundation validates the license itself during playback and
+/// reports failures through `AVPlayerItem.status` and `AVPlayerItem.error`.
+public final class OfflinePlaybackAVAsset {
+	public let urlAsset: AVURLAsset
+
+	private let contentKeySession: AVContentKeySession?
+	private let contentKeySessionDelegate: StoredOfflineLicenseDelegate?
+	private let contentKeyDelegateQueue: DispatchQueue?
+
+	var usesStoredLicense: Bool {
+		contentKeySession != nil
+	}
+
+	init(playbackAsset: OfflinePlaybackAsset) throws {
+		let urlAsset = AVURLAsset(url: playbackAsset.mediaURL)
+		guard let licenseURL = playbackAsset.licenseURL else {
+			self.urlAsset = urlAsset
+			contentKeySession = nil
+			contentKeySessionDelegate = nil
+			contentKeyDelegateQueue = nil
+			return
+		}
+
+		var isDirectory: ObjCBool = false
+		guard FileManager.default.fileExists(atPath: licenseURL.path, isDirectory: &isDirectory) else {
+			throw OfflinePlaybackAVAssetError.storedLicenseNotFound(licenseURL)
+		}
+		guard !isDirectory.boolValue else {
+			throw OfflinePlaybackAVAssetError.storedLicenseUnreadable(licenseURL)
+		}
+
+		let license: Data
+		do {
+			license = try Data(contentsOf: licenseURL)
+		} catch {
+			throw OfflinePlaybackAVAssetError.storedLicenseUnreadable(licenseURL)
+		}
+		guard !license.isEmpty else {
+			throw OfflinePlaybackAVAssetError.storedLicenseUnreadable(licenseURL)
+		}
+
+		let delegate = StoredOfflineLicenseDelegate(license: license)
+		let delegateQueue = DispatchQueue(label: "com.tidal.offliner.stored-license")
+		let session = AVContentKeySession(keySystem: .fairPlayStreaming)
+		session.setDelegate(delegate, queue: delegateQueue)
+		session.addContentKeyRecipient(urlAsset)
+
+		self.urlAsset = urlAsset
+		contentKeySession = session
+		contentKeySessionDelegate = delegate
+		contentKeyDelegateQueue = delegateQueue
+	}
+}
+
+// MARK: - StoredOfflineLicenseDelegate
+
+private final class StoredOfflineLicenseDelegate: NSObject, AVContentKeySessionDelegate {
+	private let license: Data
+
+	init(license: Data) {
+		self.license = license
+	}
+
+	func contentKeySession(
+		_ session: AVContentKeySession,
+		didProvide keyRequest: AVContentKeyRequest
+	) {
+		do {
+			#if os(iOS)
+				try keyRequest.respondByRequestingPersistableContentKeyRequestAndReturnError()
+			#else
+				try keyRequest.respondByRequestingPersistableContentKeyRequest()
+			#endif
+		} catch {
+			keyRequest.processContentKeyResponseError(error)
+		}
+	}
+
+	func contentKeySession(
+		_ session: AVContentKeySession,
+		didProvide keyRequest: AVPersistableContentKeyRequest
+	) {
+		let response = AVContentKeyResponse(fairPlayStreamingKeyResponseData: license)
+		keyRequest.processContentKeyResponse(response)
+	}
+
+	func contentKeySession(
+		_ session: AVContentKeySession,
+		contentKeyRequest keyRequest: AVContentKeyRequest,
+		didFailWithError error: Error
+	) {
+		// AVPlayerItem.status/error is the consumer-facing runtime failure channel.
+	}
+}

--- a/Sources/Offliner/Offliner.swift
+++ b/Sources/Offliner/Offliner.swift
@@ -1,6 +1,5 @@
 import Foundation
 import GRDB
-import Player
 
 // MARK: - Offliner
 
@@ -121,6 +120,38 @@ public final class Offliner {
 		}
 
 		return items
+	}
+
+	/// Returns the locally playable asset for an offlined track or video.
+	///
+	/// File bookmarks are resolved only for playback so enumerating offline content remains fast. If a stored file can no
+	/// longer be resolved, this method returns `nil` and schedules the item to be downloaded again.
+	public func getOfflinePlaybackAsset(
+		mediaType: OfflineMediaItemType,
+		resourceId: ResourceId
+	) async -> OfflinePlaybackAsset? {
+		do {
+			return try await offlineStore.getPlaybackAsset(mediaType: mediaType, resourceId: resourceId.stringValue)
+		} catch {
+			Task { try? await download(mediaType: mediaType, resourceId: resourceId) }
+			return nil
+		}
+	}
+
+	/// Returns an AVFoundation asset prepared for unprotected or stored-license playback.
+	///
+	/// Retain the returned object for the entire lifetime of every `AVPlayerItem` made from its `urlAsset`, including while
+	/// queued. Construction performs structural preparation only; AVFoundation reports runtime DRM failures through the
+	/// resulting `AVPlayerItem.status` and `AVPlayerItem.error`. If stored playback files or license preparation cannot be
+	/// resolved, this returns `nil`.
+	public func getOfflinePlaybackAVAsset(
+		mediaType: OfflineMediaItemType,
+		resourceId: ResourceId
+	) async -> OfflinePlaybackAVAsset? {
+		guard let playbackAsset = await getOfflinePlaybackAsset(mediaType: mediaType, resourceId: resourceId) else {
+			return nil
+		}
+		return try? OfflinePlaybackAVAsset(playbackAsset: playbackAsset)
 	}
 
 	public func getOfflineCollection(
@@ -386,28 +417,6 @@ public final class Offliner {
 	}
 }
 
-// MARK: - OfflineItemProvider
-
-extension Offliner: OfflineItemProvider {
-	public func get(productType: ProductType, productId: String) async -> OfflinePlaybackItem? {
-		let mediaType: OfflineMediaItemType
-		switch productType {
-		case .TRACK: mediaType = .tracks
-		case .VIDEO: mediaType = .videos
-		case .UC: return nil
-		}
-
-		do {
-			return try await offlineStore.getPlayableMediaItem(mediaType: mediaType, resourceId: productId)
-				.map { OfflinePlaybackItem($0, productType: productType) }
-		} catch {
-			Task { try? await download(mediaType: mediaType, resourceId: .identifier(productId)) }
-		}
-
-		return nil
-	}
-}
-
 // MARK: - Internal Mappings
 
 extension OfflineMediaItemType {
@@ -426,20 +435,5 @@ extension OfflineCollectionType {
 		case .playlists: return .playlist
 		case .userCollectionTracks: return .userCollectionTracks
 		}
-	}
-}
-
-// MARK: - OfflinePlaybackItem from PlayableOfflineMediaItem
-
-private extension OfflinePlaybackItem {
-	init(_ item: PlayableOfflineMediaItem, productType: ProductType) {
-		self.init(
-			mediaURL: item.mediaURL,
-			licenseURL: item.licenseURL,
-			format: item.playbackMetadata?.format.rawValue,
-			albumReplayGain: item.playbackMetadata?.albumNormalizationData?.replayGain,
-			albumPeakAmplitude: item.playbackMetadata?.albumNormalizationData?.peakAmplitude,
-			productType: productType
-		)
 	}
 }

--- a/Sources/Offliner/Offliner.swift
+++ b/Sources/Offliner/Offliner.swift
@@ -143,7 +143,7 @@ public final class Offliner {
 	/// Retain the returned object for the entire lifetime of every `AVPlayerItem` made from its `urlAsset`, including while
 	/// queued. Construction performs structural preparation only; AVFoundation reports runtime DRM failures through the
 	/// resulting `AVPlayerItem.status` and `AVPlayerItem.error`. If stored playback files or license preparation cannot be
-	/// resolved, this returns `nil`.
+	/// resolved, this returns `nil` and schedules the item to be downloaded again.
 	public func getOfflinePlaybackAVAsset(
 		mediaType: OfflineMediaItemType,
 		resourceId: ResourceId
@@ -151,7 +151,12 @@ public final class Offliner {
 		guard let playbackAsset = await getOfflinePlaybackAsset(mediaType: mediaType, resourceId: resourceId) else {
 			return nil
 		}
-		return try? OfflinePlaybackAVAsset(playbackAsset: playbackAsset)
+		do {
+			return try OfflinePlaybackAVAsset(playbackAsset: playbackAsset)
+		} catch {
+			Task { try? await download(mediaType: mediaType, resourceId: resourceId) }
+			return nil
+		}
 	}
 
 	public func getOfflineCollection(

--- a/Sources/Offliner/README.md
+++ b/Sources/Offliner/README.md
@@ -161,7 +161,7 @@ Retrieve a specific offline media item:
 
 ```swift
 if let track = try await offliner.getOfflineMediaItem(mediaType: .tracks, resourceId: "track-id") {
-    // Access mediaURL, licenseURL, artworkURL, catalogMetadata, and playbackMetadata
+	// Access artworkURL, catalogMetadata, and playbackMetadata without resolving playback files
 }
 ```
 
@@ -322,11 +322,88 @@ Removal requests are registered with the backend and task processing is triggere
 
 ## Offline Playback
 
-Offliner conforms to `OfflineItemProvider` (from the Player module), so it can be used directly as the offline content source for the Player:
+Offliner exposes a Player-independent playback asset lookup. The lookup resolves the stored media and license file bookmarks only when playback is requested:
 
 ```swift
-let item = await offliner.get(productType: .TRACK, productId: "track-id")
-// Returns an OfflinePlaybackItem with mediaURL, licenseURL, format, and normalization data
+let asset = await offliner.getOfflinePlaybackAsset(
+	mediaType: .tracks,
+	resourceId: .identifier("track-id")
+)
+// Returns mediaURL, licenseURL, and playback metadata. A missing stored file returns nil and schedules a redownload.
+```
+
+On watchOS, do not create a plain `AVURLAsset` from `mediaURL` when `licenseURL` is present. Prepare the asset through
+Offliner so protected downloads receive their persisted FairPlay license:
+
+```swift
+import AVFoundation
+import Offliner
+
+final class QueuedOfflinePlayback {
+	// Retain this wrapper for the entire lifetime of playerItem, including while it is queued.
+	let preparedAsset: OfflinePlaybackAVAsset
+	let playerItem: AVPlayerItem
+
+	init(preparedAsset: OfflinePlaybackAVAsset) {
+		self.preparedAsset = preparedAsset
+		playerItem = AVPlayerItem(asset: preparedAsset.urlAsset)
+	}
+}
+
+guard let preparedAsset = await offliner.getOfflinePlaybackAVAsset(
+	mediaType: .tracks,
+	resourceId: .identifier("track-id")
+) else {
+	// The item is unavailable locally.
+	return
+}
+
+let queuedPlayback = QueuedOfflinePlayback(preparedAsset: preparedAsset)
+player.insert(queuedPlayback.playerItem, after: nil)
+// Keep queuedPlayback alive until its playerItem has been removed from the queue.
+```
+
+`getOfflinePlaybackAVAsset` is the supported watchOS lookup. `OfflinePlaybackAVAsset` creates no content-key session for
+unprotected media. For protected media it loads the stored license, creates an
+`AVContentKeySession(.fairPlayStreaming)`, installs the stored-license delegate, and registers its `urlAsset` as the
+content-key recipient. Construction verifies only that the license file exists, is readable, and is non-empty; it does
+not prove that the license is valid or unexpired. AVFoundation reports those runtime failures through
+`AVPlayerItem.status == .failed` and `AVPlayerItem.error`, which the existing Player implementation already observes.
+The Watch consumer must observe the same runtime channel and choose its allowed streaming fallback or request repair via
+`Offliner.download`. Real FairPlay playback and that Watch fallback policy remain TM-1574 device-validation gates.
+
+Offliner has no dependency on the Player module because Player does not support watchOS. Consumers that use Player can declare the `OfflineItemProvider` conformance in a target that links both products:
+
+```swift
+import Offliner
+import Player
+
+extension Offliner: @retroactive OfflineItemProvider {
+	public func get(productType: ProductType, productId: String) async -> OfflinePlaybackItem? {
+		let mediaType: OfflineMediaItemType
+		switch productType {
+		case .TRACK: mediaType = .tracks
+		case .VIDEO: mediaType = .videos
+		case .UC: return nil
+		}
+
+		guard let asset = await getOfflinePlaybackAsset(
+			mediaType: mediaType,
+			resourceId: .identifier(productId)
+		) else {
+			return nil
+		}
+
+		return OfflinePlaybackItem(
+			mediaURL: asset.mediaURL,
+			licenseURL: asset.licenseURL,
+			format: asset.playbackMetadata?.format.rawValue,
+			albumReplayGain: asset.playbackMetadata?.albumNormalizationData?.replayGain,
+			albumPeakAmplitude: asset.playbackMetadata?.albumNormalizationData?.peakAmplitude,
+			productType: productType
+		)
+	}
+}
 ```
 
 ---

--- a/Sources/Offliner/README.md
+++ b/Sources/Offliner/README.md
@@ -4,6 +4,8 @@ Offliner is the TIDAL SDK module for managing offline content. It handles downlo
 
 ## Getting Started
 
+Offliner supports watchOS 10 and newer, matching the availability of AVFoundation's asset-download APIs.
+
 ### Initialization
 
 Offliner requires that `OpenAPIClientAPI.credentialsProvider` is configured before use (typically set to your Auth module's credential provider).
@@ -366,11 +368,12 @@ player.insert(queuedPlayback.playerItem, after: nil)
 `getOfflinePlaybackAVAsset` is the supported watchOS lookup. `OfflinePlaybackAVAsset` creates no content-key session for
 unprotected media. For protected media it loads the stored license, creates an
 `AVContentKeySession(.fairPlayStreaming)`, installs the stored-license delegate, and registers its `urlAsset` as the
-content-key recipient. Construction verifies only that the license file exists, is readable, and is non-empty; it does
-not prove that the license is valid or unexpired. AVFoundation reports those runtime failures through
-`AVPlayerItem.status == .failed` and `AVPlayerItem.error`, which the existing Player implementation already observes.
-The Watch consumer must observe the same runtime channel and choose its allowed streaming fallback or request repair via
-`Offliner.download`. Real FairPlay playback and that Watch fallback policy remain TM-1574 device-validation gates.
+content-key recipient. Construction verifies only that the license file exists, is readable, and is non-empty. A structural failure returns
+`nil` and schedules a replacement download. Construction does not prove that the license is valid or unexpired;
+AVFoundation reports those runtime failures through `AVPlayerItem.status == .failed` and `AVPlayerItem.error`, which the
+existing Player implementation already observes. The Watch consumer must observe the same runtime channel and choose
+its allowed streaming fallback or request repair via `Offliner.download`. Real FairPlay playback and that Watch fallback
+policy remain TM-1574 device-validation gates.
 
 Offliner has no dependency on the Player module because Player does not support watchOS. Consumers that use Player can declare the `OfflineItemProvider` conformance in a target that links both products:
 

--- a/Sources/Offliner/Types.swift
+++ b/Sources/Offliner/Types.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Player
 
 // MARK: - OfflineMediaItemType
 
@@ -79,12 +78,22 @@ public struct OfflineMediaItem {
 	public let artworkURL: URL?
 }
 
-// MARK: - PlayableOfflineMediaItem
+// MARK: - OfflinePlaybackAsset
 
-struct PlayableOfflineMediaItem {
-	let playbackMetadata: OfflineMediaItem.PlaybackMetadata?
-	let mediaURL: URL
-	let licenseURL: URL?
+public struct OfflinePlaybackAsset {
+	public let playbackMetadata: OfflineMediaItem.PlaybackMetadata?
+	public let mediaURL: URL
+	public let licenseURL: URL?
+
+	public init(
+		playbackMetadata: OfflineMediaItem.PlaybackMetadata?,
+		mediaURL: URL,
+		licenseURL: URL?
+	) {
+		self.playbackMetadata = playbackMetadata
+		self.mediaURL = mediaURL
+		self.licenseURL = licenseURL
+	}
 }
 
 // MARK: - OfflineCollectionState

--- a/Tests/OfflinerTests/CollectionItemsTests.swift
+++ b/Tests/OfflinerTests/CollectionItemsTests.swift
@@ -90,7 +90,7 @@ final class CollectionItemsTests: OfflinerTestCase {
 
 	// MARK: - Corrupted entries
 
-	func testItemWithDeletedMediaFileRemainsListedButIsNotPlayable() async throws {
+	func testItemWithDeletedMediaFileRemainsListedAndSchedulesRedownload() async throws {
 		let backend = StubOfflineApiClient()
 		let offliner = createOffliner(
 			offlineApiClient: backend,
@@ -124,7 +124,10 @@ final class CollectionItemsTests: OfflinerTestCase {
 		backend.enqueueTasks(tasks)
 		try await runAllTasks(offliner, backend: backend, expectedDownloads: 3)
 
-		let storedPlayableItem = await offliner.get(productType: .TRACK, productId: "track-2")
+		let storedPlayableItem = await offliner.getOfflinePlaybackAsset(
+			mediaType: .tracks,
+			resourceId: .identifier("track-2")
+		)
 		let mediaURL = try XCTUnwrap(storedPlayableItem?.mediaURL)
 		try FileManager.default.removeItem(at: mediaURL)
 
@@ -135,8 +138,17 @@ final class CollectionItemsTests: OfflinerTestCase {
 		)
 
 		XCTAssertEqual(page.items.map(\.item.catalogMetadata.id), ["track-1", "track-2", "track-3"])
-		let playableItem = await offliner.get(productType: .TRACK, productId: "track-2")
+		let playableItem = await offliner.getOfflinePlaybackAsset(
+			mediaType: .tracks,
+			resourceId: .identifier("track-2")
+		)
+		let observedRepairRequest = try await backend.waitForAddedItems(count: 1)
+
 		XCTAssertNil(playableItem)
+		XCTAssertTrue(observedRepairRequest, "Timed out waiting for playback repair request")
+		XCTAssertEqual(backend.addedItems.count, 1)
+		XCTAssertEqual(backend.addedItems.first?.type, .track)
+		XCTAssertEqual(backend.addedItems.first?.id, "track-2")
 	}
 
 	// MARK: - Empty collection

--- a/Tests/OfflinerTests/MediaItemDownloadTests.swift
+++ b/Tests/OfflinerTests/MediaItemDownloadTests.swift
@@ -132,7 +132,10 @@ final class MediaItemDownloadTests: OfflinerTestCase {
 
 		let firstItem = try await offliner.getOfflineMediaItem(mediaType: .tracks, resourceId: .identifier("track-123"))
 		let firstItemUnwrapped = try XCTUnwrap(firstItem)
-		let firstPlayableItem = await offliner.get(productType: .TRACK, productId: "track-123")
+		let firstPlayableItem = await offliner.getOfflinePlaybackAsset(
+			mediaType: .tracks,
+			resourceId: .identifier("track-123")
+		)
 		let firstMediaURL = try XCTUnwrap(firstPlayableItem?.mediaURL)
 		let firstArtworkURL = try XCTUnwrap(firstItemUnwrapped.artworkURL)
 		XCTAssertTrue(FileManager.default.fileExists(atPath: firstMediaURL.path))
@@ -143,7 +146,10 @@ final class MediaItemDownloadTests: OfflinerTestCase {
 
 		let secondItem = try await offliner.getOfflineMediaItem(mediaType: .tracks, resourceId: .identifier("track-123"))
 		let secondItemUnwrapped = try XCTUnwrap(secondItem)
-		let secondPlayableItem = await offliner.get(productType: .TRACK, productId: "track-123")
+		let secondPlayableItem = await offliner.getOfflinePlaybackAsset(
+			mediaType: .tracks,
+			resourceId: .identifier("track-123")
+		)
 		let secondMediaURL = try XCTUnwrap(secondPlayableItem?.mediaURL)
 		let secondArtworkURL = try XCTUnwrap(secondItemUnwrapped.artworkURL)
 

--- a/Tests/OfflinerTests/OfflinePlaybackAVAssetTests.swift
+++ b/Tests/OfflinerTests/OfflinePlaybackAVAssetTests.swift
@@ -1,0 +1,113 @@
+import AVFoundation
+import Foundation
+@testable import Offliner
+import XCTest
+
+final class OfflinePlaybackAVAssetTests: OfflinerTestCase {
+	func testUnprotectedAssetUsesPlainURLAsset() throws {
+		let mediaURL = tempDir.appendingPathComponent("media.movpkg")
+		let preparedAsset = try OfflinePlaybackAVAsset(playbackAsset: playbackAsset(
+			mediaURL: mediaURL,
+			licenseURL: nil
+		))
+
+		XCTAssertEqual(preparedAsset.urlAsset.url, mediaURL)
+		XCTAssertFalse(preparedAsset.usesStoredLicense)
+	}
+
+	func testProtectedAssetStructurallyPreparesNonEmptyStoredLicense() throws {
+		#if targetEnvironment(simulator)
+			throw XCTSkip("AVContentKeySession FairPlay construction is unavailable on simulators")
+		#else
+			let mediaURL = tempDir.appendingPathComponent("media.movpkg")
+			let licenseURL = tempDir.appendingPathComponent("license.key")
+			// Unit scope verifies retained setup only; AVFoundation validates license bytes during playback.
+			try Data([0x01, 0x02, 0x03]).write(to: licenseURL)
+
+			let preparedAsset = try OfflinePlaybackAVAsset(playbackAsset: playbackAsset(
+				mediaURL: mediaURL,
+				licenseURL: licenseURL
+			))
+
+			XCTAssertEqual(preparedAsset.urlAsset.url, mediaURL)
+			XCTAssertTrue(preparedAsset.usesStoredLicense)
+		#endif
+	}
+
+	func testProtectedAssetRejectsMissingStoredLicense() {
+		let licenseURL = tempDir.appendingPathComponent("missing.key")
+
+		XCTAssertThrowsError(try OfflinePlaybackAVAsset(playbackAsset: playbackAsset(
+			mediaURL: tempDir.appendingPathComponent("media.movpkg"),
+			licenseURL: licenseURL
+		))) { error in
+			XCTAssertEqual(error as? OfflinePlaybackAVAssetError, .storedLicenseNotFound(licenseURL))
+		}
+	}
+
+	func testProtectedAssetRejectsUnreadableStoredLicense() throws {
+		let licenseURL = tempDir.appendingPathComponent("license.key", isDirectory: true)
+		try FileManager.default.createDirectory(at: licenseURL, withIntermediateDirectories: true)
+
+		XCTAssertThrowsError(try OfflinePlaybackAVAsset(playbackAsset: playbackAsset(
+			mediaURL: tempDir.appendingPathComponent("media.movpkg"),
+			licenseURL: licenseURL
+		))) { error in
+			XCTAssertEqual(error as? OfflinePlaybackAVAssetError, .storedLicenseUnreadable(licenseURL))
+		}
+	}
+
+	func testProtectedAssetRejectsEmptyStoredLicense() throws {
+		let licenseURL = tempDir.appendingPathComponent("license.key")
+		try Data().write(to: licenseURL)
+
+		XCTAssertThrowsError(try OfflinePlaybackAVAsset(playbackAsset: playbackAsset(
+			mediaURL: tempDir.appendingPathComponent("media.movpkg"),
+			licenseURL: licenseURL
+		))) { error in
+			XCTAssertEqual(error as? OfflinePlaybackAVAssetError, .storedLicenseUnreadable(licenseURL))
+		}
+	}
+
+	func testPreparedLookupReturnsNilForEmptyStoredLicense() async throws {
+		let offliner = createOffliner(
+			offlineApiClient: StubOfflineApiClient(),
+			artworkDownloader: SucceedingArtworkDownloader(),
+			mediaDownloader: SuspendingMediaDownloader()
+		)
+		let mediaURL = tempDir.appendingPathComponent("track.movpkg")
+		let licenseURL = tempDir.appendingPathComponent("track.key")
+		try Data("media".utf8).write(to: mediaURL)
+		try Data().write(to: licenseURL)
+		let store = OfflineStore(lastDatabaseQueue)
+		try store.storeMediaItem(StoreItemTaskResult(
+			resourceType: OfflineMediaItemType.tracks.rawValue,
+			resourceId: "track-id",
+			catalogMetadata: .track(.mock(id: "track-id")),
+			playbackMetadata: nil,
+			collectionResourceType: OfflineCollectionType.albums.rawValue,
+			collectionResourceId: "album-id",
+			volume: 1,
+			position: 1,
+			addedAt: nil,
+			mediaURL: mediaURL,
+			licenseURL: licenseURL,
+			artworkURL: nil
+		))
+
+		let preparedAsset = await offliner.getOfflinePlaybackAVAsset(
+			mediaType: .tracks,
+			resourceId: .identifier("track-id")
+		)
+
+		XCTAssertNil(preparedAsset)
+	}
+
+	private func playbackAsset(mediaURL: URL, licenseURL: URL?) -> OfflinePlaybackAsset {
+		OfflinePlaybackAsset(
+			playbackMetadata: nil,
+			mediaURL: mediaURL,
+			licenseURL: licenseURL
+		)
+	}
+}

--- a/Tests/OfflinerTests/OfflinePlaybackAVAssetTests.swift
+++ b/Tests/OfflinerTests/OfflinePlaybackAVAssetTests.swift
@@ -69,9 +69,10 @@ final class OfflinePlaybackAVAssetTests: OfflinerTestCase {
 		}
 	}
 
-	func testPreparedLookupReturnsNilForEmptyStoredLicense() async throws {
+	func testPreparedLookupReturnsNilAndSchedulesRedownloadForEmptyStoredLicense() async throws {
+		let backend = StubOfflineApiClient()
 		let offliner = createOffliner(
-			offlineApiClient: StubOfflineApiClient(),
+			offlineApiClient: backend,
 			artworkDownloader: SucceedingArtworkDownloader(),
 			mediaDownloader: SuspendingMediaDownloader()
 		)
@@ -99,8 +100,13 @@ final class OfflinePlaybackAVAssetTests: OfflinerTestCase {
 			mediaType: .tracks,
 			resourceId: .identifier("track-id")
 		)
+		let observedRepairRequest = try await backend.waitForAddedItems(count: 1)
 
 		XCTAssertNil(preparedAsset)
+		XCTAssertTrue(observedRepairRequest, "Timed out waiting for playback repair request")
+		XCTAssertEqual(backend.addedItems.count, 1)
+		XCTAssertEqual(backend.addedItems.first?.type, .track)
+		XCTAssertEqual(backend.addedItems.first?.id, "track-id")
 	}
 
 	private func playbackAsset(mediaURL: URL, licenseURL: URL?) -> OfflinePlaybackAsset {

--- a/Tests/OfflinerTests/RemoveTests.swift
+++ b/Tests/OfflinerTests/RemoveTests.swift
@@ -40,7 +40,10 @@ final class RemoveTests: OfflinerTestCase {
 
 		let storedItemOptional = try await offliner.getOfflineMediaItem(mediaType: .tracks, resourceId: .identifier("track-123"))
 		let storedItem = try XCTUnwrap(storedItemOptional)
-		let playableItem = await offliner.get(productType: .TRACK, productId: "track-123")
+		let playableItem = await offliner.getOfflinePlaybackAsset(
+			mediaType: .tracks,
+			resourceId: .identifier("track-123")
+		)
 		let mediaURL = try XCTUnwrap(playableItem?.mediaURL)
 		let artworkURL = try XCTUnwrap(storedItem.artworkURL)
 		XCTAssertTrue(FileManager.default.fileExists(atPath: mediaURL.path))

--- a/Tests/OfflinerTests/TestFakes.swift
+++ b/Tests/OfflinerTests/TestFakes.swift
@@ -149,6 +149,18 @@ final class StubOfflineApiClient: OfflineApiClientProtocol {
 		}
 	}
 
+	func waitForAddedItems(count: Int, timeout: TimeInterval = 1) async throws -> Bool {
+		let deadline = Date().addingTimeInterval(timeout)
+		while addedItems.count < count {
+			guard Date() < deadline else {
+				return false
+			}
+			try Task.checkCancellation()
+			try await Task.sleep(nanoseconds: 10_000_000)
+		}
+		return true
+	}
+
 	func getPendingCollections(
 		type: OfflineCollectionType,
 		cursor: String?


### PR DESCRIPTION
## Why

Offliner currently depends on Player through `OfflineItemProvider`. Because Player does not support watchOS, that dependency prevents the TIDAL Watch target from adopting Offliner even though the download, persistence, and backend task layers are otherwise shared. Watch playback also cannot create a plain `AVURLAsset` for protected downloads: the stored FairPlay license session, delegate, and queue must be attached to the asset and retained for the full lifetime of every queued player item.

The previous downloader also used AVFoundation task-construction and progress-delegate APIs that are unavailable on watchOS. Offliner therefore needed both a Player-neutral playback boundary and the modern cross-platform AVFoundation download APIs before it could compile for Watch.

## What

- Remove Player from Offliner's target dependencies and expose a public Player-neutral `OfflinePlaybackAsset` lookup.
- Add `OfflinePlaybackAVAsset`, which attaches a persisted FairPlay license and retains its preparation state for consumer-owned player items.
- Adopt `AVAssetDownloadConfiguration` and `URLSessionTask.progress` across supported Apple platforms instead of adding separate iPhone and Watch downloader implementations.
- Raise the Swift tools version to 5.9 and the package minimum to watchOS 10, matching both AVFoundation's asset-download availability and the TIDAL Watch deployment target.
- Add a permanent generic-watchOS Offliner build to CI.
- Preserve playback self-healing: unresolved media files and structurally missing, unreadable, or empty stored licenses return `nil` and schedule a replacement download.
- Document consumer-owned retroactive Player conformance and the structural/runtime FairPlay error boundary.

## Risk Assessment

Medium. This changes Offliner's public Player integration and the shared AVFoundation download-task construction/progress path. The modern APIs are available at the package's existing iOS 15 and macOS 12 minimums and at the new watchOS 10 minimum; the Swift tools version increases from 5.8 to 5.9, matching the repository's supported Swift version. Compilation is covered on macOS, iOS Simulator, and generic watchOS. Protected FairPlay playback still requires physical-device validation.

## Verification at `6f871212`

- `swift build` — passed
- generic watchOS Offliner build — passed
- full Offliner iOS-simulator scheme — passed: 83 tests, 0 failures, 1 expected simulator-only protected-FairPlay skip
- repository-pinned SwiftLint 0.57.0 on changed Swift files — 0 violations
- `git diff --check` — passed

The Offliner run includes repair assertions for both a missing media file and an empty stored FairPlay license. Simulator tests verify structural preparation but cannot prove protected FairPlay playback.

## Known baseline test exceptions

The full package suite is **not** reported as passing:

- raw `swift test` compiled and then stalled; `swift test --skip PlayerTests` reproduced the stall twice in pre-existing EventProducer setup. Stack samples showed `EventsTests.setUp()` and the scheduler concurrently blocked opening the SQLite-backed `EventQueue`.
- the full Player simulator scheme failed in timing/cache/HTTP/FairPlay tests and with `ContiguousArrayBuffer` bounds crashes. The same failure families and crash signature reproduced against untouched base commit `787fe9640096b44135ff206bf4769fa9a5da56f0`, so they are recorded as baseline instability rather than evidence of this patch interacting with Player.

## Delivery boundaries

- The TIDAL Watch app must still replace OfflineKit/Realm, configure and run Offliner, retain `OfflinePlaybackAVAsset` with queued items, and define its runtime streaming fallback/repair policy.
- Construction only proves that stored FairPlay license data exists and is non-empty. AVFoundation reports invalid or expired licenses through `AVPlayerItem.status` and `AVPlayerItem.error`; physical-Watch DRM, lifetime, fallback, and runtime repair behavior remain TM-1574 gates.
- Removing Offliner's SDK-owned `OfflineItemProvider` conformance is an intentional source compatibility change. TM-1576 adoption must pin the released SDK and add the iPhone-target retroactive conformance atomically; publishing this SDK without that adoption adapter would break the current iOS consumer.

Linear: [TM-1573](https://linear.app/squareup/issue/TM-1573/watchsdk-land-offliner-watchos-enablement-player-decoupling-download)

Generated with Codex
