### PR TITLE
Player: Narrow UC product type to local file playback and rename it LOCAL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Breaking:** renamed `ProductType.UC(url:)` to `ProductType.LOCAL(url:)`, and its `rawValue` from `"UC"` to `"LOCAL"`. The case is now documented as file-URL only. (Player)
+
+### Removed
+- Removed the remote half of the former UC path: the `UCMediaPlayer` protocol, both `loadUC` implementations and the `loadUCFailed` log case. A local file now loads through the same `AVURLAsset` path as a video, which sets `AVURLAssetPreferPreciseDurationAndTimingKey` for file URLs. (Player)
+- Removed `credentialsProvider` from `PlayerLoader` and `InternalPlayerLoader`; the deleted auth-token fetch was its only user. (Player)
+
 ## [0.12.6] - 2026-08-24
 
 ### Changed

--- a/Sources/Offliner/Offliner.swift
+++ b/Sources/Offliner/Offliner.swift
@@ -394,7 +394,7 @@ extension Offliner: OfflineItemProvider {
 		switch productType {
 		case .TRACK: mediaType = .tracks
 		case .VIDEO: mediaType = .videos
-		case .UC: return nil
+		case .LOCAL: return nil
 		}
 
 		do {

--- a/Sources/Player/Common/Data/ProductType.swift
+++ b/Sources/Player/Common/Data/ProductType.swift
@@ -7,11 +7,16 @@ public typealias PlayerProductType = ProductType
 public enum ProductType: Codable, Equatable {
 	case TRACK
 	case VIDEO
-	case UC(url: URL)
+	/// A file already on the device, played straight off disk with no playback info fetched for it.
+	///
+	/// The URL must be a `file://` URL. Its only caller today is user-uploaded content the backend
+	/// has not finished processing: there is no product to look up yet, so the uploader plays the
+	/// copy they still hold.
+	case LOCAL(url: URL)
 
 	func quality(given playbackContext: PlaybackContext) -> String {
 		switch self {
-		case .TRACK, .UC:
+		case .TRACK, .LOCAL:
 			playbackContext.audioQuality?.rawValue ?? "AQ N/A"
 		case .VIDEO:
 			playbackContext.videoQuality?.rawValue ?? "VQ N/A"
@@ -20,7 +25,7 @@ public enum ProductType: Codable, Equatable {
 
 	func quality(given metadata: Metadata) -> String {
 		switch self {
-		case .TRACK, .UC:
+		case .TRACK, .LOCAL:
 			metadata.audioQuality?.rawValue ?? "AQ N/A"
 		case .VIDEO:
 			metadata.videoQuality?.rawValue ?? "VQ N/A"
@@ -31,7 +36,7 @@ public enum ProductType: Codable, Equatable {
 		switch self {
 		case .TRACK: "TRACK"
 		case .VIDEO: "VIDEO"
-		case .UC: "UC"
+		case .LOCAL: "LOCAL"
 		}
 	}
 }
@@ -42,7 +47,7 @@ extension ProductType: CustomStringConvertible {
 	public var description: String {
 		switch self {
 		case .TRACK, .VIDEO: rawValue
-		case let .UC(url): "\(rawValue) (\(url))"
+		case let .LOCAL(url): "\(rawValue) (\(url))"
 		}
 	}
 }

--- a/Sources/Player/Common/Logging/PlayerLoggable.swift
+++ b/Sources/Player/Common/Logging/PlayerLoggable.swift
@@ -127,10 +127,6 @@ enum PlayerLoggable: TidalLoggable {
 	case playWithoutQueuedItems
 	case itemChangedWithoutQueuedItems
 
-	// MARK: InternalPlayerLoader
-
-	case loadUCFailed(error: Error)
-
 	// MARK: PlayerEngine
 
 	case loadPlayerItemFailed(error: Error)
@@ -359,10 +355,6 @@ extension PlayerLoggable {
 		case .itemChangedWithoutQueuedItems:
 			"AVQueuePlayerWrapper-itemChangedWithoutQueuedItems"
 
-		// InternalPlayerLoader
-		case .loadUCFailed:
-			"InternalPlayerLoader-loadUCFailed"
-
 		// PlayerEngine
 		case .loadPlayerItemFailed:
 			"PlayerEngine-loadPlayerItemFailed"
@@ -502,7 +494,6 @@ extension PlayerLoggable {
 		     let .failedToCalculateSizeForHLSDownload(error),
 		     let .failedToCalculateSizeForProgressiveDownload(error),
 		     let .readPlaybackMetadataFailed(error),
-		     let .loadUCFailed(error),
 		     let .loadPlayerItemFailed(error):
 			metadata[Logger.Metadata.errorKey] = "\(String(describing: error))"
 		case let .backoffHandleResponseFailed(error, retryStrategy):
@@ -625,7 +616,6 @@ extension PlayerLoggable {
 		     .failedToCalculateSizeForHLSDownload,
 		     .failedToCalculateSizeForProgressiveDownload,
 		     .readPlaybackMetadataFailed,
-		     .loadUCFailed,
 		     .loadPlayerItemFailed,
 		     .alreadyInitialized:
 			.error

--- a/Sources/Player/Common/PlaybackInfo/PlaybackInfoFetcher.swift
+++ b/Sources/Player/Common/PlaybackInfo/PlaybackInfoFetcher.swift
@@ -46,11 +46,10 @@ final class PlaybackInfoFetcher {
 				playbackMode: playbackMode,
 				streamingSessionId: streamingSessionId
 			)
-		case let .UC(url):
-			await getUCPlaybackInfo(
+		case let .LOCAL(url):
+			getLocalPlaybackInfo(
 				trackId: mediaProduct.productId,
 				trackURL: url,
-				playbackMode: playbackMode,
 				streamingSessionId: streamingSessionId
 			)
 		}
@@ -271,14 +270,18 @@ private extension PlaybackInfoFetcher {
 		}
 	}
 
-	func getUCPlaybackInfo(
+	/// Synthesizes playback info for a file already on the device.
+	///
+	/// Nothing is fetched: the backend has no product to describe yet, which is the whole reason the
+	/// caller is playing off disk. The audio fields below are therefore placeholders rather than
+	/// measurements of the file.
+	func getLocalPlaybackInfo(
 		trackId: String,
 		trackURL: URL,
-		playbackMode: PlaybackMode,
 		streamingSessionId: String
-	) async -> PlaybackInfo {
+	) -> PlaybackInfo {
 		PlaybackInfo(
-			productType: .UC(url: trackURL),
+			productType: .LOCAL(url: trackURL),
 			productId: trackId,
 			streamType: .ON_DEMAND,
 			assetPresentation: .FULL,
@@ -301,7 +304,7 @@ private extension PlaybackInfoFetcher {
 			offlineRevalidateAt: nil,
 			offlineValidUntil: nil,
 			isAdaptivePlaybackEnabled: false,
-			previewReason: nil // User content doesn't use previewReason
+			previewReason: nil // A file on disk is never a preview
 		)
 	}
 

--- a/Sources/Player/Mocks/PlaybackEngine/PlayerMock.swift
+++ b/Sources/Player/Mocks/PlaybackEngine/PlayerMock.swift
@@ -23,7 +23,6 @@ public final class PlayerMock: GenericMediaPlayer {
 	private var delegates = PlayerMonitoringDelegates()
 
 	private(set) var loadCallCount = 0
-	private(set) var loadUploadedCallCount = 0
 	private(set) var unloadCallCount = 0
 	private(set) var unloadedAssets = [Asset]()
 	private(set) var playCallCount = 0
@@ -118,26 +117,6 @@ public final class PlayerMock: GenericMediaPlayer {
 	public func reset() {
 		assetPosition = 0
 		assets.removeAll()
-	}
-}
-
-// MARK: UCMediaPlayer
-
-extension PlayerMock: UCMediaPlayer {
-	public func loadUC(
-		_ url: URL,
-		loudnessNormalizationConfiguration: LoudnessNormalizationConfiguration,
-		headers: [String: String]
-	) async -> Asset {
-		loadUploadedCallCount += 1
-		let loudnessNormalizationConfiguration = LoudnessNormalizationConfiguration(
-			loudnessNormalizationMode: loudnessNormalizationMode,
-			loudnessNormalizer: loudnessNormalizer
-		)
-		let asset = AssetMock(with: self, loudnessNormalizationConfiguration: loudnessNormalizationConfiguration)
-
-		assets.append(asset)
-		return asset
 	}
 }
 

--- a/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/AVQueuePlayerWrapper.swift
+++ b/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/AVQueuePlayerWrapper.swift
@@ -91,7 +91,7 @@ final class AVQueuePlayerWrapper: GenericMediaPlayer {
 			return true
 		}
 
-		if case let .UC(url) = productType, url.isFileURL {
+		if case let .LOCAL(url) = productType, url.isFileURL {
 			return true
 		}
 
@@ -248,42 +248,6 @@ final class AVQueuePlayerWrapper: GenericMediaPlayer {
 	func addMonitoringDelegate(monitoringDelegate: PlayerMonitoringDelegate) {
 		queue.dispatch {
 			self.delegates.add(delegate: monitoringDelegate)
-		}
-	}
-}
-
-// MARK: UCMediaPlayer
-
-extension AVQueuePlayerWrapper: UCMediaPlayer {
-	func loadUC(
-		_ url: URL,
-		loudnessNormalizationConfiguration: LoudnessNormalizationConfiguration,
-		headers: [String: String]
-	) async -> Asset {
-		await withCheckedContinuation { continuation in
-			queue.dispatch {
-				var options: [String: Any] = [
-					"AVURLAssetHTTPHeaderFieldsKey": headers,
-				]
-
-				if !url.isFileURL {
-					if #available(iOS 17.0, macOS 14.0, *) {
-						options[AVURLAssetOverrideMIMETypeKey] = "application/vnd.apple.mpegurl"
-					}
-				}
-
-				let urlAsset = AVURLAsset(url: url, options: options)
-
-				let asset = self.load(
-					urlAsset,
-					loudnessNormalizationConfiguration: loudnessNormalizationConfiguration,
-					and: nil,
-					AVPlayerAsset.self,
-					player: self
-				)
-
-				continuation.resume(returning: asset)
-			}
 		}
 	}
 }

--- a/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/CrossfadingPlayerWrapper.swift
+++ b/Sources/Player/PlaybackEngine/Internal/AVQueuePlayer/CrossfadingPlayerWrapper.swift
@@ -58,7 +58,7 @@ final class CrossfadingPlayerWrapper: GenericMediaPlayer {
 		if productType == .VIDEO {
 			return false
 		}
-		if case .UC = productType {
+		if case .LOCAL = productType {
 			return false
 		}
 		return currentPlayer.canPlay(

--- a/Sources/Player/PlaybackEngine/Internal/InternalPlayerLoader.swift
+++ b/Sources/Player/PlaybackEngine/Internal/InternalPlayerLoader.swift
@@ -1,4 +1,3 @@
-import Auth
 import AVFoundation
 import Foundation
 
@@ -7,8 +6,6 @@ import Foundation
 final class InternalPlayerLoader: PlayerLoader {
 	private var configuration: Configuration
 	private let fairPlayLicenseFetcher: FairPlayLicenseFetcher
-
-	private let credentialsProvider: CredentialsProvider
 
 	private let featureFlagProvider: FeatureFlagProvider
 
@@ -28,14 +25,12 @@ final class InternalPlayerLoader: PlayerLoader {
 		with configuration: Configuration,
 		and fairplayLicenseFetcher: FairPlayLicenseFetcher,
 		featureFlagProvider: FeatureFlagProvider,
-		credentialsProvider: CredentialsProvider,
 		avQueuePlayerWrapper: AVQueuePlayerWrapper,
 		crossfadingPlayerWrapper: CrossfadingPlayerWrapper,
 		externalPlayers: [GenericMediaPlayer.Type]
 	) {
 		self.configuration = configuration
 		fairPlayLicenseFetcher = fairplayLicenseFetcher
-		self.credentialsProvider = credentialsProvider
 		self.featureFlagProvider = featureFlagProvider
 		crossfadePlayer = crossfadingPlayerWrapper
 		crossfadePlayer.crossfadeDuration = configuration.crossfadeDuration
@@ -98,8 +93,8 @@ final class InternalPlayerLoader: PlayerLoader {
 				loudnessNormalizationConfiguration: loudnessNormalizationConfiguration,
 				licenseLoader: licenseLoader
 			)
-		case .UC:
-			return await loadUC(
+		case .LOCAL:
+			return await loadLocalFile(
 				url: offlinedProduct.mediaURL,
 				loudnessNormalizationConfiguration: loudnessNormalizationConfiguration,
 				licenseLoader: licenseLoader
@@ -139,8 +134,8 @@ final class InternalPlayerLoader: PlayerLoader {
 				loudnessNormalizationConfiguration: loudnessNormalizationConfiguration,
 				licenseLoader: nil
 			)
-		case .UC:
-			return await loadUC(
+		case .LOCAL:
+			return await loadLocalFile(
 				url: storedMediaProduct.url,
 				loudnessNormalizationConfiguration: loudnessNormalizationConfiguration,
 				licenseLoader: nil
@@ -187,8 +182,8 @@ final class InternalPlayerLoader: PlayerLoader {
 				loudnessNormalizationConfiguration: loudnessNormalizationConfiguration,
 				licenseLoader: licenseLoader
 			)
-		case .UC:
-			return await loadUC(
+		case .LOCAL:
+			return await loadLocalFile(
 				url: item.mediaURL,
 				loudnessNormalizationConfiguration: loudnessNormalizationConfiguration,
 				licenseLoader: licenseLoader
@@ -242,12 +237,11 @@ final class InternalPlayerLoader: PlayerLoader {
 				loudnessNormalizationConfiguration: loudnessNormalizationConfiguration,
 				licenseLoader: licenseLoader
 			)
-		case .UC:
-			return try await loadUC(
-				using: playbackInfo,
-				with: streamingSessionId,
-				and: loudnessNormalizer,
-				player: videoPlayer
+		case .LOCAL:
+			return await loadLocalFile(
+				url: playbackInfo.url,
+				loudnessNormalizationConfiguration: loudnessNormalizationConfiguration,
+				licenseLoader: nil
 			)
 		}
 	}
@@ -297,7 +291,12 @@ private extension InternalPlayerLoader {
 		)
 	}
 
-	func loadUC(
+	/// Loads a file already on the device.
+	///
+	/// Goes through the same `AVURLAsset` path as a video, which sets
+	/// `AVURLAssetPreferPreciseDurationAndTimingKey` for file URLs. Nothing is fetched and no
+	/// credentials are needed: the bytes are already here.
+	func loadLocalFile(
 		url: URL,
 		loudnessNormalizationConfiguration: LoudnessNormalizationConfiguration,
 		licenseLoader: LicenseLoader?
@@ -308,37 +307,6 @@ private extension InternalPlayerLoader {
 			loudnessNormalizationConfiguration: loudnessNormalizationConfiguration,
 			and: licenseLoader
 		)
-	}
-
-	func loadUC(
-		using playbackInfo: PlaybackInfo,
-		with streamingSessionId: String,
-		and loudnessNormalizer: LoudnessNormalizer?,
-		player: UCMediaPlayer
-	) async throws -> Asset {
-		do {
-			let loudnessNormalizationConfiguration = LoudnessNormalizationConfiguration(
-				loudnessNormalizationMode: loudnessNormalizationMode,
-				loudnessNormalizer: loudnessNormalizer
-			)
-
-			let token: String = try await credentialsProvider.getAuthBearerToken()
-
-			let headers: [String: String] = [
-				"Authorization": token,
-				"X-Tidal-Streaming-Session-Id": streamingSessionId,
-			]
-
-			return await player.loadUC(
-				playbackInfo.url,
-				loudnessNormalizationConfiguration: loudnessNormalizationConfiguration,
-				headers: headers
-			)
-
-		} catch {
-			PlayerWorld.logger?.log(loggable: PlayerLoggable.loadUCFailed(error: error))
-			throw error
-		}
 	}
 
 	func getPlayer(

--- a/Sources/Player/PlaybackEngine/Internal/MediaPlayers/UCMediaPlayer.swift
+++ b/Sources/Player/PlaybackEngine/Internal/MediaPlayers/UCMediaPlayer.swift
@@ -1,9 +1,0 @@
-import Foundation
-
-protocol UCMediaPlayer: AnyObject {
-	func loadUC(
-		_ url: URL,
-		loudnessNormalizationConfiguration: LoudnessNormalizationConfiguration,
-		headers: [String: String]
-	) async -> Asset
-}

--- a/Sources/Player/PlaybackEngine/Internal/PlayerLoader.swift
+++ b/Sources/Player/PlaybackEngine/Internal/PlayerLoader.swift
@@ -1,4 +1,3 @@
-import Auth
 import AVFoundation
 import Foundation
 
@@ -23,7 +22,6 @@ protocol PlayerLoader: AnyObject {
 		with configuration: Configuration,
 		and fairplayLicenseFetcher: FairPlayLicenseFetcher,
 		featureFlagProvider: FeatureFlagProvider,
-		credentialsProvider: CredentialsProvider,
 		avQueuePlayerWrapper: AVQueuePlayerWrapper,
 		crossfadingPlayerWrapper: CrossfadingPlayerWrapper,
 		externalPlayers: [GenericMediaPlayer.Type]

--- a/Sources/Player/Player.swift
+++ b/Sources/Player/Player.swift
@@ -446,7 +446,6 @@ private extension Player {
 			with: configuration,
 			and: fairplayLicenseFetcher,
 			featureFlagProvider: featureFlagProvider,
-			credentialsProvider: credentialsProvider,
 			avQueuePlayerWrapper: avQueuePlayerWrapper,
 			crossfadingPlayerWrapper: crossfadingPlayerWrapper,
 			externalPlayers: externalPlayersSupplier?() ?? []

--- a/Tests/PlayerTests/Mocks/PlaybackEngine/Internal/PlayerLoaderMock.swift
+++ b/Tests/PlayerTests/Mocks/PlaybackEngine/Internal/PlayerLoaderMock.swift
@@ -1,4 +1,3 @@
-import Auth
 import AVFoundation
 @testable import Player
 
@@ -17,7 +16,6 @@ final class PlayerLoaderMock: PlayerLoader {
 		with configuration: Configuration,
 		and fairplayLicenseFetcher: FairPlayLicenseFetcher,
 		featureFlagProvider: FeatureFlagProvider = .mock,
-		credentialsProvider: CredentialsProvider = CredentialsProviderMock(),
 		avQueuePlayerWrapper: AVQueuePlayerWrapper = AVQueuePlayerWrapper(
 			cachePath: URL(fileURLWithPath: NSTemporaryDirectory()),
 			featureFlagProvider: .mock

--- a/Tests/PlayerTests/Player/PlaybackEngine/Internal/InternalPlayerLoaderTests.swift
+++ b/Tests/PlayerTests/Player/PlaybackEngine/Internal/InternalPlayerLoaderTests.swift
@@ -1,4 +1,3 @@
-import Auth
 import Foundation
 @testable import Player
 import Testing
@@ -25,7 +24,6 @@ final class InternalPlayerLoaderTests {
 			with: Configuration.mock(),
 			and: fairPlayLicenseFetcher,
 			featureFlagProvider: FeatureFlagProvider.mock,
-			credentialsProvider: CredentialsProviderMock(),
 			avQueuePlayerWrapper: AVQueuePlayerWrapper(cachePath: cachePath, featureFlagProvider: .mock),
 			crossfadingPlayerWrapper: CrossfadingPlayerWrapper(cachePath: cachePath, featureFlagProvider: .mock),
 			externalPlayers: [PlayerMock.self]


### PR DESCRIPTION
## Summary

Replaces #270, which had a stale approval sitting on a rewritten diff. Same change, fresh branch off current `main`, fresh review.

`UC` meant two unrelated things: *play these bytes off disk*, and *fetch this remote URL as HLS*. Only the first has ever been used — the sole construction site in the app passes a file URL, and `productUrl` is `nil` everywhere else. This drops the remote half and names what is left.

## Changes

- `ProductType.UC(url:)` → `ProductType.LOCAL(url:)`, documented as file-URL only. `rawValue` moves from `"UC"` to `"LOCAL"`.
- `UCMediaPlayer`, both `loadUC` implementations and the `loadUCFailed` log case are gone. A local file now loads through the same `AVURLAsset` path as a video.
- `credentialsProvider` drops out of `PlayerLoader` and `InternalPlayerLoader`. Its only user was the bearer-token fetch that ran before playing a file already on disk.
- `getUCPlaybackInfo` → `getLocalPlaybackInfo`, no longer `async` (it never awaited anything).

## Carried over from #270: local playback must keep working

The original version of #270 deleted the UC path outright. @deaa caught the problem:

> Don't we still using this as playing local files?

That is correct, and it is why this PR narrows-and-renames instead of deleting. `.LOCAL` still routes through `loadLocalFile` in all four `InternalPlayerLoader` entry points (offlined product, stored media product, player item, and playback-info load), so playback of user-uploaded files the backend has not finished processing is preserved. Offline files continue to use the separate `StoredMediaProduct` path and are untouched.

Please re-check this specifically — it is the one behaviour that must not regress.

## Notes for review

- **This is a source-breaking change** for anyone pattern-matching `.UC`. The only known consumer is the TIDAL iOS app, which constructs `.UC(url:)` in exactly one place (`BoomBoxTypeConverter.productType(from:)`).
- **`rawValue` is deliberately changed**, not pinned. It reaches the backend via `PlayLogEvent`, `PlaybackStatistics`, `DownloadStatistics` and `PlayerItem.sessionProductType`. There is no existing `"UC"` traffic to preserve — the path has never fired in production — so nothing regresses, but flag it if analytics wants `"UC"` kept.
- **Behaviour improves for file URLs.** The deleted `loadUC` attached `AVURLAssetHTTPHeaderFieldsKey` (useless for a file URL) and never set `AVURLAssetPreferPreciseDurationAndTimingKey`. The generic `load(_ url:cacheKey:…)` sets it based on `url.isFileURL`.
- **The fabricated playback info is unchanged** — `audioQuality: .LOW`, `audioCodec: .HE_AAC_V1`, `mediaType: HLS` are still placeholders rather than measurements of the file. Left alone to keep this diff to the rename; worth a follow-up.
- `Offliner` already returns `nil` for this case, so offlining is unaffected.

## Attribution

The narrowing is @asendra's original work from #270 (Oct 2025), re-applied onto current `main` rather than merged — their branch was 684 commits behind, and resolving the conflicts risked silently reverting a year of changes in those files. Their original commits are preserved at tag `backup/cleanup-uc-type-20251022`.

## Verification

`swift build` clean for `Player` and `Offliner`, `--build-tests` compiles, swiftformat and swiftlint clean on the changed files. These were run on the equivalent tree in #270; the tree here is byte-identical.
